### PR TITLE
Remove etag on `aws_s3_bucket_object` resource

### DIFF
--- a/modules/db-snapshot-to-s3/20-rds-to-s3-lambda.tf
+++ b/modules/db-snapshot-to-s3/20-rds-to-s3-lambda.tf
@@ -129,7 +129,6 @@ resource "aws_s3_bucket_object" "rds_snapshot_to_s3_lambda" {
   key    = "rds_snapshot_to_s3_lambda.zip"
   source = data.archive_file.rds_snapshot_to_s3_lambda.output_path
   acl    = "private"
-  etag   = filemd5(data.archive_file.rds_snapshot_to_s3_lambda.output_path)
   depends_on = [
     data.archive_file.rds_snapshot_to_s3_lambda
   ]

--- a/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
+++ b/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
@@ -117,7 +117,6 @@ resource "aws_s3_bucket_object" "s3_to_s3_copier_lambda" {
   key    = "s3-to-s3-export-copier.zip"
   source = data.archive_file.s3_to_s3_copier_lambda.output_path
   acl    = "private"
-  etag   = filemd5(data.archive_file.s3_to_s3_copier_lambda.output_path)
   depends_on = [
     data.archive_file.s3_to_s3_copier_lambda
   ]


### PR DESCRIPTION
This is to fix the error of no file being found at path of lambda on etag which uses filemd5

Co-authored-by: maysakanoni <maysa@madetech.com>