### PR TITLE
update crawler database for repairs dlo cleaned to refined zone database

### DIFF
--- a/terraform/23-aws-glue-job-repairs-dlo.tf
+++ b/terraform/23-aws-glue-job-repairs-dlo.tf
@@ -27,7 +27,7 @@ module "housing_repairs_dlo_cleaning_job" {
   glue_scripts_bucket_id = module.glue_scripts.bucket_id
   crawler_details = {
     table_prefix       = "housing_repairs_repairs_dlo_"
-    database_name      = module.department_housing_repairs.raw_zone_catalog_database_name
+    database_name      = module.department_housing_repairs.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone.bucket_id}/housing-repairs/repairs-dlo/cleaned/"
   }
 }


### PR DESCRIPTION
- the crawler for repairs dlo cleaned data was uploading to the wrong database
- updated it so that it adds tables to the refined zone database