### PR TITLE
remove the - when using the short identifier prefix

### DIFF
--- a/modules/google-sheets-glue-job/10-aws-glue-job.tf
+++ b/modules/google-sheets-glue-job/10-aws-glue-job.tf
@@ -26,7 +26,7 @@ resource "aws_glue_job" "google_sheet_import" {
 }
 
 resource "aws_glue_workflow" "workflow" {
-  name = "${var.identifier_prefix}-${var.department_name}-${var.dataset_name}"
+  name = "${var.identifier_prefix}${var.department_name}-${var.dataset_name}"
 }
 
 resource "aws_glue_crawler" "google_sheet_import" {


### PR DESCRIPTION
Lots of  `-google-sheetes-import-wf` and `emma--google-sheetes-import-wf`