### PR TITLE
Disable triggers which schedule tascomi ingestion

### DIFF
--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -124,7 +124,7 @@ resource "aws_glue_trigger" "tascomi_tables_daily_ingestion_triggers" {
   name     = "${local.short_identifier_prefix}Tascomi ${title(replace(each.value, "_", " "))} Ingestion Trigger"
   type     = "SCHEDULED"
   schedule = "cron(0 3 * * ? *)"
-  enabled  = local.is_live_environment
+  enabled  = false
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name
@@ -141,7 +141,7 @@ resource "aws_glue_trigger" "tascomi_tables_weekly_ingestion_triggers" {
   name     = "${local.short_identifier_prefix}Tascomi ${title(replace(each.value, "_", " "))} Ingestion Trigger"
   type     = "SCHEDULED"
   schedule = "cron(0 22 ? * SUN *)"
-  enabled  = local.is_live_environment
+  enabled  = false
 
   actions {
     job_name = aws_glue_job.ingest_tascomi_data.name


### PR DESCRIPTION
We've been blocked out of the Tascomi API, until this gets resolved we don't want to run any ingestion as it will just fill up the tables with failed requests. 