### PR TITLE
Update 26-google-sheets-imports.tf

### DIFF
--- a/terraform/26-google-sheets-imports.tf
+++ b/terraform/26-google-sheets-imports.tf
@@ -173,3 +173,25 @@ module "parking_spreadsheet_estate_permit_limits" {
   dataset_name                    = "estate_permit_limits"
   google_sheet_import_schedule    = "cron(0 6 ? * * *)"
 }
+
+module "parking_spreadsheet_parkmap_restrictions_report" {
+  count                           = local.is_live_environment ? 1 : 0
+  source                          = "../modules/google-sheets-glue-job"
+  identifier_prefix               = local.short_identifier_prefix
+  is_live_environment             = local.is_live_environment
+  glue_role_arn                   = aws_iam_role.parking_glue.arn
+  glue_scripts_bucket_id          = module.glue_scripts.bucket_id
+  helpers_script_key              = aws_s3_bucket_object.helpers.key
+  glue_catalog_database_name      = module.department_parking.raw_zone_catalog_database_name
+  glue_temp_storage_bucket_id     = module.glue_temp_storage.bucket_id
+  glue_crawler_excluded_blobs     = local.glue_crawler_excluded_blobs
+  google_sheets_import_script_key = aws_s3_bucket_object.google_sheets_import_script.key
+  bucket_id                       = module.raw_zone.bucket_id
+  sheets_credentials_name         = module.department_parking.google_service_account.credentials_secret.name
+  tags                            = module.tags.values
+  google_sheets_document_id       = "14Ago8grVd-tW7N0aSlcNZoxzsLDViSYys4shw1wLRno"
+  google_sheets_worksheet_name    = "6th June 2019"
+  department_name                 = "parking"
+  dataset_name                    = "parkmap_restrictions_report"
+  google_sheet_import_schedule    = "cron(0 6 ? * * *)"
+}


### PR DESCRIPTION
Added entry to import Google sheet with Park Map restrictions data as currently no process for this data to be pulled from earthlight or other sources in corporate GIS.