### PR TITLE
Remove admin role assignment to Google Project

### DIFF
--- a/terraform/40-google-platform.tf
+++ b/terraform/40-google-platform.tf
@@ -5,21 +5,21 @@ resource "google_project_service" "sheets_api" {
   disable_dependent_services = true
 }
 
-data "google_iam_policy" "project_admin" {
-  binding {
-    role = "roles/admin"
+# data "google_iam_policy" "project_admin" {
+#   binding {
+#     role = "roles/admin"
 
-    members = [
-      "user:maysa.kanoni@hackney.gov.uk",
-      "user:matt.bee@hackney.gov.uk",
-      "user:james.oates@hackney.gov.uk",
-      "user:ben.dalton@hackney.gov.uk",
-      "user:elena.vilimaite@hackney.gov.uk"
-    ]
-  }
-}
+#     members = [
+#       "user:maysa.kanoni@hackney.gov.uk",
+#       "user:matt.bee@hackney.gov.uk",
+#       "user:james.oates@hackney.gov.uk",
+#       "user:ben.dalton@hackney.gov.uk",
+#       "user:elena.vilimaite@hackney.gov.uk"
+#     ]
+#   }
+# }
 
-resource "google_project_iam_policy" "project_iam" {
-  project     = "dataplatform-stg"
-  policy_data = data.google_iam_policy.project_admin.policy_data
-}
+# resource "google_project_iam_policy" "project_iam" {
+#   project     = "dataplatform-stg"
+#   policy_data = data.google_iam_policy.project_admin.policy_data
+# }


### PR DESCRIPTION
We think that by changing the IAM roles attached to a project might be
interfering with the ability to create resources, so we are trying
without setting these users. In reality there should be no reason for
specific engineers to need to access the project once created.

Co-authored-by: joates-madetech <james.oates@madetech.com>
Co-authored-by: maysakanoni <maysa@madetech.com>
Co-authored-by: elena-vi <elena@madetech.com>