### PR TITLE
Add rds export role

### DIFF
--- a/.github/actions/aws-terraform/action.yml
+++ b/.github/actions/aws-terraform/action.yml
@@ -26,6 +26,9 @@ inputs:
   aws_deploy_account:
     description: "AWS account id to deploy to"
     required: true
+  aws_api_account:
+    description: "AWS api account id to deploy to"
+    required: true
   aws_deploy_iam_role_name:
     description: "AWS IAM role name to assume for deployment"
     required: true
@@ -143,7 +146,7 @@ runs:
       run: |
         if [ "${{ inputs.terraform_destroy }}" != "destroy_me" ]; then
           ${{ github.action_path }}/box.sh "Running Terraform plan"
-          terraform plan -var-file='../config/terraform/${{ inputs.environment }}.tfvars' -var 'aws_deploy_region=${{ inputs.aws_deploy_region }}' -var 'aws_deploy_account=${{ inputs.aws_deploy_account }}' -var 'aws_deploy_iam_role_name=${{ inputs.aws_deploy_iam_role_name }}' -var 'environment=${{ inputs.environment }}' -var 'automation_build_url=${{ inputs.automation_build_url }}' -input=false -out=plan.out
+          terraform plan -var-file='../config/terraform/${{ inputs.environment }}.tfvars' -var 'aws_deploy_region=${{ inputs.aws_deploy_region }}'  -var 'aws_api_account=${{ inputs.aws_api_account }}' -var 'aws_deploy_account=${{ inputs.aws_deploy_account }}' -var 'aws_deploy_iam_role_name=${{ inputs.aws_deploy_iam_role_name }}' -var 'environment=${{ inputs.environment }}' -var 'automation_build_url=${{ inputs.automation_build_url }}' -input=false -out=plan.out
           echo -e "\n"
         fi
       shell: bash

--- a/.github/workflows/data_platform_stg.yml
+++ b/.github/workflows/data_platform_stg.yml
@@ -4,6 +4,8 @@ env:
   # AWS Account to deploy to. Account IDs are saved as secrets in this GitHub repository for convenience, using the naming convention AWS_ACCOUNT_ACCOUNT_NAME
   # where any spaces, dashes are converted to underscore (_). You can also use the Account Id value as literal string "12345679".
   aws_deploy_account: ${{ secrets.AWS_ACCOUNT_DATA_PLATFORM_STG }}
+  aws_api_account: ${{ secrets.AWS_API_ACCOUNT_STG }}
+
   # AWS region to deploy to. London is eu-west-2, Ireland is eu-west-1. Unless you have a reason, keep region to eu-west-2.
   aws_deploy_region: "eu-west-2"
   # Set this to the environment. It will passed through to Terraform for using the correct configuraiton. Must be one of 'Dev', 'Stg', 'Prod' or 'Mgmt'
@@ -59,6 +61,7 @@ jobs:
           environment: ${{ env.environment }}
           automation_build_url: ${{ env.automation_build_url }}
           aws_deploy_account: ${{ env.aws_deploy_account }}
+          aws_api_account: ${{ env.aws_api_account }}
           aws_deploy_iam_role_name: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           branch: ${GITHUB_REF##*/}
           terraform_import: ${{ github.event.inputs.terraform_import }}

--- a/terraform/00-init.tf
+++ b/terraform/00-init.tf
@@ -7,6 +7,15 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias = "aws_api_account"
+  region = var.aws_deploy_region
+  assume_role {
+    role_arn     = "arn:aws:iam::${var.aws_api_account}:role/${var.aws_deploy_iam_role_name}"
+    session_name = "Terraform"
+  }
+}
+
 provider "google" {
   region = "europe-west2"
   zone   = "europe-west2-a"

--- a/terraform/01-inputs-required.tf
+++ b/terraform/01-inputs-required.tf
@@ -9,6 +9,11 @@ variable "aws_deploy_account" {
   type        = string
 }
 
+variable "aws_api_account" {
+  description = "AWS api account id"
+  type        = string
+}
+
 variable "aws_deploy_iam_role_name" {
   description = "AWS IAM role name to assume for deployment"
   type        = string

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -52,6 +52,38 @@ resource "aws_lambda_function" "rds_snapshot_to_s3_lambda" {
   ]
 }
 
+resource "aws_iam_role" "rds_export_process_role" {
+  provider = aws.aws_api_account
+  name = "rds_export_process_role"
+  assume_role_policy = jsonencode({
+     Version: "2012-10-17",
+     Statement: [
+        {
+          Effect: "Allow",
+          Action: [
+              "s3:ListBucket",
+              "s3:GetBucketLocation"
+          ],
+          Resource: [
+              "arn:aws:s3:::*"
+          ]
+        },
+        {
+          Effect: "Allow",
+          Action: [
+              "s3:PutObject*",
+              "s3:GetObject*",
+              "s3:CopyObject*",
+              "s3:DeleteObject*"
+          ],
+          Resource: [
+              "arn:aws:s3:::data-platform-snapshot-export-test",
+              "arn:aws:s3:::data-platform-snapshot-export-test/*"
+          ]
+        }
+     ]
+  })
+}
 // set up SNS topic
 
 // set up event subscription


### PR DESCRIPTION
## What

Added a aws provider with new account to deploy the iam role to as this
is the account which contains the snapshot we would like to export. An
IAM tole is created to allow us to use the aws cli to check the export
file is in a parquet format.

 Co-authored-by: joates-madetech <james.oates@madetech.com>
 Co-authored-by: b-dalton <ben.dalton@madetech.com>
 Co-authored-by: mattbee <matt.bee@madetech.com>