### PR TITLE
Add in an import_pathname column

### DIFF
--- a/terraform/22-aws-glue-scripts.tf
+++ b/terraform/22-aws-glue-scripts.tf
@@ -28,14 +28,14 @@ resource "aws_s3_bucket_object" "levenshtein_address_matching" {
   etag   = filemd5("../scripts/levenshtein_address_matching.py")
 }
 
-resource "aws_s3_bucket_object" "copy_manually_uploaded_csv_data_to_raw" {
+resource "aws_s3_bucket_object" "import_manually_uploaded_csv_data_to_raw" {
   tags = module.tags.values
 
   bucket = module.glue_scripts.bucket_id
-  key    = "scripts/copy_manually_uploaded_csv_data_to_raw.py"
+  key    = "scripts/import_manually_uploaded_csv_data_to_raw.py"
   acl    = "private"
-  source = "../scripts/copy_manually_uploaded_csv_data_to_raw.py"
-  etag   = filemd5("../scripts/copy_manually_uploaded_csv_data_to_raw.py")
+  source = "../scripts/import_manually_uploaded_csv_data_to_raw.py"
+  etag   = filemd5("../scripts/import_manually_uploaded_csv_data_to_raw.py")
 }
 
 resource "aws_s3_bucket_object" "address_cleaning" {

--- a/terraform/23-aws-glue-jobs.tf
+++ b/terraform/23-aws-glue-jobs.tf
@@ -57,13 +57,13 @@ resource "aws_glue_job" "manually_uploaded_parking_data_to_raw" {
 
   tags = module.tags.values
 
-  name              = "${local.short_identifier_prefix}Parking Copy Manually Uploaded CSVs to Raw"
+  name              = "${local.short_identifier_prefix}Parking Import Manually Uploaded CSVs to Raw"
   number_of_workers = 2
   worker_type       = "Standard"
   role_arn          = aws_iam_role.glue_role.arn
   command {
     python_version  = "3"
-    script_location = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.copy_manually_uploaded_csv_data_to_raw.key}"
+    script_location = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.import_manually_uploaded_csv_data_to_raw.key}"
   }
 
   glue_version = "2.0"


### PR DESCRIPTION
This takes the form:
`s3://dataplatform-landing-zone/parking/manual/important_parking_information/blah.csv`

@stevefarrhackneygovuk will take a look at how we can split this further, current thinking is around using something similar to this:
```
test_df.withColumn('import_pathname', f.element_at(f.split(test_df.filename, '/'), -1))
```

Co-authored-by: Steve Farr <steve.farr@hackney.gov.uk>