### PR TITLE
Ingest tascomi tables on schedule

### DIFF
--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -102,39 +102,6 @@ resource "aws_glue_trigger" "tascomi_raw_zone_crawler_trigger" {
   }
 }
 
-
-resource "aws_glue_trigger" "ingest_tascomi_applications_trigger" {
-  tags = module.tags.values
-
-  name     = "${local.short_identifier_prefix}Tascomi Applications Ingestion Trigger"
-  type     = "ON_DEMAND"
-//  schedule = "cron(0 2 * * ? *)"
-//  enabled  = local.is_live_environment
-
-  actions {
-    job_name = aws_glue_job.ingest_tascomi_data.name
-    arguments = {
-      "--resource" = "applications"
-    }
-  }
-}
-
-resource "aws_glue_trigger" "ingest_tascomi_documents_trigger" {
-  tags = module.tags.values
-
-  name     = "${local.short_identifier_prefix}Tascomi Documents Ingestion Trigger"
-  type     = "SCHEDULED"
-  schedule = "cron(0 2 * * ? *)"
-  enabled  = local.is_live_environment
-
-  actions {
-    job_name = aws_glue_job.ingest_tascomi_data.name
-    arguments = {
-      "--resource" = "documents"
-    }
-  }
-}
-
 resource "aws_glue_trigger" "tascomi_tables_daily_ingestion_triggers" {
   tags = module.tags.values
   for_each = toset(local.tascomi_table_names)
@@ -151,4 +118,3 @@ resource "aws_glue_trigger" "tascomi_tables_daily_ingestion_triggers" {
     }
   }
 }
-


### PR DESCRIPTION
Set a cron schedule to ingest the following Tascomi tables daily at 3am:
- applications
- contacts
- emails
- enforcements
- fees
- public_comments
- communications
- fee_payments

