### PR TITLE
add department name to glue crawler name in glue module

### DIFF
--- a/modules/aws-glue-job/11-aws-glue-crawler.tf
+++ b/modules/aws-glue-job/11-aws-glue-crawler.tf
@@ -3,7 +3,7 @@ resource "aws_glue_crawler" "crawler" {
   tags  = var.department.tags
 
   database_name = var.crawler_details.database_name
-  name          = local.job_name_identifier
+  name          = "${var.department.identifier}-${local.job_name_identifier}"
   role          = var.department.glue_role_arn
   table_prefix  = var.crawler_details.table_prefix
 


### PR DESCRIPTION
- when creating crawlers from the glue module we want the department name as well as the job name
![image](https://user-images.githubusercontent.com/70905620/141489540-7b2c7e70-6aa8-4719-9c63-40bb8dd97419.png)
