### PR TITLE
Added Delete Trigger permission to AWS Glue iam role

### DIFF
--- a/modules/department/50-aws-iam-role.tf
+++ b/modules/department/50-aws-iam-role.tf
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:CreateTrigger",
       "glue:DeleteDevEndpoint",
       "glue:DeleteJob",
-      "glue:DeleteTrigger"
+      "glue:DeleteTrigger",
       "glue:Get*",
       "glue:List*",
       "glue:ResetJobBookmark",


### PR DESCRIPTION
Per request on trello ticket https://trello.com/c/Ev3MX634 (Give the parking role permissions to delete triggers)