### PR TITLE
Separate out the deequ jar by itself

### DIFF
--- a/.github/workflows/data_platform_prod.yml
+++ b/.github/workflows/data_platform_prod.yml
@@ -59,9 +59,9 @@ jobs:
       - name: Install dependencies in g-drive-to-s3 lambda
         working-directory: "./lambdas/g_drive_to_s3"
         run: make install-requirements
-      - name: Package jars
+      - name: Package & download jars
         working-directory: "./jars"
-        run: make package
+        run: make all
       - name: Deploy Data Platform Network
         uses: ./.github/actions/aws-terraform
         with:

--- a/.github/workflows/data_platform_stg.yml
+++ b/.github/workflows/data_platform_stg.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Install dependencies in g-drive-to-s3 lambda
         working-directory: "./lambdas/g_drive_to_s3"
         run: make install-requirements
-      - name: Package jars
+      - name: Package & download jars
         working-directory: "./jars"
-        run: make package
+        run: make all
       - name: Deploy Data Platform Network
         uses: ./.github/actions/aws-terraform
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
         run: |
           echo "{}" >> ./google_service_account_creds.json
         shell: bash
+      - name: Package & download jars
+        working-directory: "./jars"
+        run: make all
       - name: Run `terraform validate` on Terraform Networking
         working-directory: "./terraform-networking"
         run: |

--- a/jars/Makefile
+++ b/jars/Makefile
@@ -1,4 +1,9 @@
-.PHONY: package
+.PHONY: all
 
-package:
+all: target/java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar target/deequ-1.0.3.jar
+
+target/java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar: pom.xml
 	mvn assembly:assembly -DdescriptorId=jar-with-dependencies
+
+target/deequ-1.0.3.jar:
+	wget https://repo1.maven.org/maven2/com/amazon/deequ/deequ/1.0.3/deequ-1.0.3.jar -O target/deequ-1.0.3.jar

--- a/jars/pom.xml
+++ b/jars/pom.xml
@@ -24,11 +24,6 @@
       <artifactId>spark-excel_2.11</artifactId>
       <version>0.13.7</version>
     </dependency>
-    <dependency>
-      <groupId>com.amazon.deequ</groupId>
-      <artifactId>deequ</artifactId>
-      <version>1.2.2-spark-2.4</version>
-    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/terraform/22-aws-glue-scripts.tf
+++ b/terraform/22-aws-glue-scripts.tf
@@ -68,6 +68,16 @@ resource "aws_s3_bucket_object" "jars" {
   etag   = filemd5("../jars/target/java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar")
 }
 
+resource "aws_s3_bucket_object" "deeque_jar" {
+  tags = module.tags.values
+
+  bucket = module.glue_scripts.bucket_id
+  key    = "jars/deequ-1.0.3.jar"
+  acl    = "private"
+  source = "../jars/target/deequ-1.0.3.jar"
+  etag   = filemd5("../jars/target/deequ-1.0.3.jar")
+}
+
 resource "aws_s3_bucket_object" "repairs_cleaning_helpers" {
   tags = module.tags.values
 


### PR DESCRIPTION
This jar wasn't working when bundled as part of the
`java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar`

Sample error message:
```
py4j.protocol.Py4JJavaError: An error occurred while calling None.com.amazon.deequ.analyzers.Completeness.
: java.lang.NoSuchMethodError: scala.Product.$init$(Lscala/Product;)V
	at com.amazon.deequ.analyzers.Completeness.<init>(Completeness.scala:27)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:238)
	at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
	at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)

```

When running with version 1.0.3 as suggested by this guide it worked.
https://aws.amazon.com/blogs/big-data/monitor-data-quality-in-your-data-lake-using-pydeequ-and-aws-glue/

We suspect that the generated JAR includes versions of spark code
which conflict with the AWS Glue environment.