### PR TITLE
Listen for "CompleteMultipartUpload" events

### DIFF
--- a/modules/sql-to-parquet/40-cloudwatch-event.tf
+++ b/modules/sql-to-parquet/40-cloudwatch-event.tf
@@ -78,7 +78,8 @@ resource "aws_cloudwatch_event_rule" "new_s3_object" {
         "s3.amazonaws.com"
       ],
       "eventName" : [
-        "PutObject"
+        "PutObject",
+        "CompleteMultipartUpload"
       ],
       "requestParameters" : {
         "bucketName" : [


### PR DESCRIPTION
The Liberator S3 uploader uses a multipart upload, because of the size of the object.

By listening to "CompleteMultipartUpload", we will also be invoked when the liberator ZIP file arrives in the bucket.

More guidance on multipart uploads with S3:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html