### PR TITLE
Create a Liberator specific database, crawler, and trigger

### DIFF
--- a/terraform/20-aws-glue.tf
+++ b/terraform/20-aws-glue.tf
@@ -152,6 +152,36 @@ resource "aws_glue_crawler" "landing_zone_parking_crawler" {
   }
 }
 
+resource "aws_glue_catalog_database" "landing_zone_liberator" {
+  name = "${local.identifier_prefix}-liberator-landing-zone"
+}
+
+resource "aws_glue_crawler" "landing_zone_liberator" {
+  tags = module.tags.values
+
+  database_name = aws_glue_catalog_database.landing_zone_liberator.name
+  name          = "${local.identifier_prefix}-landing-zone-liberator"
+  role          = aws_iam_role.glue_role.arn
+
+  s3_target {
+    path       = "s3://${module.landing_zone.bucket_id}/parking/liberator"
+    exclusions = local.crawler_excluded_blogs
+  }
+}
+
+resource "aws_glue_trigger" "landing_zone_liberator_crawler_trigger" {
+  tags = module.tags.values
+
+  name     = "${local.identifier_prefix} Landing Zone Liberator Crawler"
+  schedule = "cron(0 * * * ? *)"
+  type     = "SCHEDULED"
+  enabled  = true
+
+  actions {
+    crawler_name = aws_glue_crawler.landing_zone_liberator.name
+  }
+}
+
 // ==== RAW ZONE ===========
 resource "aws_glue_catalog_database" "raw_zone_catalog_database" {
   name = "${local.identifier_prefix}-raw-zone-database"


### PR DESCRIPTION
This will compact the liberator tables into one place, making it easier for analysts to focus their searches for tables.

NOTE: This is running in the landing zone at the moment, but once filtering of data is implemented analysts will be looking at the raw zone instead.