### PR TITLE
Add push_down_predicate to further filter the partitions to consider

### DIFF
--- a/scripts/copy_parking_liberator_landing_to_raw.py
+++ b/scripts/copy_parking_liberator_landing_to_raw.py
@@ -35,7 +35,8 @@ for table_name in tables_to_move:
   table_data_frame = glue_context.create_dynamic_frame.from_catalog(
       name_space = database_name_source,
       table_name = table_name,
-      transformation_ctx = "data_source" + table_name
+      transformation_ctx = "data_source" + table_name,
+      push_down_predicate = "import_date>=date_format(date_sub(current_date, 5), 'yyyyMMdd')"
   ).toDF()
 
   if(len(table_data_frame.columns) == 0):


### PR DESCRIPTION
This job was getting very slow > 3 hours to complete, even without any data to copy.

By adding a push down predicate Spark can reduce the number of partitions to consider, reducing the duration of the job back down to 15 minutes.

5 days was chosen as a good compromise between speed and catching any previously missed data in the event of job failure.

Note that this job uses bookmarks to prevent data from being reprocessed.  It would appear that this process of bookmark checking is slow.