### PR TITLE
Add option to filter tables when copying from landing to raw

### DIFF
--- a/scripts/copy_parking_liberator_landing_to_raw.py
+++ b/scripts/copy_parking_liberator_landing_to_raw.py
@@ -23,9 +23,10 @@ database_name_source = get_glue_env_var("glue_database_name_source")
 database_name_target = get_glue_env_var("glue_database_name_target")
 bucket_target = get_glue_env_var("s3_bucket_target")
 prefix = get_glue_env_var("s3_prefix")
+table_filter_expression = get_glue_env_var("table_filter_expression")
 logger = glue_context.get_logger()
 
-for table in glue_client.get_tables(DatabaseName=database_name_source)['TableList']:
+for table in glue_client.get_tables(DatabaseName=database_name_source, Expression=table_filter_expression)['TableList']:
   logger.info(f"Starting copying table {database_name_source}{table['Name']}")
   table_dynamic_frame = glue_context.create_dynamic_frame.from_catalog(
       name_space = database_name_source,

--- a/terraform/23-aws-glue-jobs.tf
+++ b/terraform/23-aws-glue-jobs.tf
@@ -95,6 +95,7 @@ resource "aws_glue_job" "copy_parking_liberator_landing_to_raw" {
     "--job-bookmark-option"       = "job-bookmark-enable"
     "--s3_bucket_target"          = module.raw_zone.bucket_id
     "--s3_prefix"                 = "parking/liberator/"
+    "--table_filter_expression"   = "^liberator_(?!fpn).*"
     "--glue_database_name_source" = aws_glue_catalog_database.landing_zone_liberator.name
     "--glue_database_name_target" = aws_glue_catalog_database.raw_zone_liberator.name
     "--extra-py-files"            = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"


### PR DESCRIPTION
For the liberator import, match tables which don't match "liberator_fpn".

These tables come from liberator, but aren't for parking departments
consumption, as they contain non-parking sensitive data.
