### PR TITLE
tascomi ingestion job parameter change: Reduce number of workers 12 -> 6

### DIFF
--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -1,6 +1,6 @@
 
 locals {
-  number_of_workers   = 12
+  number_of_workers   = 6
   max_concurrent_runs = max(length(local.tascomi_table_names), length(local.tascomi_static_tables))
   tascomi_table_names = [
     "applications",


### PR DESCRIPTION
As per bug report found here: https://hackney.atlassian.net/jira/software/projects/DP/boards/53?selectedIssue=DP-364

we're currently being blocked by the tascomi API. This PR reduces the number of workers that will be calling the API.