### PR TITLE
add int fields to Tascomi dictionary

### DIFF
--- a/scripts/jobs/planning/tascomi-column-type-dictionary.json
+++ b/scripts/jobs/planning/tascomi-column-type-dictionary.json
@@ -470,10 +470,10 @@
             "dtf_locations": ["creation_user_id","custodian_code_id","id","last_updated_by","merge_source_id","street_id"],
             "documents": ["appeal_id","application_id","asset_constraint_id","communication_id","consultation_duration","creation_user_id","document_type_id","email_id","enforcement_id","id","last_updated_by","legal_agreement_id","officer_id","parent_document_id","preapplication_id","publication_id","public_comment_id","publicity_duration","publicity_justification_id","public_record_id","uploaded_file_id"],
             "users": ["creation_user_id","id","last_updated_by"],
-            "committee_application_map": ["id","load_order"],
-            "user_teams": ["id"],
-            "user_team_map": ["id"],
-            "application_types": ["id","target_days","received_stage_target_days","incomplete_stage_target_days","complete_stage_target_days","consultation_stage_target_days","consultation_complete_stage_target_days","assessment_stage_target_days","recommendation_stage_target_days","committee_stage_target_days","determination_referred_stage_target_days","decision_issued_stage_target_days","under_appeal_stage_target_days","default_decision_expiry_months","default_decision_expiry_years"]
+            "committee_application_map": ["id","load_order","creation_user_id","application_id","committee_id"],
+            "user_teams": ["id","creation_user_id"],
+            "user_team_map": ["id","creation_user_id","user_id","user_team_id"],
+            "application_types": ["id","creation_user_id","target_days","received_stage_target_days","incomplete_stage_target_days","complete_stage_target_days","consultation_stage_target_days","consultation_complete_stage_target_days","assessment_stage_target_days","recommendation_stage_target_days","committee_stage_target_days","determination_referred_stage_target_days","decision_issued_stage_target_days","under_appeal_stage_target_days","default_decision_expiry_months","default_decision_expiry_years"]
         },
         "boolean": {
             "applications": [


### PR DESCRIPTION
Hole in the Playbook: some fields appearing as "foreign" in the Documentation were not added as "integer" in the dictionary, hence were imported a "string" in the DP.