### PR TITLE
Refactor lambda artefact S3 bucket to use S3 module

### DIFF
--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -81,10 +81,12 @@ module "liberator_data_storage" {
   bucket_identifier = "liberator-data-storage"
 }
 
-resource "aws_s3_bucket" "data_platform_lambda_artefact_storage" {
-  tags = module.tags.values
-
-  bucket        = lower("${local.identifier_prefix}-data-platform-lambda-artefact-storage")
-  acl           = "private"
-  force_destroy = true
+module "lambda_artefact_storage" {
+  source            = "../modules/s3-bucket"
+  tags              = module.tags.values
+  project           = var.project
+  environment       = var.environment
+  identifier_prefix = local.identifier_prefix
+  bucket_name       = "Lambda Artefact Storage"
+  bucket_identifier = "dp-lambda-artefact-storage"
 }

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -1,10 +1,15 @@
-resource "aws_s3_bucket" "lambda_artefact_storage" {
-  provider = aws.aws_api_account
-  tags     = module.tags.values
+module "lambda_artefact_storage_for_api_account" {
+  source            = "../modules/s3-bucket"
+  tags              = module.tags.values
+  project           = var.project
+  environment       = var.environment
+  identifier_prefix = local.identifier_prefix
+  bucket_name       = "Lambda Artefact Storage"
+  bucket_identifier = "api-lambda-artefact-storage"
 
-  bucket        = lower("${local.identifier_prefix}-lambda-artefact-storage")
-  acl           = "private"
-  force_destroy = true
+  providers = {
+    aws = aws.aws_api_account
+  }
 }
 
 module "db_snapshot_to_s3" {
@@ -13,7 +18,7 @@ module "db_snapshot_to_s3" {
   project                        = var.project
   environment                    = var.environment
   identifier_prefix              = local.identifier_prefix
-  lambda_artefact_storage_bucket = aws_s3_bucket.lambda_artefact_storage.bucket
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage_for_api_account.bucket_id
   landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
   landing_zone_bucket_arn        = module.landing_zone.bucket_arn
   landing_zone_bucket_id         = module.landing_zone.bucket_id
@@ -23,7 +28,4 @@ module "db_snapshot_to_s3" {
   providers = {
     aws = aws.aws_api_account
   }
-  depends_on = [
-    aws_s3_bucket.lambda_artefact_storage
-  ]
 }

--- a/terraform/61-liberator-data-sftp-to-s3.tf
+++ b/terraform/61-liberator-data-sftp-to-s3.tf
@@ -7,5 +7,5 @@ module "liberator_data_sftp_to_s3" {
   s3_bucket_id          = module.liberator_data_storage.bucket_id
   run_daily             = var.environment != "dev"
 
-  lambda_artefact_storage_bucket_name = aws_s3_bucket.data_platform_lambda_artefact_storage.bucket
+  lambda_artefact_storage_bucket_name = module.lambda_artefact_storage.bucket_id
 }

--- a/terraform/90-sql-to-s3.tf
+++ b/terraform/90-sql-to-s3.tf
@@ -16,14 +16,10 @@ module "liberator_db_snapshot_to_s3" {
   project                        = var.project
   environment                    = var.environment
   identifier_prefix              = "${local.identifier_prefix}-dp"
-  lambda_artefact_storage_bucket = aws_s3_bucket.data_platform_lambda_artefact_storage.bucket
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
   landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
   landing_zone_bucket_arn        = module.landing_zone.bucket_arn
   landing_zone_bucket_id         = module.landing_zone.bucket_id
   service_area                   = "parking"
   rds_instance_ids               = [module.liberator_to_parquet.rds_instance_id]
-
-  depends_on = [
-    aws_s3_bucket.data_platform_lambda_artefact_storage
-  ]
 }


### PR DESCRIPTION
**What**
- Refactored lambda artefact storage S3 bucket to use S3 module
- Corrected the name of lambda artefact storage S3 bucket

This will ensure that the bucket uses the same bucket ACL permissions and other configurations as the S3 module

Co-authored-by: joates-madetech <james.oates@madetech.com>