### PR TITLE
Give parking role permission to delete from the raw zone

### DIFF
--- a/terraform/80-roles.tf
+++ b/terraform/80-roles.tf
@@ -206,11 +206,11 @@ data "aws_iam_policy_document" "parking_s3_access" {
     sid    = "DeleteObject"
     effect = "Allow"
     actions = [
-      "s3:DeleteObject"
+      "s3:Delete*"
     ]
     resources = [
       "${module.landing_zone.bucket_arn}/parking/manual/*",
-      "${module.raw_zone.bucket_arn}/parking/manual/*",
+      "${module.raw_zone.bucket_arn}/parking/*",
       "${module.refined_zone.bucket_arn}/parking/*",
       "${module.glue_temp_storage.bucket_arn}/parking/*"
     ]


### PR DESCRIPTION
As part of creating an ETL DataSet with SparkSQL, the job will create files under a `*/_temporary/*` folder structure, before moving those to the final folder.

As part of this "moving", it calls a MultiObjectDelete on these temporary parquet files.