### PR TITLE
fix `exportTaskIdentifier` as it was being truncated

### DIFF
--- a/lambdas/rds-database-snapshot-replicator/index.js
+++ b/lambdas/rds-database-snapshot-replicator/index.js
@@ -113,10 +113,8 @@ exports.handler = async (event) => {
     const databaseName = latestSnapshot.DBInstanceIdentifier;
     console.log("databaseName:", databaseName);
 
-    const exportTaskIdentifier = snapshotIdentifier.substr(0, 100);
-
     const startExportTaskParams = {
-      ExportTaskIdentifier: exportTaskIdentifier,
+      ExportTaskIdentifier: snapshotIdentifier,
       IamRoleArn: iamRoleArn,
       KmsKeyId: kmsKeyId,
       S3BucketName: s3BucketName,


### PR DESCRIPTION
Previously, the `ExportTaskIdentifier` parameter was being truncated due to the substring being too short. Removed the creation of a new variable which did this and passed in the `snapshotIdentifier` directly

This had meant that the export identifier which was being created was not unique and therefore no snapshot export was being started and it was error-ing out

Co-authored-by: maysakanoni <maysa@madetech.com>