### PR TITLE
fix catalog_table output to display the correct table name

### DIFF
--- a/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
+++ b/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
@@ -67,6 +67,11 @@ variable "output_folder_name" {
   type        = string
 }
 
+variable "data_set_name" {
+  description = "Data set name"
+  type        = string
+}
+
 variable "input_file_name" {
   description = "XLSX input file name"
   type        = string

--- a/modules/import-data-from-xlsx-sheet-job/03-input-derived.tf
+++ b/modules/import-data-from-xlsx-sheet-job/03-input-derived.tf
@@ -1,5 +1,5 @@
 locals {
   worksheet_key  = lower(replace(trimspace(var.worksheet_name), " ", "-"))
   import_name    = "${var.department_folder_name}-${local.worksheet_key}"
-  s3_output_path = "s3://${var.raw_zone_bucket_id}/${var.department_folder_name}/${var.output_folder_name}"
+  s3_output_path = "s3://${var.raw_zone_bucket_id}/${var.department_folder_name}/${var.output_folder_name}/${var.data_set_name}"
 }

--- a/modules/import-data-from-xlsx-sheet-job/99-outputs.tf
+++ b/modules/import-data-from-xlsx-sheet-job/99-outputs.tf
@@ -7,6 +7,10 @@ output "job_arn" {
 }
 
 output "catalog_table" {
+  value = replace("${var.department_folder_name}_${var.data_set_name}", "-", "_")
+}
+
+output "worksheet_key" {
   value = local.worksheet_key
 }
 

--- a/modules/import-xlsx-file-from-g-drive/10-import-xlsx-file-from-g-drive.tf
+++ b/modules/import-xlsx-file-from-g-drive/10-import-xlsx-file-from-g-drive.tf
@@ -29,7 +29,8 @@ module "import_data_from_xlsx_sheet_job" {
   tags                           = var.tags
   glue_job_name                  = "${var.glue_job_name} - ${each.value.worksheet_name}"
   department_folder_name         = var.department_folder_name
-  output_folder_name             = "${var.output_folder_name}/${lower(replace(replace(trimspace(each.value.worksheet_name), "/[^a-zA-Z0-9]+/", "-"), "/-+/", "-"))}"
+  output_folder_name             = var.output_folder_name
+  data_set_name                  = lower(replace(replace(trimspace(each.value.worksheet_name), "/[^a-zA-Z0-9]+/", "-"), "/-+/", "-"))
   raw_zone_bucket_id             = var.raw_zone_bucket_id
   input_file_name                = var.input_file_name
   header_row_number              = each.value.header_row_number

--- a/modules/import-xlsx-file-from-g-drive/99-outputs.tf
+++ b/modules/import-xlsx-file-from-g-drive/99-outputs.tf
@@ -1,6 +1,6 @@
 output "worksheet_resources" {
   value = tomap({
-    for k in keys(module.import_data_from_xlsx_sheet_job) : module.import_data_from_xlsx_sheet_job[k].catalog_table => {
+    for k in keys(module.import_data_from_xlsx_sheet_job) : module.import_data_from_xlsx_sheet_job[k].worksheet_key => {
       catalog_table = module.import_data_from_xlsx_sheet_job[k].catalog_table
       crawler_name  = module.import_data_from_xlsx_sheet_job[k].crawler_name
       job_arn       = module.import_data_from_xlsx_sheet_job[k].job_arn


### PR DESCRIPTION
fixing the outputs to look something: 
```
  "door-entry" = {
    "catalog_table" = "housing_repairs_door_entry"
    "crawler_name" = "raw-zone-housing-repairs-door-entry"
    "job_arn" = "arn:aws:glue:eu-west-2:xxxxxxxx:job/Xlsx Import Job - Electrical Mechanical Fire Safety Repairs - Door Entry"
    "job_name" = "Xlsx Import Job - Electrical Mechanical Fire Safety Repairs - Door Entry"
    "workflow_name" = "el-housing-repairs-door-entry"
  }
  "dpa" = {
    "catalog_table" = "housing_repairs_dpa"
    "crawler_name" = "raw-zone-housing-repairs-dpa"
    "job_arn" = "arn:aws:glue:eu-west-2:xxxxxxxx:job:job/Xlsx Import Job - Electrical Mechanical Fire Safety Repairs - DPA"
    "job_name" = "Xlsx Import Job - Electrical Mechanical Fire Safety Repairs - DPA"
    "workflow_name" = "el-housing-repairs-dpa"
  }
```