### PR TITLE
Add secret to hold parking redshift user credentials

### DIFF
--- a/terraform/50-aws-secrets-manager.tf
+++ b/terraform/50-aws-secrets-manager.tf
@@ -1,3 +1,11 @@
+resource "aws_kms_key" "secrets_manager_key" {
+  tags = module.tags.values
+
+  description             = "${local.identifier_prefix}-secrets-manager-key"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
 resource "aws_kms_key" "sheets_credentials" {
   tags = module.tags.values
 
@@ -21,4 +29,12 @@ resource "aws_secretsmanager_secret_version" "housing_json_credentials_secret_ve
   count         = terraform.workspace == "default" ? 1 : 0
   secret_id     = aws_secretsmanager_secret.sheets_credentials_housing.id
   secret_binary = google_service_account_key.housing_json_credentials[0].private_key
+}
+
+resource "aws_secretsmanager_secret" "redshift_cluster_parking_credentials" {
+  tags  = module.tags.values
+
+  name        = "${local.identifier_prefix}-parking/redshift-cluster-parking-user"
+  description = "Credentials for the redshift cluster parking user "
+  kms_key_id  = aws_kms_key.secrets_manager_key.id
 }


### PR DESCRIPTION
- A kms key to use in secrets managers
- A policy to allow the parking power user to access the secret and use the KMS key

I moved the resources around in the roles files, so the diff doesn't look great - sorry!