### PR TITLE
Set node version in workflow before running npm install

### DIFF
--- a/.github/workflows/data_platform_stg.yml
+++ b/.github/workflows/data_platform_stg.yml
@@ -41,9 +41,13 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2
+      - name: Set Node.js 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
       - name: Install dependencies in rds-database-snapshot-replicator lambda
+        working-directory: "./data-platform/lambdas/rds-database-snapshot-replicator/lambda"
         run: npm install
-          working-directory: "./data-platform/lambdas/rds-database-snapshot-replicator/lambda"
       - name: Run AWS Terraform
         uses: ./.github/actions/aws-terraform
         with:


### PR DESCRIPTION
### What
- set node version in workflow pipeline before running npm install

Co-authored-by: joates-madetech <james.oates@madetech.com>
Co-authored-by: mattbee <matt.bee@madetech.com>
Co-authored-by: maysakanoni <maysa@madetech.com>