### PR TITLE
specify crawler to update all new and existing partitions with metada…

### DIFF
--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
@@ -41,17 +41,17 @@ resource "aws_glue_crawler" "refined_zone_housing_repairs_elec_mech_fire_electri
   role          = aws_iam_role.glue_role.arn
   table_prefix  = "housing_repairs_elec_mech_fire_electrical_supplies_"
 
+  configuration = jsonencode({
+    Version = 1.0
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+    }
+  })
+
   s3_target {
     path = "s3://${module.refined_zone.bucket_id}/housing-repairs/repairs-electrical-mechanical-fire/housing-electrical-supplies/cleaned/"
 
-
     exclusions = local.glue_crawler_excluded_blobs
-    configuration = jsonencode({
-      Version = 1.0
-      CrawlerOutput = {
-        Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
-      }
-    })
   }
 }
 


### PR DESCRIPTION
Was previously getting this error:
![image](https://user-images.githubusercontent.com/70905620/126173041-13114568-bcc1-485d-8f58-34f61f6e3a2d.png)

This is because we are changing the format of a column from string to timestamp and when the table's schema changes, the schemas for partitions are not updated to remain in sync with the table's schema. (see [here](https://docs.aws.amazon.com/athena/latest/ug/updates-and-partitions.html)) 

This fix adds configuration to the crawler so that by default partitions inherit the schema from the table

See docs: https://aws.amazon.com/premiumsupport/knowledge-center/athena-hive-partition-schema-mismatch/