### PR TITLE
de-duplicate vulnerability dataset before joining

### DIFF
--- a/scripts/get_uprn_from_uhref.py
+++ b/scripts/get_uprn_from_uhref.py
@@ -44,6 +44,7 @@ uhref_uprn_lookup_ddf = glueContext.create_dynamic_frame.from_catalog(
 uhref_uprn_lookup_df = uhref_uprn_lookup_ddf.toDF()
 uhref_uprn_lookup_df = get_latest_partitions(uhref_uprn_lookup_df)
 uhref_uprn_lookup_df = uhref_uprn_lookup_df.select(col("ten_property_ref"), col("uprn").cast("string")).where("ten_property_ref IS NOT NULL")
+uhref_uprn_lookup_df = uhref_uprn_lookup_df.dropDuplicates(["ten_property_ref"])
 uhref_uprn_lookup_df = uhref_uprn_lookup_df.withColumnRenamed("ten_property_ref", source_uhref_header)
 
 # ### JOIN


### PR DESCRIPTION
This should avoid duplicates in DLO data in the trusted zone. The duplicated were due to duplicates in the recovered vulnerability data.