### PR TITLE
add ACL to share API bucket access permissions with Data Platform

### DIFF
--- a/lambdas/s3_to_s3_export_copier/index.js
+++ b/lambdas/s3_to_s3_export_copier/index.js
@@ -43,6 +43,7 @@ async function s3CopyFolder(s3Client, sourceBucketName, sourcePath, targetBucket
           Bucket: targetBucketName,
           CopySource: `${sourceBucketName}/${file.Key}`,
           Key: `${targetPath}/${databaseName}/table_name=${tableName}/import_year=${year}/import_month=${month}/import_day=${day}/${fileName}`,
+          ACL: "bucket-owner-full-control",
         };
         console.log("copyObjectParams", copyObjectParams)
 


### PR DESCRIPTION
* This is to ensure that the landing zone bucket has the same permissions (`bucket-owner-full-control`) as the bucket owner - API S3 bucket 

* This is to address the bug where we weren't able to access data that has been ingested to the Data Platform i.e. could not download or read the contents 

[Documentation on ACL - Copy Object S3](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html)