### PR TITLE
add tf validate workflow to actions on new prs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,3 @@ jobs:
         run: |
           terraform init -backend=false
           terraform validate
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install TFLint
-        uses: lablabs/setup-tflint@v1.0.2
-        with:
-          tflint_version: latest
-      - name: Run linter
-        run: ./scripts/lint_terraform.sh

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-for TFFILE in $(find . -name '*.tf');
-do
-  tflint $TFFILE
-done;


### PR DESCRIPTION
The terraform validate command validates the configuration files in a directory, referring only to the configuration and not accessing any remote services such as remote state, provider APIs, etc.

Validate runs checks that verify whether a configuration is syntactically valid and internally consistent, regardless of any provided variables or existing state. It is thus primarily useful for general verification of reusable modules, including correctness of attribute names and value types.