### PR TITLE
Output the secret name, that holds the google sheets credentials

### DIFF
--- a/modules/google-service-account/99-outpus.tf
+++ b/modules/google-service-account/99-outpus.tf
@@ -1,3 +1,7 @@
 output "email" {
   value = google_service_account.service_account.email
 }
+
+output "credentials_secret_name" {
+  value = aws_secretsmanager_secret.sheets_credentials.name
+}


### PR DESCRIPTION
This secret name is needed for the google sheets import module.