### PR TITLE
Re-add copier lambda for role access to landing zone

### DIFF
--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -7,7 +7,7 @@ module "landing_zone" {
   bucket_name       = "Landing Zone"
   bucket_identifier = "landing-zone"
   role_arns_to_share_access_with = [
-    # module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
+    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
   ]
 }
 


### PR DESCRIPTION
Uncommented `module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn` on landing zone bucket to give the copier lambda access to the landing zone