### PR TITLE
Only start workflow run when the exportTaskStatus == COMPLETE

### DIFF
--- a/lambdas/s3_to_s3_export_copier/index.js
+++ b/lambdas/s3_to_s3_export_copier/index.js
@@ -118,10 +118,10 @@ exports.handler = async (events) => {
 
       // If it has copy the files from s3 bucket A => s3 bucket B
       await s3CopyFolder(s3Client, sourceBucketName, pathPrefix, targetBucketName, targetServiceArea, snapshotTime);
-    })
-    )
 
-    if (workflowName) {
-      await startWorkflowRun(workflowName);
-    }
+      if (workflowName) {
+        await startWorkflowRun(workflowName);
+      }
+    })
+  )
 };


### PR DESCRIPTION
Previously it was starting the workflow every time the s3 to s3 copier lambda is invoked, but it only needs to run on the final invocation.