### PR TITLE
Each repairs sheet has it's own address cleaning job 

### DIFF
--- a/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
@@ -84,8 +84,8 @@ variable "dataset_name" {
   type        = string
 }
 
-variable "address_cleaning_job_name" {
-  description = "Address cleaning job name"
+variable "address_cleaning_script_key" {
+  description = "S3 key of the Address cleaning script in the glue scripts bucket"
   type        = string
 }
 

--- a/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
@@ -1,3 +1,32 @@
+resource "aws_glue_job" "address_cleaning" {
+  tags = var.tags
+
+  name              = "${var.identifier_prefix}Housing Repairs - ${title(replace(var.dataset_name, "-", " "))} Address Cleaning"
+  number_of_workers = 10
+  worker_type       = "G.1X"
+  role_arn          = var.glue_role_arn
+  command {
+    python_version  = "3"
+    script_location = "s3://${var.glue_scripts_bucket_id}/${var.address_cleaning_script_key}"
+  }
+
+  execution_property {
+    max_concurrent_runs = 1
+  }
+
+  glue_version = "2.0"
+
+  default_arguments = {
+    "--TempDir"                            = var.glue_temp_storage_bucket_id
+    "--extra-py-files"                     = "s3://${var.glue_scripts_bucket_id}/${var.helper_script_key},s3://${var.glue_scripts_bucket_id}/${var.cleaning_helper_script_key}"
+    "--source_catalog_database"            = var.refined_zone_catalog_database_name
+    "--source_catalog_table"               = "housing_repairs_${replace(var.dataset_name, "-", "_")}_cleaned"
+    "--cleaned_addresses_s3_bucket_target" = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/with-cleaned-addresses"
+    "--source_address_column_header"       = "property_address"
+    "--source_postcode_column_header"      = "None"
+  }
+}
+
 resource "aws_glue_trigger" "housing_repairs_address_cleaning" {
 
   name          = "${var.identifier_prefix}-housing-repairs-${var.dataset_name}-address-cleaning-trigger"
@@ -12,13 +41,6 @@ resource "aws_glue_trigger" "housing_repairs_address_cleaning" {
     }
   }
   actions {
-    arguments = {
-      "--source_catalog_database" : var.refined_zone_catalog_database_name
-      "--source_catalog_table" : "housing_repairs_${replace(var.dataset_name, "-", "_")}_cleaned"
-      "--cleaned_addresses_s3_bucket_target" : "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/with-cleaned-addresses"
-      "--source_address_column_header" : "property_address"
-      "--source_postcode_column_header" : "None"
-    }
-    job_name = var.address_cleaning_job_name
+    job_name = aws_glue_job.address_cleaning.name
   }
 }

--- a/terraform/23-aws-glue-job-repairs-alpha-track.tf
+++ b/terraform/23-aws-glue-job-repairs-alpha-track.tf
@@ -26,7 +26,7 @@ module "housing_repairs_alphatrack" {
   cleaning_helper_script_key         = aws_s3_bucket_object.repairs_cleaning_helpers.key
   catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 
   data_cleaning_script_key = aws_s3_bucket_object.housing_repairs_repairs_alpha_track_cleaning_script.key
   source_catalog_table     = "housing_repairs_repairs_alpha_track"

--- a/terraform/23-aws-glue-job-repairs-avonline.tf
+++ b/terraform/23-aws-glue-job-repairs-avonline.tf
@@ -26,7 +26,7 @@ module "housing_repairs_avonline" {
   cleaning_helper_script_key         = aws_s3_bucket_object.repairs_cleaning_helpers.key
   catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 
   data_cleaning_script_key = aws_s3_bucket_object.housing_repairs_repairs_avonline_cleaning_script.key
   source_catalog_table     = "housing_repairs_repairs_avonline"

--- a/terraform/23-aws-glue-job-repairs-axis.tf
+++ b/terraform/23-aws-glue-job-repairs-axis.tf
@@ -26,7 +26,7 @@ module "housing_repairs_axis" {
   cleaning_helper_script_key         = aws_s3_bucket_object.repairs_cleaning_helpers.key
   catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 
   data_cleaning_script_key = aws_s3_bucket_object.housing_repairs_repairs_axis_cleaning_script.key
   source_catalog_table     = "housing_repairs_repairs_axis"

--- a/terraform/23-aws-glue-job-repairs-herts-heritage.tf
+++ b/terraform/23-aws-glue-job-repairs-herts-heritage.tf
@@ -33,5 +33,5 @@ module "housing_repairs_herts_heritage" {
 
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
   dataset_name                       = "repairs-herts-heritage"
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 }

--- a/terraform/23-aws-glue-job-repairs-purdy.tf
+++ b/terraform/23-aws-glue-job-repairs-purdy.tf
@@ -26,7 +26,7 @@ module "housing_repairs_purdy" {
   cleaning_helper_script_key         = aws_s3_bucket_object.repairs_cleaning_helpers.key
   catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 
   data_cleaning_script_key = aws_s3_bucket_object.housing_repairs_repairs_purdy_cleaning_script.key
   source_catalog_table     = "housing_repairs_repairs_purdy"

--- a/terraform/23-aws-glue-job-repairs-stannah.tf
+++ b/terraform/23-aws-glue-job-repairs-stannah.tf
@@ -26,7 +26,7 @@ module "housing_repairs_stannah" {
   cleaning_helper_script_key         = aws_s3_bucket_object.repairs_cleaning_helpers.key
   catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_job_name          = aws_glue_job.address_cleaning[0].name
+  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
 
   data_cleaning_script_key = aws_s3_bucket_object.housing_repairs_repairs_stannah_cleaning_script.key
   source_catalog_table     = "housing_repairs_repairs_stannah"


### PR DESCRIPTION
Currently, each sheet is calling the same job to clean addresses. However this means we can't trigger any further jobs/ crawlers that are specific to the sheet on completion of the address cleaning job.

The jobs all point to the same source script but have been separated out. 