### PR TITLE
Added shutdown tags to EC2 resources

### DIFF
--- a/modules/qlik-sense-enterprise/10-aws-ec2.tf
+++ b/modules/qlik-sense-enterprise/10-aws-ec2.tf
@@ -140,6 +140,7 @@ resource "aws_security_group" "qlik_sense_enterprise" {
 resource "aws_instance" "qlik_sense_enterprise" {
   tags = merge(var.tags, {
     "Name" : "${var.identifier_prefix}-qlik-sense-enterprise",
+    "OOOShutdown" : "true"
   })
 
   ami                  = data.aws_ami.latest_windows.id

--- a/terraform/06-network.tf
+++ b/terraform/06-network.tf
@@ -114,7 +114,8 @@ resource "aws_security_group" "bastion" {
 
 resource "aws_instance" "bastion" {
   tags = merge(module.tags.values, {
-    "Name" : "${local.identifier_prefix}-bastion"
+    "Name" : "${local.identifier_prefix}-bastion",
+    "OOOShutdown" : "true"
   })
 
   ami                  = data.aws_ami.latest_amazon_linux_2.id


### PR DESCRIPTION
Updates the EC2 instances to have the 000Shutdown tag which uses the common deployed infrastructure to shut the instance down "out of hours".