### PR TITLE
Add depends on block

### DIFF
--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -22,4 +22,7 @@ module "db_snapshot_to_s3" {
   providers = {
     aws = aws.aws_api_account
   }
+  depends_on = [
+    aws_s3_bucket.lambda_artefact_storage
+  ]
 }


### PR DESCRIPTION
Terraform was complaining about a conflicting conditional operation on the s3 lambda artefact resource so a depends on block was added to fix this 