### PR TITLE
change the parquet timestamp output type

### DIFF
--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
@@ -30,6 +30,7 @@ resource "aws_glue_job" "housing_elec_mech_fire_electrical_supplies_cleaning" {
     "--source_catalog_table"             = module.repairs_fire_alarm_aov[0].worksheet_resources["electrical-supplies"].catalog_table
     "--TempDir"                          = module.glue_temp_storage.bucket_url
     "--extra-py-files"                   = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key},s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.repairs_cleaning_helpers.key}"
+    "--conf"                             = "spark.sql.parquet.outputTimestampType=TIMESTAMP_MILLIS"
   }
 }
 


### PR DESCRIPTION
change the parquet timestamp output type to `TIMESTAMP_MILLIS`

By default, timestamp is outputted to parquet as `INT96` ([see docs](https://spark.apache.org/docs/latest/configuration.html) on `spark.sql.parquet.outputTimestampType`). This is not supported by AWS Athena and has caused issues reading the data from columns of that type

![image](https://user-images.githubusercontent.com/70905620/126354085-5b1a06d5-7d90-4f71-96d9-c041c0a9785a.png)


**Considerations:**
- spark alternatives to`INT96` timestamp output type are: `TIMESTAMP_MILLIS` or `TIMESTAMP_MICROS`. They're both standard timestamp types in parquet, however,  
`TIMESTAMP_MILLIS` stores with millisecond precision (one thousandth of a second) whereas `TIMESTAMP_MICROS` has a more granular precision (one millionth of a second). 
As far as I am aware none of our timestamp data goes past seconds so there isn't really a need for more precision which is why I initially opted for `TIMESTAMP_MILLIS` (but gives us room if we need to record a little more precision)

- update other cleaning glue jobs to fix this as well (where appropriate)

**Tradeoffs to using `TIMESTAMP_MILLIS` or `TIMESTAMP_MICROS`:**
- if there is timezone information then this will be lost
- the timestamps may be displayed differently depending on the execution environment, as they are typically displayed in the local time zone of the user




