### PR TITLE
Add example of pyspark + UnitTest

### DIFF
--- a/scripts/spark_example.py
+++ b/scripts/spark_example.py
@@ -1,0 +1,7 @@
+from pyspark.sql import DataFrame
+
+
+def only_hackney_addresses(dataframe: DataFrame) -> DataFrame:
+  """Used to demonstrate pytest + pyspark.  See test_spark_example.py
+  """
+  return dataframe.filter(dataframe.council == 'Hackney')

--- a/scripts/test_spark_example.py
+++ b/scripts/test_spark_example.py
@@ -1,0 +1,23 @@
+
+from spark_example import only_hackney_addresses
+
+from unittest.case import TestCase
+from pyspark.sql import SparkSession, Row
+
+spark = SparkSession.builder.master("local").getOrCreate()
+
+class TestSparkExample(TestCase):
+  def test_filters_only_hackney_addresses(self):
+    self.assertEqual(
+      [
+        {'line1': '13', 'line2': 'Cheese Lane', 'postcode': 'E8 13HB', 'council': 'Hackney'}
+      ],
+      self.only_hackney_addresses([
+        {'line1': '13', 'line2': 'Cheese Lane', 'postcode': 'E8 13HB', 'council': 'Hackney'},
+        {'line1': '13', 'line2': 'Pickle Lane', 'postcode': 'E15 13HB', 'council': 'Newham'},
+      ])
+    )
+
+  def only_hackney_addresses(self, addresses):
+    query_addresses = spark.createDataFrame(spark.sparkContext.parallelize([Row(**i) for i in addresses]))
+    return [row.asDict() for row in only_hackney_addresses(query_addresses).rdd.collect()]


### PR DESCRIPTION
I also found a [pyspark-test](https://github.com/debugger24/pyspark-test/blob/6793a768fd0734691a7dd08f4483c8168db249ee/src/pyspark_test.py#L70) package, but believe manually constructing dataframes would create tests which were less readable than this approach of specifying dicts.