### PR TITLE
Tascomi api ingestion jobs run every day retrieveing any updated records

### DIFF
--- a/scripts/tascomi_api_ingestion.py
+++ b/scripts/tascomi_api_ingestion.py
@@ -22,6 +22,10 @@ def authenticate_tascomi(headers, public_key, private_key):
     headers['X-Hash'] = auth_hash
     return headers
 
+def not_today(date_str):
+    date = datetime.strptime(date_str[:19], "%Y-%m-%d %H:%M:%S")
+    return date.date() != datetime.now().date()
+
 def get_tascomi_resource(url, body):
     global public_key
     global private_key
@@ -41,7 +45,7 @@ def get_tascomi_resource(url, body):
             print(res.json)
             return ([""], url, res.status_code, f"Null data response: {json.dumps(res.json)}")
 
-        serialized_records = [json.dumps(record) for record in records]
+        serialized_records = [json.dumps(record) for record in records if not_today(record['last_updated']) ]
 
         return (serialized_records, url, res.status_code, "")
 

--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -75,9 +75,9 @@ resource "aws_glue_crawler" "raw_zone_tascomi_crawler" {
 resource "aws_glue_trigger" "tascomi_raw_zone_crawler_trigger" {
   tags = module.tags.values
 
-  name          = "${local.short_identifier_prefix}Tascomi Data Crawler Trigger"
-  type          = "CONDITIONAL"
-  enabled       = true
+  name    = "${local.short_identifier_prefix}Tascomi Data Crawler Trigger"
+  type    = "CONDITIONAL"
+  enabled = true
 
   predicate {
     conditions {
@@ -95,10 +95,10 @@ resource "aws_glue_trigger" "tascomi_raw_zone_crawler_trigger" {
 resource "aws_glue_trigger" "ingest_tascomi_applications_trigger" {
   tags = module.tags.values
 
-  name          = "${local.short_identifier_prefix}Tascomi Applications Ingestion Trigger"
-  type          = "SCHEDULED"
-  schedule      = "cron(0 2 * * ? *)"
-  enabled       = true
+  name     = "${local.short_identifier_prefix}Tascomi Applications Ingestion Trigger"
+  type     = "SCHEDULED"
+  schedule = "cron(0 2 * * ? *)"
+  enabled  = local.is_live_environment
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name
@@ -111,10 +111,10 @@ resource "aws_glue_trigger" "ingest_tascomi_applications_trigger" {
 resource "aws_glue_trigger" "ingest_tascomi_contacts_trigger" {
   tags = module.tags.values
 
-  name          = "${local.short_identifier_prefix}Tascomi Contacts Ingestion Trigger"
-  type          = "SCHEDULED"
-  schedule      = "cron(0 2 * * ? *)"
-  enabled       = true
+  name     = "${local.short_identifier_prefix}Tascomi Contacts Ingestion Trigger"
+  type     = "SCHEDULED"
+  schedule = "cron(0 2 * * ? *)"
+  enabled  = local.is_live_environment
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name
@@ -127,10 +127,10 @@ resource "aws_glue_trigger" "ingest_tascomi_contacts_trigger" {
 resource "aws_glue_trigger" "ingest_tascomi_public_comments_trigger" {
   tags = module.tags.values
 
-  name          = "${local.short_identifier_prefix}Tascomi Public Comments Ingestion Trigger"
-  type          = "SCHEDULED"
-  schedule      = "cron(0 2 * * ? *)"
-  enabled       = true
+  name     = "${local.short_identifier_prefix}Tascomi Public Comments Ingestion Trigger"
+  type     = "SCHEDULED"
+  schedule = "cron(0 2 * * ? *)"
+  enabled  = local.is_live_environment
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name
@@ -143,10 +143,10 @@ resource "aws_glue_trigger" "ingest_tascomi_public_comments_trigger" {
 resource "aws_glue_trigger" "ingest_tascomi_documents_trigger" {
   tags = module.tags.values
 
-  name          = "${local.short_identifier_prefix}Tascomi Documents Ingestion Trigger"
-  type          = "SCHEDULED"
-  schedule      = "cron(0 2 * * ? *)"
-  enabled       = true
+  name     = "${local.short_identifier_prefix}Tascomi Documents Ingestion Trigger"
+  type     = "SCHEDULED"
+  schedule = "cron(0 2 * * ? *)"
+  enabled  = local.is_live_environment
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name


### PR DESCRIPTION
Edit job to only pull records that have been updated since the last import date. 
Schedule the triggers to run every day at 2 am.