### PR TITLE
Convert `headerRowNumber` to integer in script

### DIFF
--- a/scripts/google-sheets-import.py
+++ b/scripts/google-sheets-import.py
@@ -90,7 +90,7 @@ googleSheetsWorksheet = googleSheetsDocument.worksheet(googleSheetsWorksheetName
 
 # Create a data frame from the google sheet data
 pandasDataFrame = pd.DataFrame(googleSheetsWorksheet.get_all_records(
-    head = headerRowNumber
+    head = int(headerRowNumber)
 ))
 
 # Convert all columns to strings


### PR DESCRIPTION
This is an update to the previous fix to allow Google sheets with multiple headers to be imported as there was still an error

The `headerRowNumber` environment variable gets converted to string when passed into the script and was therefore causing the job to fail.

- The script has been updated to convert this environment variable back to integer


