### PR TITLE
update raw zone bucket permissions to share access with s3 copier lambda

### DIFF
--- a/modules/db-snapshot-to-s3/01-inputs-required.tf
+++ b/modules/db-snapshot-to-s3/01-inputs-required.tf
@@ -22,15 +22,15 @@ variable "lambda_artefact_storage_bucket" {
   type = string
 }
 
-variable "landing_zone_kms_key_arn" {
+variable "zone_kms_key_arn" {
   type = string
 }
 
-variable "landing_zone_bucket_arn" {
+variable "zone_bucket_arn" {
   type = string
 }
 
-variable "landing_zone_bucket_id" {
+variable "zone_bucket_id" {
   type = string
 }
 

--- a/modules/db-snapshot-to-s3/20-rds-to-s3-lambda.tf
+++ b/modules/db-snapshot-to-s3/20-rds-to-s3-lambda.tf
@@ -95,7 +95,7 @@ data "aws_iam_policy_document" "rds_snapshot_to_s3_lambda" {
     ]
     effect = "Allow"
     resources = [
-      var.landing_zone_kms_key_arn,
+      var.zone_kms_key_arn,
     ]
   }
 }

--- a/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
+++ b/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
@@ -55,9 +55,9 @@ data "aws_iam_policy_document" "s3_to_s3_copier_lambda" {
     resources = [
       module.rds_export_storage.kms_key_arn,
       "${module.rds_export_storage.bucket_arn}/*",
-      var.landing_zone_kms_key_arn,
-      var.landing_zone_bucket_arn,
-      "${var.landing_zone_bucket_arn}/*",
+      var.zone_kms_key_arn,
+      var.zone_bucket_arn,
+      "${var.zone_bucket_arn}/*",
     ]
   }
 
@@ -71,8 +71,8 @@ data "aws_iam_policy_document" "s3_to_s3_copier_lambda" {
     ]
     effect = "Allow"
     resources = [
-      var.landing_zone_bucket_arn,
-      "${var.landing_zone_bucket_arn}/*",
+      var.zone_bucket_arn,
+      "${var.zone_bucket_arn}/*",
       module.rds_export_storage.bucket_arn,
       "${module.rds_export_storage.bucket_arn}/*"
     ]
@@ -149,7 +149,7 @@ resource "aws_lambda_function" "s3_to_s3_copier_lambda" {
 
   environment {
     variables = {
-      BUCKET_DESTINATION = var.landing_zone_bucket_id,
+      BUCKET_DESTINATION = var.zone_bucket_id,
       SERVICE_AREA       = var.service_area
       WORKFLOW_NAME      = var.workflow_name
     }

--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -6,9 +6,6 @@ module "landing_zone" {
   identifier_prefix = local.identifier_prefix
   bucket_name       = "Landing Zone"
   bucket_identifier = "landing-zone"
-  role_arns_to_share_access_with = [
-    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
-  ]
 }
 
 module "raw_zone" {
@@ -19,6 +16,9 @@ module "raw_zone" {
   identifier_prefix = local.identifier_prefix
   bucket_name       = "Raw Zone"
   bucket_identifier = "raw-zone"
+  role_arns_to_share_access_with = [
+    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn
+  ]
 }
 
 module "refined_zone" {

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -19,9 +19,9 @@ module "db_snapshot_to_s3" {
   environment                    = var.environment
   identifier_prefix              = local.identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage_for_api_account.bucket_id
-  landing_zone_kms_key_arn       = module.raw_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.raw_zone.bucket_arn
-  landing_zone_bucket_id         = module.raw_zone.bucket_id
+  zone_kms_key_arn               = module.raw_zone.kms_key_arn
+  zone_bucket_arn                = module.raw_zone.bucket_arn
+  zone_bucket_id                 = module.raw_zone.bucket_id
   service_area                   = "unrestricted"
   rds_instance_ids               = var.rds_instance_ids
 

--- a/terraform/90-sql-to-s3.tf
+++ b/terraform/90-sql-to-s3.tf
@@ -17,9 +17,9 @@ module "liberator_db_snapshot_to_s3" {
   environment                    = var.environment
   identifier_prefix              = "${local.identifier_prefix}-dp"
   lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
+  zone_kms_key_arn               = module.landing_zone.kms_key_arn
+  zone_bucket_arn                = module.landing_zone.bucket_arn
+  zone_bucket_id                 = module.landing_zone.bucket_id
   service_area                   = "parking"
   rds_instance_ids               = [module.liberator_to_parquet.rds_instance_id]
   workflow_name                  = aws_glue_workflow.liberator_data.name


### PR DESCRIPTION
- This fix ensures that the raw zone is sharing access with the s3 copier lambda as previously we were getting an Access Denied error and therefore the data was not being copied to the data platform  

- Renamed the S3 bucket variable in `60-db-snapshot-to-s3` to `zone` instead of `landing zone` to avoid confusion because we use different bucket zones with this module 