### PR TITLE
Added count to resource aws_cloudtrail

### DIFF
--- a/modules/sql-to-parquet/20-cloudtrail.tf
+++ b/modules/sql-to-parquet/20-cloudtrail.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudtrail" "events" {
-  count                           = terraform.workspace == "default" ? 1 : 0
+  count                         = terraform.workspace == "default" ? 1 : 0
   name                          = var.identifier_prefix
   s3_bucket_name                = aws_s3_bucket.cloudtrail.id
   s3_key_prefix                 = "prefix"


### PR DESCRIPTION
- Fixes issue where terraform apply fails due to trying to create too many cloudtrail resources in dev
- Addition of Count now creates cloudtrail resource only on "default" workspace (ie. Staging/production)