### PR TITLE
make script name variable required in the aws glue job module

### DIFF
--- a/modules/aws-glue-job/01-inputs-required.tf
+++ b/modules/aws-glue-job/01-inputs-required.tf
@@ -17,6 +17,16 @@ variable "job_name" {
   }
 }
 
+variable "script_name" {
+  description = <<EOF
+    Optional.
+    Name of the Glue job script. If no value is provided,
+    then it will be the same as the job name
+  EOF
+  type        = string
+}
+
+
 variable "glue_scripts_bucket_id" {
   description = "S3 bucket which contains the Glue scripts"
   type        = string

--- a/modules/aws-glue-job/02-inputs-optional.tf
+++ b/modules/aws-glue-job/02-inputs-optional.tf
@@ -27,16 +27,6 @@ variable "workflow_name" {
   default     = null
 }
 
-variable "script_name" {
-  description = <<EOF
-    Optional.
-    Name of the Glue job script. If no value is provided,
-    then it will be the same as the job name
-  EOF
-  type        = string
-  default     = null
-}
-
 variable "triggered_by_crawler" {
   description = <<EOF
     Can populate either this variable, the job_to_trigger variable or the schedule.


### PR DESCRIPTION
- Make script name variable required as it makes more sense to have this passed in to the aws glue job module after adding the script to the data platform project
- [Documentation](https://lbhackney-it.github.io/Data-Platform-Playbook/playbook/transforming-data/deploy-glue-jobs#:~:text=Copy-,script_name,-(required)%3A%20Name%20of) has already been updated to specify that `script name` variable is required