### PR TITLE
Handle exceptions in tascomi ingestion

### DIFF
--- a/scripts/tascomi_api_ingestion.py
+++ b/scripts/tascomi_api_ingestion.py
@@ -30,9 +30,10 @@ def not_today(date_str):
     return date.date() != datetime.now().date()
 
 def get_tascomi_resource(page_number, url, body):
-    logger.info(f"Calling API to get page {page_number}")
     global public_key
     global private_key
+
+    print(f"Calling API to get page {page_number}")
 
     headers = {
         'content-type': "application/json",
@@ -45,7 +46,7 @@ def get_tascomi_resource(page_number, url, body):
     try:
         res = requests.get(url, data=body, headers=headers)
         if not res.text or json.loads(res.text) == None:
-            logger.info(f"Null data response, with status code {res.status_code} for page {page_number}")
+            print(f"Null data response, with status code {res.status_code} for page {page_number}")
             return ([""], url, res.status_code, "Null data response.")
         records = json.loads(res.text)
 
@@ -55,7 +56,7 @@ def get_tascomi_resource(page_number, url, body):
 
     except Exception as e:
         exception = str(e)
-        logger.info(f"ERROR: {exception} when getting page {page_number}. Status code {res.status_code}, response text {res.text}")
+        print(f"ERROR: {exception} when getting page {page_number}. Status code {res.status_code}, response text {res.text}")
         return ([""], url, res.status_code, exception)
 
 def calculate_auth_hash(public_key, private_key):

--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -56,14 +56,15 @@ module "ingest_tascomi_data" {
   max_concurrent_runs_of_glue_job = local.max_concurrent_runs
   job_name                        = "${local.short_identifier_prefix}Ingest tascomi data"
   job_parameters = {
-    "--s3_bucket_target"        = module.raw_zone.bucket_id
-    "--s3_prefix"               = "planning/tascomi/api-responses/"
-    "--extra-py-files"          = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"
-    "--enable-glue-datacatalog" = "true"
-    "--public_key_secret_id"    = aws_secretsmanager_secret.tascomi_api_public_key.id
-    "--private_key_secret_id"   = aws_secretsmanager_secret.tascomi_api_private_key.id
-    "--number_of_workers"       = local.number_of_workers
-    "--target_database_name"    = aws_glue_catalog_database.raw_zone_tascomi.name
+    "--s3_bucket_target"                 = module.raw_zone.bucket_id
+    "--s3_prefix"                        = "planning/tascomi/api-responses/"
+    "--extra-py-files"                   = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"
+    "--enable-glue-datacatalog"          = "true"
+    "--public_key_secret_id"             = aws_secretsmanager_secret.tascomi_api_public_key.id
+    "--private_key_secret_id"            = aws_secretsmanager_secret.tascomi_api_private_key.id
+    "--number_of_workers"                = local.number_of_workers
+    "--target_database_name"             = aws_glue_catalog_database.raw_zone_tascomi.name
+    "--enable-continuous-cloudwatch-log" = "true"
   }
   script_name            = aws_s3_bucket_object.ingest_tascomi_data.key
   glue_scripts_bucket_id = module.glue_scripts.bucket_id


### PR DESCRIPTION
If there are non 2XX status codes returned from the Tascomi API then it will retry those failed calls 2 more times before failing the job for someone to investigate it.