### PR TITLE
address matching output data saved to the trusted zone

### DIFF
--- a/modules/electrical-mechnical-fire-safety-cleaning-job/01-inputs-required.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/01-inputs-required.tf
@@ -74,11 +74,6 @@ variable "refined_zone_catalog_database_name" {
   type        = string
 }
 
-variable "trusted_zone_catalog_database_name" {
-  description = "Trusted zone catalog database name"
-  type        = string
-}
-
 variable "dataset_name" {
   description = "Name of the data set"
   type        = string

--- a/modules/electrical-mechnical-fire-safety-cleaning-job/12-aws-glue-address-matching.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/12-aws-glue-address-matching.tf
@@ -16,8 +16,8 @@ resource "aws_glue_job" "housing_repairs_elec_mech_fire_address_matching_job" {
   default_arguments = {
     "--addresses_api_data_database" = var.addresses_api_data_catalog
     "--addresses_api_data_table"    = "unrestricted_address_api_dbo_hackney_address"
-    "--source_catalog_database"     = var.catalog_database
-    "--source_catalog_table"        = var.worksheet_resource.catalog_table
+    "--source_catalog_database"     = var.refined_zone_catalog_database_name
+    "--source_catalog_table"        = "housing_repairs_elec_mech_fire_${replace(var.dataset_name, "-", "_")}_with_cleaned_addresses"
     "--target_destination"          = "s3://${var.trusted_zone_bucket_id}/housing-repairs/repairs/"
     "--TempDir"                     = var.glue_temp_storage_bucket_id
     "--extra-py-files"              = "s3://${var.glue_scripts_bucket_id}/${var.helper_script_key}"

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-communal-lighting.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-communal-lighting.tf
@@ -33,5 +33,4 @@ module "communal_lighting" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-door-entry.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-door-entry.tf
@@ -33,5 +33,4 @@ module "door_entry" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-dpa.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-dpa.tf
@@ -33,5 +33,4 @@ module "dpa" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-electrical-supplies.tf
@@ -33,5 +33,4 @@ module "electrical_supplies" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-fire-alarmaov.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-fire-alarmaov.tf
@@ -33,5 +33,4 @@ module "fire_alarmaov" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-lift-breakdown-ela.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-lift-breakdown-ela.tf
@@ -33,5 +33,4 @@ module "lift_breakdown_el" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-lightning-protection.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-lightning-protection.tf
@@ -33,5 +33,4 @@ module "lightning_protection" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-reactive-rewires.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-reactive-rewires.tf
@@ -33,5 +33,4 @@ module "reactive_rewires" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-repairs-electric-heating.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-repairs-electric-heating.tf
@@ -33,5 +33,4 @@ module "electric_heating" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-repairs-emergency-lighting-service.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-repairs-emergency-lighting-service.tf
@@ -33,5 +33,4 @@ module "emergency_lighting_servicing" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-tv-aerials.tf
+++ b/terraform/23-aws-glue-job-electrical-mechnical-fire-safety-tv-aerials.tf
@@ -33,5 +33,4 @@ module "tv_aerials" {
   address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
   addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   trusted_zone_bucket_id             = module.trusted_zone.bucket_id
-  trusted_zone_catalog_database_name = module.department_housing_repairs.trusted_zone_catalog_database_name
 }

--- a/terraform/23-aws-glue-job-repairs-dlo.tf
+++ b/terraform/23-aws-glue-job-repairs-dlo.tf
@@ -155,7 +155,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_cleaned_crawler_trigger" {
   predicate {
     conditions {
       job_name = aws_glue_job.housing_repairs_dlo_address_cleaning[0].name
-      state  = "SUCCEEDED"
+      state    = "SUCCEEDED"
     }
   }
   actions {
@@ -166,7 +166,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_cleaned_crawler_trigger" {
 resource "aws_glue_crawler" "refined_zone_housing_repairs_dlo_with_cleaned_addresses_crawler" {
   count = local.is_live_environment ? 1 : 0
 
-  tags = module.tags.values
+  tags          = module.tags.values
   database_name = module.department_housing_repairs.refined_zone_catalog_database_name
   name          = "${local.short_identifier_prefix}refined-zone-housing-repairs-dlo-with-cleaned-addresses"
   role          = aws_iam_role.glue_role.arn
@@ -243,7 +243,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_uprn_crawler_trigger" {
   predicate {
     conditions {
       job_name = aws_glue_job.get_uprn_from_uhref[0].name
-      state  = "SUCCEEDED"
+      state    = "SUCCEEDED"
     }
   }
   actions {
@@ -252,7 +252,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_uprn_crawler_trigger" {
 }
 
 resource "aws_glue_crawler" "refined_zone_housing_repairs_with_uprn_from_uhref_crawler" {
-  tags = module.tags.values
+  tags  = module.tags.values
   count = local.is_live_environment ? 1 : 0
 
   database_name = module.department_housing_repairs.refined_zone_catalog_database_name
@@ -330,7 +330,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_uprn_address_matched_crawler_tr
   predicate {
     conditions {
       job_name = aws_glue_job.repairs_dlo_levenshtein_address_matching[0].name
-      state  = "SUCCEEDED"
+      state    = "SUCCEEDED"
     }
   }
   actions {
@@ -339,7 +339,7 @@ resource "aws_glue_trigger" "housing_repairs_dlo_uprn_address_matched_crawler_tr
 }
 
 resource "aws_glue_crawler" "refined_zone_housing_repairs_dlo_with_matched_addresses_crawler" {
-  tags = module.tags.values
+  tags  = module.tags.values
   count = local.is_live_environment ? 1 : 0
 
   database_name = module.department_housing_repairs.refined_zone_catalog_database_name


### PR DESCRIPTION
1, Output is saved to a generic housing repairs folder so we can crawl all housing repairs data into one table
2, Remove the crawler which was running after the address matching, this will be replaced by a single crawler which will run after all the housing repairs data has been cleaned and addresses
3, Corrected the source catalog and table name for address matching

Also ran format so there are some random whitespace changes.