### PR TITLE
update all new and existing partitions with metadata from table

### DIFF
--- a/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-job-electrical-mechnical-fire-safety-cleaning.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-job-electrical-mechnical-fire-safety-cleaning.tf
@@ -41,8 +41,8 @@ resource "aws_glue_crawler" "refined_zone_housing_repairs_elec_mech_fire_cleaned
 
   configuration = jsonencode({
     Version = 1.0
-    Grouping = {
-      TableLevelConfiguration = 5
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
     }
   })
 }

--- a/modules/import-data-from-xlsx-sheet-job/10-aws-glue-job.tf
+++ b/modules/import-data-from-xlsx-sheet-job/10-aws-glue-job.tf
@@ -40,6 +40,13 @@ resource "aws_glue_crawler" "xlsx_import" {
   s3_target {
     path = local.s3_output_path
   }
+
+  configuration = jsonencode({
+    Version = 1.0
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+    }
+  })
 }
 
 resource "aws_glue_trigger" "xlsx_import_trigger" {


### PR DESCRIPTION
This fixes the error below when querying the raw zone and refined zone Electrical Mechanical repairs data in Athena:

![image](https://user-images.githubusercontent.com/70905620/127501133-5416d43c-f138-4a43-b6d0-3640f085eea9.png)

This is because we are changing the format of a column from string to timestamp and when the table's schema changes, the schemas for partitions are not updated to remain in sync with the table's schema. (see here)

This fix adds configuration to the crawler so that by default partitions inherit the schema from the table

See docs: https://aws.amazon.com/premiumsupport/knowledge-center/athena-hive-partition-schema-mismatch/