### PR TITLE
update department permissions to allow trusted zone bucket access

### DIFF
--- a/modules/department/50-aws-iam-role.tf
+++ b/modules/department/50-aws-iam-role.tf
@@ -84,7 +84,8 @@ data "aws_iam_policy_document" "s3_department_access" {
       "${var.raw_zone_bucket.bucket_arn}/unrestricted/*",
       "${var.refined_zone_bucket.bucket_arn}/${local.department_identifier}/*",
       "${var.refined_zone_bucket.bucket_arn}/unrestricted/*",
-      "${var.glue_temp_storage_bucket.bucket_arn}/${local.department_identifier}/*"
+      "${var.trusted_zone_bucket.bucket_arn}/${local.department_identifier}/*",
+      "${var.glue_temp_storage_bucket.bucket_arn}/${local.department_identifier}/*",
     ]
   }
 


### PR DESCRIPTION
Address matching jobs were previously failing because the jobs were writing to the trusted zone and because Glue writes and deletes temporary files in the target destination and it did not have permissions to that bucket it was causing it to throw an error