### PR TITLE
Added the Planning Department group

### DIFF
--- a/terraform/05-departments.tf
+++ b/terraform/05-departments.tf
@@ -164,5 +164,6 @@ module "department_planning" {
   secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
   sso_instance_arn                = local.sso_instance_arn
   identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
 }


### PR DESCRIPTION
The department email address which identifies the group in google had been incorrectly assigned to google_group_admin_display_name this resulted in the group not being linked to the permissions sets in SSO stopping members of the planning team from accessing the data platform