### PR TITLE
Don't include management events in liberator trail

### DIFF
--- a/modules/sql-to-rds-snapshot/20-cloudtrail.tf
+++ b/modules/sql-to-rds-snapshot/20-cloudtrail.tf
@@ -11,7 +11,7 @@ resource "aws_cloudtrail" "events" {
 
   event_selector {
     read_write_type           = "All"
-    include_management_events = true
+    include_management_events = false
 
     data_resource {
       type = "AWS::S3::Object"


### PR DESCRIPTION
These cost money as it is the second trail that records them in this region and we don't use them here.