### PR TITLE
correct catalog database used for cleaning crawler in housing repairs module

### DIFF
--- a/modules/electrical-mechnical-fire-safety-cleaning-job/03-inputs-derived.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/03-inputs-derived.tf
@@ -1,4 +1,4 @@
 locals {
-  catalog_database                   = var.department.raw_zone_catalog_database_name
+  raw_zone_catalog_database_name     = var.department.raw_zone_catalog_database_name
   refined_zone_catalog_database_name = var.department.refined_zone_catalog_database_name
 }

--- a/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-data-cleaning.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-data-cleaning.tf
@@ -22,7 +22,7 @@ module "housing_repairs_elec_mech_fire_cleaning" {
   pydeequ_zip_key   = var.pydeequ_zip_key
   job_parameters = {
     "--cleaned_repairs_s3_bucket_target" = "s3://${var.refined_zone_bucket_id}/housing-repairs/repairs-electrical-mechanical-fire/${var.dataset_name}/cleaned/"
-    "--source_catalog_database"          = local.catalog_database
+    "--source_catalog_database"          = local.raw_zone_catalog_database_name
     "--source_catalog_table"             = var.worksheet_resource.catalog_table
     "--deequ_metrics_location"           = "s3://${var.refined_zone_bucket_id}/quality-metrics/department=${var.department.identifier}/dataset=${var.dataset_name}-cleaned/deequ-metrics.json"
     "--extra-jars"                       = var.deequ_jar_file_path

--- a/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
@@ -39,11 +39,6 @@ variable "glue_crawler_excluded_blobs" {
   default     = []
 }
 
-variable "catalog_database" {
-  description = "Catalog data name"
-  type        = string
-}
-
 variable "source_catalog_table" {
   description = "Name of the source table in the catalog"
   type        = string
@@ -56,11 +51,6 @@ variable "trigger_crawler_name" {
 
 variable "workflow_name" {
   description = "Name of the workflow to add all the triggers created here to"
-  type        = string
-}
-
-variable "refined_zone_catalog_database_name" {
-  description = "Refined zone catalog database name"
   type        = string
 }
 
@@ -108,10 +98,12 @@ variable "pydeequ_zip_key" {
 variable "department" {
   description = "The department with all its properties"
   type = object({
-    identifier            = string
-    glue_role_arn         = string
-    tags                  = map(string)
-    identifier_snake_case = string
+    identifier                         = string
+    glue_role_arn                      = string
+    refined_zone_catalog_database_name = string
+    raw_zone_catalog_database_name     = string
+    tags                               = map(string)
+    identifier_snake_case              = string
     glue_temp_bucket = object({
       bucket_id = string
     })

--- a/modules/housing-repairs-google-sheets-cleaning/03-inputs-derived.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/03-inputs-derived.tf
@@ -1,3 +1,5 @@
 locals {
-  glue_job_name = "${var.short_identifier_prefix}Housing Repairs - ${title(replace(var.dataset_name, "-", " "))}"
+  glue_job_name                      = "${var.short_identifier_prefix}Housing Repairs - ${title(replace(var.dataset_name, "-", " "))}"
+  raw_zone_catalog_database_name     = var.department.raw_zone_catalog_database_name
+  refined_zone_catalog_database_name = var.department.refined_zone_catalog_database_name
 }

--- a/modules/housing-repairs-google-sheets-cleaning/10-aws-glue-data-cleaning.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/10-aws-glue-data-cleaning.tf
@@ -21,7 +21,7 @@ module "housing_repairs_google_sheets_cleaning" {
   helper_module_key = var.helper_module_key
   pydeequ_zip_key   = var.pydeequ_zip_key
   job_parameters = {
-    "--source_catalog_database"          = var.catalog_database
+    "--source_catalog_database"          = local.raw_zone_catalog_database_name
     "--source_catalog_table"             = var.source_catalog_table
     "--cleaned_repairs_s3_bucket_target" = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/cleaned/"
   }
@@ -30,7 +30,7 @@ module "housing_repairs_google_sheets_cleaning" {
   triggered_by_crawler = var.trigger_crawler_name
   crawler_details = {
     table_prefix       = "housing_repairs_${replace(var.dataset_name, "-", "_")}_"
-    database_name      = var.catalog_database
+    database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/cleaned/"
   }
 }

--- a/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
@@ -6,7 +6,7 @@ module "housing_repairs_google_sheets_address_cleaning" {
   helper_module_key = var.helper_module_key
   pydeequ_zip_key   = var.pydeequ_zip_key
   job_parameters = {
-    "--source_catalog_database"            = var.refined_zone_catalog_database_name
+    "--source_catalog_database"            = local.refined_zone_catalog_database_name
     "--source_catalog_table"               = "housing_repairs_${replace(var.dataset_name, "-", "_")}_cleaned"
     "--cleaned_addresses_s3_bucket_target" = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/with-cleaned-addresses"
     "--source_address_column_header"       = "property_address"
@@ -17,7 +17,7 @@ module "housing_repairs_google_sheets_address_cleaning" {
   triggered_by_crawler = module.housing_repairs_google_sheets_cleaning.crawler_name
   crawler_details = {
     table_prefix       = "housing_repairs_${replace(var.dataset_name, "-", "_")}_"
-    database_name      = var.refined_zone_catalog_database_name
+    database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/with-cleaned-addresses/"
   }
 }

--- a/modules/housing-repairs-google-sheets-cleaning/12-aws-glue-address-matching.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/12-aws-glue-address-matching.tf
@@ -8,7 +8,7 @@ module "housing_repairs_google_sheets_address_matching" {
   job_parameters = {
     "--addresses_api_data_database" = var.addresses_api_data_catalog
     "--addresses_api_data_table"    = "unrestricted_address_api_dbo_hackney_address"
-    "--source_catalog_database"     = var.refined_zone_catalog_database_name
+    "--source_catalog_database"     = local.refined_zone_catalog_database_name
     "--source_catalog_table"        = "housing_repairs_${replace(var.dataset_name, "-", "_")}_with_cleaned_addresses"
     "--target_destination"          = "s3://${var.trusted_zone_bucket_id}/housing-repairs/repairs/"
     "--match_to_property_shell"     = var.match_to_property_shell

--- a/terraform/23-aws-glue-job-repairs-alpha-track.tf
+++ b/terraform/23-aws-glue-job-repairs-alpha-track.tf
@@ -3,22 +3,20 @@ module "housing_repairs_alphatrack" {
 
   source = "../modules/housing-repairs-google-sheets-cleaning"
 
-  department                         = module.department_housing_repairs
-  short_identifier_prefix            = local.short_identifier_prefix
-  identifier_prefix                  = local.identifier_prefix
-  glue_scripts_bucket_id             = module.glue_scripts.bucket_id
-  glue_role_arn                      = aws_iam_role.glue_role.arn
-  glue_crawler_excluded_blobs        = local.glue_crawler_excluded_blobs
-  glue_temp_storage_bucket_url       = module.glue_temp_storage.bucket_url
-  refined_zone_bucket_id             = module.refined_zone.bucket_id
-  helper_module_key                  = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                    = aws_s3_bucket_object.pydeequ.key
-  catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
-  address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
-  trusted_zone_bucket_id             = module.trusted_zone.bucket_id
+  department                   = module.department_housing_repairs
+  short_identifier_prefix      = local.short_identifier_prefix
+  identifier_prefix            = local.identifier_prefix
+  glue_scripts_bucket_id       = module.glue_scripts.bucket_id
+  glue_role_arn                = aws_iam_role.glue_role.arn
+  glue_crawler_excluded_blobs  = local.glue_crawler_excluded_blobs
+  glue_temp_storage_bucket_url = module.glue_temp_storage.bucket_url
+  refined_zone_bucket_id       = module.refined_zone.bucket_id
+  helper_module_key            = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key              = aws_s3_bucket_object.pydeequ.key
+  address_cleaning_script_key  = aws_s3_bucket_object.address_cleaning.key
+  addresses_api_data_catalog   = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
+  address_matching_script_key  = aws_s3_bucket_object.levenshtein_address_matching.key
+  trusted_zone_bucket_id       = module.trusted_zone.bucket_id
 
   data_cleaning_script_name = "repairs_alpha_track_cleaning"
   source_catalog_table      = "housing_repairs_repairs_alpha_track"

--- a/terraform/23-aws-glue-job-repairs-avonline.tf
+++ b/terraform/23-aws-glue-job-repairs-avonline.tf
@@ -3,22 +3,20 @@ module "housing_repairs_avonline" {
 
   source = "../modules/housing-repairs-google-sheets-cleaning"
 
-  department                         = module.department_housing_repairs
-  short_identifier_prefix            = local.short_identifier_prefix
-  identifier_prefix                  = local.identifier_prefix
-  glue_scripts_bucket_id             = module.glue_scripts.bucket_id
-  glue_role_arn                      = aws_iam_role.glue_role.arn
-  glue_crawler_excluded_blobs        = local.glue_crawler_excluded_blobs
-  glue_temp_storage_bucket_url       = module.glue_temp_storage.bucket_url
-  refined_zone_bucket_id             = module.refined_zone.bucket_id
-  helper_module_key                  = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                    = aws_s3_bucket_object.pydeequ.key
-  catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
-  address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
-  trusted_zone_bucket_id             = module.trusted_zone.bucket_id
+  department                   = module.department_housing_repairs
+  short_identifier_prefix      = local.short_identifier_prefix
+  identifier_prefix            = local.identifier_prefix
+  glue_scripts_bucket_id       = module.glue_scripts.bucket_id
+  glue_role_arn                = aws_iam_role.glue_role.arn
+  glue_crawler_excluded_blobs  = local.glue_crawler_excluded_blobs
+  glue_temp_storage_bucket_url = module.glue_temp_storage.bucket_url
+  refined_zone_bucket_id       = module.refined_zone.bucket_id
+  helper_module_key            = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key              = aws_s3_bucket_object.pydeequ.key
+  address_cleaning_script_key  = aws_s3_bucket_object.address_cleaning.key
+  addresses_api_data_catalog   = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
+  address_matching_script_key  = aws_s3_bucket_object.levenshtein_address_matching.key
+  trusted_zone_bucket_id       = module.trusted_zone.bucket_id
 
   data_cleaning_script_name = "repairs_avonline_cleaning"
   source_catalog_table      = "housing_repairs_repairs_avonline"

--- a/terraform/23-aws-glue-job-repairs-axis.tf
+++ b/terraform/23-aws-glue-job-repairs-axis.tf
@@ -3,22 +3,20 @@ module "housing_repairs_axis" {
 
   source = "../modules/housing-repairs-google-sheets-cleaning"
 
-  department                         = module.department_housing_repairs
-  short_identifier_prefix            = local.short_identifier_prefix
-  identifier_prefix                  = local.identifier_prefix
-  glue_scripts_bucket_id             = module.glue_scripts.bucket_id
-  glue_role_arn                      = aws_iam_role.glue_role.arn
-  glue_crawler_excluded_blobs        = local.glue_crawler_excluded_blobs
-  glue_temp_storage_bucket_url       = module.glue_temp_storage.bucket_url
-  refined_zone_bucket_id             = module.refined_zone.bucket_id
-  helper_module_key                  = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                    = aws_s3_bucket_object.pydeequ.key
-  catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
-  address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
-  trusted_zone_bucket_id             = module.trusted_zone.bucket_id
+  department                   = module.department_housing_repairs
+  short_identifier_prefix      = local.short_identifier_prefix
+  identifier_prefix            = local.identifier_prefix
+  glue_scripts_bucket_id       = module.glue_scripts.bucket_id
+  glue_role_arn                = aws_iam_role.glue_role.arn
+  glue_crawler_excluded_blobs  = local.glue_crawler_excluded_blobs
+  glue_temp_storage_bucket_url = module.glue_temp_storage.bucket_url
+  refined_zone_bucket_id       = module.refined_zone.bucket_id
+  helper_module_key            = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key              = aws_s3_bucket_object.pydeequ.key
+  address_cleaning_script_key  = aws_s3_bucket_object.address_cleaning.key
+  addresses_api_data_catalog   = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
+  address_matching_script_key  = aws_s3_bucket_object.levenshtein_address_matching.key
+  trusted_zone_bucket_id       = module.trusted_zone.bucket_id
 
   data_cleaning_script_name = "repairs_axis_cleaning"
   source_catalog_table      = "housing_repairs_repairs_axis"

--- a/terraform/23-aws-glue-job-repairs-herts-heritage.tf
+++ b/terraform/23-aws-glue-job-repairs-herts-heritage.tf
@@ -14,7 +14,6 @@ module "housing_repairs_herts_heritage" {
   refined_zone_bucket_id       = module.refined_zone.bucket_id
   helper_module_key            = aws_s3_bucket_object.helpers.key
   pydeequ_zip_key              = aws_s3_bucket_object.pydeequ.key
-  catalog_database             = module.department_housing_repairs.raw_zone_catalog_database_name
   addresses_api_data_catalog   = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
   address_matching_script_key  = aws_s3_bucket_object.levenshtein_address_matching.key
   trusted_zone_bucket_id       = module.trusted_zone.bucket_id
@@ -23,8 +22,7 @@ module "housing_repairs_herts_heritage" {
   trigger_crawler_name = module.repairs_herts_heritage[0].crawler_name
   workflow_name        = module.repairs_herts_heritage[0].workflow_name
 
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  dataset_name                       = "repairs-herts-heritage"
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  match_to_property_shell            = "forbid"
+  dataset_name                = "repairs-herts-heritage"
+  address_cleaning_script_key = aws_s3_bucket_object.address_cleaning.key
+  match_to_property_shell     = "forbid"
 }

--- a/terraform/23-aws-glue-job-repairs-purdy.tf
+++ b/terraform/23-aws-glue-job-repairs-purdy.tf
@@ -3,23 +3,21 @@ module "housing_repairs_purdy" {
 
   source = "../modules/housing-repairs-google-sheets-cleaning"
 
-  department                         = module.department_housing_repairs
-  short_identifier_prefix            = local.short_identifier_prefix
-  identifier_prefix                  = local.identifier_prefix
-  glue_scripts_bucket_id             = module.glue_scripts.bucket_id
-  glue_role_arn                      = aws_iam_role.glue_role.arn
-  number_of_workers_for_glue_job     = 16
-  glue_crawler_excluded_blobs        = local.glue_crawler_excluded_blobs
-  glue_temp_storage_bucket_url       = module.glue_temp_storage.bucket_url
-  refined_zone_bucket_id             = module.refined_zone.bucket_id
-  helper_module_key                  = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                    = aws_s3_bucket_object.pydeequ.key
-  catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
-  address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
-  trusted_zone_bucket_id             = module.trusted_zone.bucket_id
+  department                     = module.department_housing_repairs
+  short_identifier_prefix        = local.short_identifier_prefix
+  identifier_prefix              = local.identifier_prefix
+  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+  glue_role_arn                  = aws_iam_role.glue_role.arn
+  number_of_workers_for_glue_job = 16
+  glue_crawler_excluded_blobs    = local.glue_crawler_excluded_blobs
+  glue_temp_storage_bucket_url   = module.glue_temp_storage.bucket_url
+  refined_zone_bucket_id         = module.refined_zone.bucket_id
+  helper_module_key              = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+  address_cleaning_script_key    = aws_s3_bucket_object.address_cleaning.key
+  addresses_api_data_catalog     = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
+  address_matching_script_key    = aws_s3_bucket_object.levenshtein_address_matching.key
+  trusted_zone_bucket_id         = module.trusted_zone.bucket_id
 
   data_cleaning_script_name = "repairs_purdy_cleaning"
   source_catalog_table      = "housing_repairs_repairs_purdy"

--- a/terraform/23-aws-glue-job-repairs-stannah.tf
+++ b/terraform/23-aws-glue-job-repairs-stannah.tf
@@ -3,22 +3,20 @@ module "housing_repairs_stannah" {
 
   source = "../modules/housing-repairs-google-sheets-cleaning"
 
-  department                         = module.department_housing_repairs
-  short_identifier_prefix            = local.short_identifier_prefix
-  identifier_prefix                  = local.identifier_prefix
-  glue_scripts_bucket_id             = module.glue_scripts.bucket_id
-  glue_role_arn                      = aws_iam_role.glue_role.arn
-  glue_crawler_excluded_blobs        = local.glue_crawler_excluded_blobs
-  glue_temp_storage_bucket_url       = module.glue_temp_storage.bucket_url
-  refined_zone_bucket_id             = module.refined_zone.bucket_id
-  helper_module_key                  = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                    = aws_s3_bucket_object.pydeequ.key
-  catalog_database                   = module.department_housing_repairs.raw_zone_catalog_database_name
-  refined_zone_catalog_database_name = module.department_housing_repairs.refined_zone_catalog_database_name
-  address_cleaning_script_key        = aws_s3_bucket_object.address_cleaning.key
-  addresses_api_data_catalog         = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
-  address_matching_script_key        = aws_s3_bucket_object.levenshtein_address_matching.key
-  trusted_zone_bucket_id             = module.trusted_zone.bucket_id
+  department                   = module.department_housing_repairs
+  short_identifier_prefix      = local.short_identifier_prefix
+  identifier_prefix            = local.identifier_prefix
+  glue_scripts_bucket_id       = module.glue_scripts.bucket_id
+  glue_role_arn                = aws_iam_role.glue_role.arn
+  glue_crawler_excluded_blobs  = local.glue_crawler_excluded_blobs
+  glue_temp_storage_bucket_url = module.glue_temp_storage.bucket_url
+  refined_zone_bucket_id       = module.refined_zone.bucket_id
+  helper_module_key            = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key              = aws_s3_bucket_object.pydeequ.key
+  address_cleaning_script_key  = aws_s3_bucket_object.address_cleaning.key
+  addresses_api_data_catalog   = aws_glue_catalog_database.raw_zone_unrestricted_address_api.name
+  address_matching_script_key  = aws_s3_bucket_object.levenshtein_address_matching.key
+  trusted_zone_bucket_id       = module.trusted_zone.bucket_id
 
   data_cleaning_script_name = "repairs_stannah_cleaning"
   source_catalog_table      = "housing_repairs_repairs_stannah"


### PR DESCRIPTION
- previously the cleaning crawler was writing refined data back to the raw zone database instead of refined zone database. The PR corrects this.
- get catalog databases from department instead and remove unneeded variables