### PR TITLE
Reset resources to deploy to ProductionAPI from main

### DIFF
--- a/modules/db-snapshot-to-s3/25-rds-to-s3-queue.tf
+++ b/modules/db-snapshot-to-s3/25-rds-to-s3-queue.tf
@@ -37,12 +37,12 @@ resource "aws_sqs_queue_policy" "rds_snapshot_to_s3" {
   policy    = data.aws_iam_policy_document.rds_snapshot_to_s3.json
 }
 
-# resource "aws_sqs_queue" "rds_snapshot_to_s3_deadletter" {
+resource "aws_sqs_queue" "rds_snapshot_to_s3_deadletter" {
 
-#   tags = var.tags
+  tags = var.tags
 
-#   name = lower("${var.identifier_prefix}-rds-snapshot-to-s3-deadletter")
-# }
+  name = lower("${var.identifier_prefix}-rds-snapshot-to-s3-deadletter")
+}
 
 resource "aws_sns_topic_subscription" "subscribe_sqs_to_sns_topic" {
 

--- a/modules/db-snapshot-to-s3/45-s3-to-s3-copier-queue.tf
+++ b/modules/db-snapshot-to-s3/45-s3-to-s3-copier-queue.tf
@@ -32,11 +32,11 @@ resource "aws_sqs_queue_policy" "s3_copier_to_s3" {
   policy    = data.aws_iam_policy_document.s3_to_s3_copier.json
 }
 
-# resource "aws_sqs_queue" "s3_to_s3_copier_deadletter" {
-#   tags = var.tags
+resource "aws_sqs_queue" "s3_to_s3_copier_deadletter" {
+  tags = var.tags
 
-#   name = lower("${var.identifier_prefix}-s3-to-s3-copier-deadletter")
-# }
+  name = lower("${var.identifier_prefix}-s3-to-s3-copier-deadletter")
+}
 
 resource "aws_lambda_event_source_mapping" "s3_to_s3_copier_mapping" {
 

--- a/modules/db-snapshot-to-s3/50-rds-event-subscription.tf
+++ b/modules/db-snapshot-to-s3/50-rds-event-subscription.tf
@@ -53,14 +53,14 @@ resource "aws_iam_policy_attachment" "sns_cloudwatch_policy_attachment" {
   policy_arn = aws_iam_policy.sns_cloudwatch_logging.arn
 }
 
-# resource "aws_sns_topic" "rds_snapshot_to_s3" {
-#   tags = var.tags
+resource "aws_sns_topic" "rds_snapshot_to_s3" {
+  tags = var.tags
 
-#   name                             = lower("${var.identifier_prefix}-rds-snapshot-to-s3")
-#   sqs_success_feedback_role_arn    = aws_iam_role.sns_cloudwatch_logging.arn
-#   sqs_success_feedback_sample_rate = 100
-#   sqs_failure_feedback_role_arn    = aws_iam_role.sns_cloudwatch_logging.arn
-# }
+  name                             = lower("${var.identifier_prefix}-rds-snapshot-to-s3")
+  sqs_success_feedback_role_arn    = aws_iam_role.sns_cloudwatch_logging.arn
+  sqs_success_feedback_sample_rate = 100
+  sqs_failure_feedback_role_arn    = aws_iam_role.sns_cloudwatch_logging.arn
+}
 
 resource "aws_db_event_subscription" "snapshot_to_s3" {
   count = length(var.rds_instance_ids) > 0 ? 1 : 0

--- a/modules/s3-bucket/10-s3-bucket.tf
+++ b/modules/s3-bucket/10-s3-bucket.tf
@@ -41,15 +41,15 @@ data "aws_iam_policy_document" "key_policy" {
   }
 }
 
-# resource "aws_kms_key" "key" {
-#   tags = var.tags
+resource "aws_kms_key" "key" {
+  tags = var.tags
 
-#   description             = "${var.project} ${var.environment} - ${var.bucket_name} Bucket Key"
-#   deletion_window_in_days = 10
-#   enable_key_rotation     = true
+  description             = "${var.project} ${var.environment} - ${var.bucket_name} Bucket Key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
 
-#   policy = data.aws_iam_policy_document.key_policy.json
-# }
+  policy = data.aws_iam_policy_document.key_policy.json
+}
 
 
 resource "aws_kms_alias" "key_alias" {

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -1,11 +1,11 @@
-# resource "aws_s3_bucket" "lambda_artefact_storage" {
-#   provider = aws.aws_api_account
-#   tags     = module.tags.values
+resource "aws_s3_bucket" "lambda_artefact_storage" {
+  provider = aws.aws_api_account
+  tags     = module.tags.values
 
-#   bucket        = lower("${local.identifier_prefix}-lambda-artefact-storage")
-#   acl           = "private"
-#   force_destroy = true
-# }
+  bucket        = lower("${local.identifier_prefix}-lambda-artefact-storage")
+  acl           = "private"
+  force_destroy = true
+}
 
 # module "db_snapshot_to_s3" {
 #   source                         = "../modules/db-snapshot-to-s3"


### PR DESCRIPTION
Other modules may be referencing these resources so they have been reset, the module which had to be removed from the infrastructure has been left commented

Co-authored-by: b-dalton <ben.dalton@madetech.com>