### PR TITLE
Update Service attached to rds_export_process_role

### DIFF
--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -63,7 +63,7 @@ resource "aws_iam_role" "rds_export_process_role" {
         Effect = "Allow"
         Sid    = ""
         Principal = {
-          Service = "rds.amazonaws.com"
+          Service = "export.rds.amazonaws.com"
         }
       },
     ]


### PR DESCRIPTION
The incorrect service was set, so this updates to specifically set the
export.rds.amazonaws.com service.

Co-authored-by: joates-madetech <james.oates@madetech.com>
Co-authored-by: maysakanoni <maysa@madetech.com>
Co-authored-by: elena-vi <elena@madetech.com>