### PR TITLE
Only save the most recent metrics if the constraint checks succeed 

### DIFF
--- a/scripts/elec_mech_fire_tv_aerials_cleaning.py
+++ b/scripts/elec_mech_fire_tv_aerials_cleaning.py
@@ -74,7 +74,11 @@ df2 = df2.select("data_source", "datetime_raised",
 
 
 metricsRepository = FileSystemMetricsRepository(spark_session, metrics_target_location)
-resultKey = ResultKey(spark_session, ResultKey.current_milli_time(), {"source_database": source_catalog_database, "source_table": source_catalog_table})
+resultKey = ResultKey(spark_session, ResultKey.current_milli_time(), {
+        "source_database": source_catalog_database,
+        "source_table": source_catalog_table,
+        "glue_job_id": args['JOB_RUN_ID']
+    })
 
 try:
     verificationSuite = VerificationSuite(spark_session) \


### PR DESCRIPTION
Previously you had the scenario where previously failing anomaly check would succeed because it was checking against incorrect metrics.

Co-authored-by: Ben Dalton <ben.dalton@madetech.com>