### PR TITLE
Create security group for redshift cluster

### DIFF
--- a/modules/redshift/10-redshift.tf
+++ b/modules/redshift/10-redshift.tf
@@ -93,16 +93,25 @@ resource "aws_redshift_subnet_group" "redshift" {
 }
 
 resource "aws_security_group" "redshift_cluster_security_group" {
-  name        = "${var.identifier_prefix}-redshift-secuirty-group"
-  description = "specifies the rules for inbound traffic to the Redshift cluster"
+  name        = "${var.identifier_prefix}-redshift"
+  description = "Specifies the rules for inbound traffic to the Redshift cluster"
   vpc_id      = var.vpc_id
 
   ingress {
-    description      = "allows inbound traffic from BI tools using PostgreSQL protocol"
+    description      = "Allows inbound traffic from BI tools using PostgreSQL protocol"
     from_port        = 5439
     to_port          = 5439
     protocol         = "tcp"
     cidr_blocks      = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description      = "Allows all outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
   }
 
   tags = var.tags


### PR DESCRIPTION
Create security group for our redshift cluster which allows traffic from tcp port 5439

It was previously using a default security group

Co-authored-by: maysakanoni <maysa@madetech.com>
Co-authored-by: joates-madetech <james.oates@madetech.com>