### PR TITLE
 Add a prefix to job names which are deployed via terraform in staging

### DIFF
--- a/modules/aws-glue-job/01-inputs-required.tf
+++ b/modules/aws-glue-job/01-inputs-required.tf
@@ -5,6 +5,7 @@ variable "department" {
     glue_role_arn         = string
     identifier_snake_case = string
     tags                  = map(string)
+    environment           = string
     glue_temp_bucket = object({
       bucket_id = string
     })

--- a/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/modules/aws-glue-job/10-aws-glue-job.tf
@@ -17,12 +17,13 @@ resource "aws_s3_bucket_object" "job_script" {
 locals {
   object_key      = var.script_s3_object_key == null ? aws_s3_bucket_object.job_script[0].key : var.script_s3_object_key
   script_location = "s3://${var.department.glue_scripts_bucket.bucket_id}/${local.object_key}"
+  job_name_prefix = var.department.environment == "stg" ? "stg " : ""
 }
 
 resource "aws_glue_job" "job" {
   tags = var.department.tags
 
-  name              = var.job_name
+  name              = "${local.job_name_prefix}${var.job_name}"
   number_of_workers = var.number_of_workers_for_glue_job
   worker_type       = var.glue_job_worker_type
   role_arn          = local.glue_role_arn

--- a/modules/department/99-outputs.tf
+++ b/modules/department/99-outputs.tf
@@ -72,3 +72,8 @@ output "glue_scripts_bucket" {
   description = "Bucket where we store glue scripts"
   value       = var.glue_scripts_bucket
 }
+
+output "environment" {
+  description = "Environment e.g. dev, stg, prod"
+  value       = var.environment
+}

--- a/modules/electrical-mechnical-fire-safety-cleaning-job/01-inputs-required.tf
+++ b/modules/electrical-mechnical-fire-safety-cleaning-job/01-inputs-required.tf
@@ -12,6 +12,7 @@ variable "department" {
     refined_zone_catalog_database_name = string
     raw_zone_catalog_database_name     = string
     tags                               = map(string)
+    environment                        = string
     glue_temp_bucket = object({
       bucket_id = string
     })

--- a/modules/google-sheets-glue-job/01-inputs-required.tf
+++ b/modules/google-sheets-glue-job/01-inputs-required.tf
@@ -5,6 +5,7 @@ variable "department" {
     glue_role_arn         = string
     tags                  = map(string)
     identifier_snake_case = string
+    environment           = string
     glue_temp_bucket = object({
       bucket_id = string
     })

--- a/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
+++ b/modules/housing-repairs-google-sheets-cleaning/01-inputs-required.tf
@@ -103,6 +103,7 @@ variable "department" {
     refined_zone_catalog_database_name = string
     raw_zone_catalog_database_name     = string
     tags                               = map(string)
+    environment                        = string
     identifier_snake_case              = string
     glue_temp_bucket = object({
       bucket_id = string

--- a/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
+++ b/modules/import-data-from-xlsx-sheet-job/01-inputs-required.tf
@@ -5,6 +5,7 @@ variable "department" {
     glue_role_arn         = string
     tags                  = map(string)
     identifier_snake_case = string
+    environment           = string
     glue_temp_bucket = object({
       bucket_id = string
     })

--- a/modules/import-xlsx-file-from-g-drive/01-inputs-required.tf
+++ b/modules/import-xlsx-file-from-g-drive/01-inputs-required.tf
@@ -5,6 +5,7 @@ variable "department" {
     glue_role_arn         = string
     tags                  = map(string)
     identifier_snake_case = string
+    environment           = string
     glue_temp_bucket = object({
       bucket_id = string
     })


### PR DESCRIPTION
This is to prevent naming conflicts between jobs that have been protyped in glue studio staging and jobs which are deployed in terraform