### PR TITLE
Remove retrieves from the tascomi ingestion script

### DIFF
--- a/terraform/24-aws-glue-tascomi-data.tf
+++ b/terraform/24-aws-glue-tascomi-data.tf
@@ -1,6 +1,6 @@
 
 locals {
-  number_of_workers   = 6
+  number_of_workers   = 4
   max_concurrent_runs = max(length(local.tascomi_table_names), length(local.tascomi_static_tables))
   tascomi_table_names = [
     "applications",
@@ -54,7 +54,7 @@ module "ingest_tascomi_data" {
   source = "../modules/aws-glue-job"
 
   department                      = module.department_planning
-  number_of_workers_for_glue_job  = 4
+  number_of_workers_for_glue_job  = local.number_of_workers
   max_concurrent_runs_of_glue_job = local.max_concurrent_runs
   job_name                        = "${local.short_identifier_prefix}Ingest tascomi data"
   job_parameters = {


### PR DESCRIPTION
Replacing it with a flag that when set to true will try and get all the failed requests from the last imported day.

This will have to be run manually at first but could trigger it in the future or could bundle up previously failed requests with and new requests for that day.

Using the retries was causing strange behaviour, such as trying to get the same page of data multiple times and taking a long time to finish, in the end this felt like a simpler solution for now.

