### PR TITLE
Fix security config typo

### DIFF
--- a/terraform/23-aws-glue-job-configuration.tf
+++ b/terraform/23-aws-glue-job-configuration.tf
@@ -37,7 +37,7 @@ resource "aws_glue_security_configuration" "glue_job_security_configuration_to_r
 }
 
 resource "aws_glue_security_configuration" "glue_job_security_configuration_to_trusted" {
-  name = "glue-job-security-configuration-to-refined"
+  name = "glue-job-security-configuration-to-trusted"
 
   encryption_configuration {
     cloudwatch_encryption {


### PR DESCRIPTION
## What

The `glue_job_security_configuration_to_refined` was applying twice, this has been updated to include `glue_job_security_configuration_to_trusted` and `glue_job_security_configuration_to_refined`