### PR TITLE
Add provider to attachment

### DIFF
--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -105,6 +105,7 @@ resource "aws_iam_policy" "export_bucket_policy_document" {
 }
 
 resource "aws_iam_role_policy_attachment" "export_bucket_policy_attachment" {
+  provider = aws.aws_api_account
   role = aws_iam_role.rds_export_process_role.name
   policy_arn = aws_iam_policy.export_bucket_policy_document.arn
 }


### PR DESCRIPTION
## What
Add provider to policy attachment without the provider being specified, the attachment was being done in
a separate AWS account to the role and policy