### PR TITLE
Set default timeout for glue jobs to 2h when using the module

### DIFF
--- a/modules/aws-glue-job/02-inputs-optional.tf
+++ b/modules/aws-glue-job/02-inputs-optional.tf
@@ -139,3 +139,9 @@ variable "extra_jars" {
   type        = list(string)
   default     = []
 }
+
+variable "glue_job_timeout" {
+  description = "Set the timeout for the glue job in minutes. By default this is set to 120"
+  type        = number
+  default     = 120
+}

--- a/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/modules/aws-glue-job/10-aws-glue-job.tf
@@ -27,6 +27,7 @@ resource "aws_glue_job" "job" {
   number_of_workers = var.number_of_workers_for_glue_job
   worker_type       = var.glue_job_worker_type
   role_arn          = local.glue_role_arn
+  timeout           = var.glue_job_timeout
   command {
     python_version  = "3"
     script_location = local.script_location


### PR DESCRIPTION
With an optional variable so it can be overridden if necessary.

Co-authored-by: Ben Dalton <ben.dalton@madetech.com>