### PR TITLE
Deploy to Data platform Staging to point to API production

### DIFF
--- a/.github/workflows/data_platform_stg.yml
+++ b/.github/workflows/data_platform_stg.yml
@@ -4,7 +4,7 @@ env:
   # AWS Account to deploy to. Account IDs are saved as secrets in this GitHub repository for convenience, using the naming convention AWS_ACCOUNT_ACCOUNT_NAME
   # where any spaces, dashes are converted to underscore (_). You can also use the Account Id value as literal string "12345679".
   aws_deploy_account: ${{ secrets.AWS_ACCOUNT_DATA_PLATFORM_STG }}
-  aws_api_account: ${{ secrets.AWS_API_ACCOUNT_STG }}
+  aws_api_account: ${{ secrets.AWS_API_ACCOUNT_PROD }}
   google_project_id: ${{ secrets.GOOGLE_PROJECT_ID_STG }}
 
   # AWS region to deploy to. London is eu-west-2, Ireland is eu-west-1. Unless you have a reason, keep region to eu-west-2.

--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -6,9 +6,9 @@ module "landing_zone" {
   identifier_prefix              = local.identifier_prefix
   bucket_name                    = "Landing Zone"
   bucket_identifier              = "landing-zone"
-//  role_arns_to_share_access_with = [
-//    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
-//  ]
+  role_arns_to_share_access_with = [
+    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
+  ]
 }
 
 module "raw_zone" {

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -7,19 +7,19 @@ resource "aws_s3_bucket" "lambda_artefact_storage" {
   force_destroy = true
 }
 
-# module "db_snapshot_to_s3" {
-#   source                         = "../modules/db-snapshot-to-s3"
-#   tags                           = module.tags.values
-#   project                        = var.project
-#   environment                    = var.environment
-#   identifier_prefix              = local.identifier_prefix
-#   lambda_artefact_storage_bucket = aws_s3_bucket.lambda_artefact_storage.bucket
-#   landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-#   landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-#   landing_zone_bucket_id         = module.landing_zone.bucket_id
-#   rds_instance_ids               = var.rds_instance_ids
+module "db_snapshot_to_s3" {
+  source                         = "../modules/db-snapshot-to-s3"
+  tags                           = module.tags.values
+  project                        = var.project
+  environment                    = var.environment
+  identifier_prefix              = local.identifier_prefix
+  lambda_artefact_storage_bucket = aws_s3_bucket.lambda_artefact_storage.bucket
+  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+  landing_zone_bucket_id         = module.landing_zone.bucket_id
+  rds_instance_ids               = var.rds_instance_ids
 
-#   providers = {
-#     aws = aws.aws_api_account
-#   }
-# }
+  providers = {
+    aws = aws.aws_api_account
+  }
+}


### PR DESCRIPTION
Redeploying to the production environment so that we can get access to the UPRN data in Production API account and copy to Data Platform staging account

Co-authored-by: maysakanoni <maysa@madetech.com>