### PR TITLE
Increase the diskspace of the RDS instance

### DIFF
--- a/modules/sql-to-parquet/30-rds.tf
+++ b/modules/sql-to-parquet/30-rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_instance" "ingestion_db" {
-  allocated_storage    = 5
+  allocated_storage    = 15
   engine               = "mysql"
   engine_version       = "8.0"
   instance_class       = "db.t3.micro"
@@ -14,6 +14,7 @@ resource "aws_db_instance" "ingestion_db" {
 
   username = "dataplatform"
   password = random_password.rds_password.result
+  skip_final_snapshot = true
 }
 
 resource "random_password" "rds_password" {


### PR DESCRIPTION
The Liberator dataset requires 5GB, and so 15GB felt like a fair size to accommodate growth.