### PR TITLE
Remove "table_name=" from exported RDS file names

### DIFF
--- a/lambdas/s3_to_s3_export_copier/index.js
+++ b/lambdas/s3_to_s3_export_copier/index.js
@@ -43,7 +43,7 @@ async function s3CopyFolder(s3Client, sourceBucketName, sourcePath, targetBucket
         const copyObjectParams = {
           Bucket: targetBucketName,
           CopySource: `${sourceBucketName}/${file.Key}`,
-          Key: `${targetPath}/${databaseName}/table_name=${tableName}/import_year=${year}/import_month=${month}/import_day=${day}/${fileName}`,
+          Key: `${targetPath}/${databaseName}/${tableName}/import_year=${year}/import_month=${month}/import_day=${day}/${fileName}`,
           ACL: "bucket-owner-full-control",
         };
         console.log("copyObjectParams", copyObjectParams)


### PR DESCRIPTION
This is causing crawled tables to contain a prefix of "table_name".

Having tables contain the prefix "table_name" is confusing when it is repeated so many times across all tables.