### PR TITLE
Prevent multiple GitHub deploy workflows being executed at once

### DIFF
--- a/.github/workflows/data_platform_prod.yml
+++ b/.github/workflows/data_platform_prod.yml
@@ -1,4 +1,5 @@
 name: Data-Platform (Production)
+concurrency: production-deploy
 env:
   aws_deploy_account: ${{ secrets.AWS_ACCOUNT_DATA_PLATFORM_PROD }}
   aws_api_account: ${{ secrets.AWS_API_ACCOUNT_PROD }}

--- a/.github/workflows/data_platform_stg.yml
+++ b/.github/workflows/data_platform_stg.yml
@@ -1,4 +1,5 @@
 name: Data-Platform (Staging)
+concurrency: staging-deploy
 env:
   aws_deploy_account: ${{ secrets.AWS_ACCOUNT_DATA_PLATFORM_STG }}
   aws_api_account: ${{ secrets.AWS_API_ACCOUNT_PROD }}


### PR DESCRIPTION
We've seen workflows fail when main is pushed to in quick succession.

This is because the second terraform process is unable to acquire the lock.

This is annoying as the second commit won't be deployed, meaning your fantastic change won't be deployed to the platform. 😿

GitHub Actions have a beta feature called "concurrency" which aims to fix this deficiency in the workflow executor by queuing up that second build until the first finishes.

See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency