### PR TITLE
Add glue full access to redshift policy

### DIFF
--- a/modules/redshift/10-redshift.tf
+++ b/modules/redshift/10-redshift.tf
@@ -24,10 +24,7 @@ resource "aws_iam_policy" "redshift_access_policy" {
       {
         Effect : "Allow",
         Action : [
-          "glue:GetDatabase",
-          "glue:CreateDatabase",
-          "glue:CreateTable",
-          "glue:GetTable"
+          "glue:*"
         ],
         Resource : [
           "*"


### PR DESCRIPTION
The previous policy allowed us to connect to a data catalogue db however did not list the tables in the db. This is because it was missing some glue permissions. We've amended the redshift policy to have full access to glue, but were unsure if this is giving the redshift policy too much access.

Co-authored-by: elena <elena@madetech.com>