### PR TITLE
pass department identifier snakecase to glue module ato use as crawler table prefix

### DIFF
--- a/modules/aws-glue-job/01-inputs-required.tf
+++ b/modules/aws-glue-job/01-inputs-required.tf
@@ -1,9 +1,10 @@
 variable "department" {
   description = "The department with all its properties"
   type = object({
-    identifier    = string
-    glue_role_arn = string
-    tags          = map(string)
+    identifier_snake_case = string
+    identifier            = string
+    glue_role_arn         = string
+    tags                  = map(string)
   })
 }
 

--- a/modules/google-sheets-glue-job/01-inputs-required.tf
+++ b/modules/google-sheets-glue-job/01-inputs-required.tf
@@ -1,9 +1,10 @@
 variable "department" {
   description = "The department with all its properties"
   type = object({
-    identifier    = string
-    glue_role_arn = string
-    tags          = map(string)
+    identifier_snake_case = string
+    identifier            = string
+    glue_role_arn         = string
+    tags                  = map(string)
     google_service_account = object({
       credentials_secret = object({
         name = string

--- a/modules/google-sheets-glue-job/10-aws-glue-job.tf
+++ b/modules/google-sheets-glue-job/10-aws-glue-job.tf
@@ -23,7 +23,7 @@ module "google_sheet_import" {
   crawler_details = {
     database_name      = var.glue_catalog_database_name
     s3_target_location = local.full_output_path
-    table_prefix       = "${var.department.identifier}_"
+    table_prefix       = "${var.department.identifier_snake_case}_"
     configuration = jsonencode({
       Version = 1.0
       Grouping = {

--- a/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
+++ b/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
@@ -1,9 +1,10 @@
 variable "department" {
   description = "The department with all its properties"
   type = object({
-    identifier    = string
-    glue_role_arn = string
-    tags          = map(string)
+    identifier            = string
+    identifier_snake_case = string
+    glue_role_arn         = string
+    tags                  = map(string)
   })
 }
 

--- a/modules/import-data-from-xlsx-sheet-job/10-aws-glue-job.tf
+++ b/modules/import-data-from-xlsx-sheet-job/10-aws-glue-job.tf
@@ -17,7 +17,7 @@ module "xlsx_import" {
   workflow_name          = aws_glue_workflow.workflow.name
   glue_scripts_bucket_id = var.glue_scripts_bucket_id
   crawler_details = {
-    table_prefix       = "${replace(var.department.identifier, "-", "_")}_"
+    table_prefix       = "${var.department.identifier_snake_case}_"
     database_name      = var.glue_catalog_database_name
     s3_target_location = local.s3_output_path
   }

--- a/modules/import-xlsx-file-from-g-drive/01-inputs-required.tf
+++ b/modules/import-xlsx-file-from-g-drive/01-inputs-required.tf
@@ -1,9 +1,10 @@
 variable "department" {
   description = "The department with all its properties"
   type = object({
-    identifier    = string
-    glue_role_arn = string
-    tags          = map(string)
+    identifier            = string
+    identifier_snake_case = string
+    glue_role_arn         = string
+    tags                  = map(string)
   })
 }
 


### PR DESCRIPTION
- previously in the google sheets import and xls import, the crawler table prefix was set to create tables with hyphen separated names
- updated the glue module to use the department snakecase identifier which is used for the crawler table prefixes instead
- this is to ensure consistency in catalog table names