### PR TITLE
comment out reference to s3 copier lambda role in landing zone module

### DIFF
--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -6,9 +6,9 @@ module "landing_zone" {
   identifier_prefix              = local.identifier_prefix
   bucket_name                    = "Landing Zone"
   bucket_identifier              = "landing-zone"
-  role_arns_to_share_access_with = [
-    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
-  ]
+//  role_arns_to_share_access_with = [
+//    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
+//  ]
 }
 
 module "raw_zone" {


### PR DESCRIPTION
- Commented out the reference to `s3_to_s3_copier_lambda_role_arn` on the `db_snapshot_to_s3` module as this module was commented out in the previous pull request
- this is part of PR #71 which aims to remove the old infrastructure from the Staging API account