### PR TITLE
Snapshot to s3 ready to queue files to be copied

### DIFF
--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -88,7 +88,8 @@ data "aws_iam_policy_document" "rds_snapshot_to_s3_lambda" {
 
   statement {
     actions = [
-      "rds:StartExportTask"
+      "rds:StartExportTask",
+      "rds:DescribeExportTasks"
     ]
     effect = "Allow"
     resources = [


### PR DESCRIPTION
how it currently works: 
- look at how many exports are running, if count it's 5 requeue the message
- look at snapshots associated to that instance, if there's a new snapshot still being created requeue the message
- start export

what's missing:
- trigger copy from api s3 to data platfrom
- set up rds subscriptions in terrafrom