### PR TITLE
Add make target to start up the v3 aws glue libs docker image

### DIFF
--- a/notebook/Makefile
+++ b/notebook/Makefile
@@ -1,6 +1,14 @@
 run-notebook:
 	-(aws-vault exec hackney-dataplatform-staging -- env | grep  ^AWS_)  > ./.env
-	docker compose up -d notebook
+	docker compose up notebook
+
+run-notebook-v3:
+	-(aws-vault exec hackney-dataplatform-staging -- env | grep  ^AWS_)  > ./.env
+	docker run -it -p 8888:8888 -p 4040:4040 -e DISABLE_SSL="true" \
+	--env-file ./.env \
+	--name glue_jupyter_v4 -v $$PWD/scripts:/home/glue_user/workspace/jupyter_workspace \
+	amazon/aws-glue-libs:glue_libs_3.0.0_image_01
+# /home/glue_user/jupyter/jupyter_start.sh
 
 remove-images:
 	-docker kill glue_jupyter
@@ -12,4 +20,4 @@ thrift-server:
 spark-sql:
 	docker compose exec notebook /home/spark-2.4.3-bin-spark-2.4.3-bin-hadoop2.8/bin/beeline -u jdbc:hive2://localhost:10000/default -n root -p ""
 
-.PHONY: run-notebook
+.PHONY: run-notebook run-notebook-v3

--- a/notebook/docker-compose.yml
+++ b/notebook/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: glue_jupyter
     image: amazon/aws-glue-libs:glue_libs_1.0.0_image_01
     env_file: .env
+    environment:
+      - DISABLE_SSL="true"
     ports:
       - "8888:8888"
       - "4040:4040"

--- a/notebook/scripts/test-s3-connection.ipynb
+++ b/notebook/scripts/test-s3-connection.ipynb
@@ -8,14 +8,45 @@
    "source": [
     "from pyspark import SparkContext\n",
     "from awsglue.context import GlueContext\n",
-    "s3_url=\"s3://dataplatform-emmacorbett-landing-zone/parking/manual/cedar-parking-expenditure/Parking Expenditure-Table 1.csv\"\n",
+    "import  boto3\n",
+    "\n",
+    "s3Client = boto3.client('s3')\n",
+    "s3Bucket=\"dataplatform-stg-landing-zone\"\n",
+    "prefix = \"parking/manual\"\n",
+    "\n",
+    "objects = s3Client.list_objects_v2(\n",
+    "    Bucket=s3Bucket,\n",
+    "    Prefix=prefix\n",
+    ")['Contents']\n",
+    "\n",
+    "nonEmptyObjects = list(filter(lambda x: x['Size'] != 0, objects))\n",
+    "nonEmptyObjects[0:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exampleObject = nonEmptyObjects[0]['Key']\n",
+    "exampleObject"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
     "\n",
     "glueContext = GlueContext(SparkContext.getOrCreate()) \n",
     "inputDF = glueContext.create_dynamic_frame_from_options(\n",
     "    connection_type = \"s3\",\n",
-    "    connection_options = {\"paths\": [s3_url]}, format = \"csv\", format_options = { \"withHeader\": True })\n",
+    "    connection_options = {\"paths\": [f\"s3://{s3Bucket}/{exampleObject}\"]}, format = \"csv\", format_options = { \"withHeader\": True })\n",
     "\n",
-    "inputDF.toDF().show()"
+    "inputDF.toDF().show(10)"
    ]
   },
   {
@@ -26,19 +57,12 @@
    "source": [
     "inputDF.toDF().columns"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "PySpark",
-   "language": "",
+   "display_name": "Glue Spark - Local (PySpark)",
+   "language": "python",
    "name": "pysparkkernel"
   },
   "language_info": {
@@ -46,6 +70,7 @@
     "name": "python",
     "version": 3
    },
+   "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "pyspark",
    "pygments_lexer": "python3"


### PR DESCRIPTION
Improve the test s3 notebook, It'll work in pre prod now. It'll also find it's own file to test with.

Added an extra target to run the version 3 awsglue libs docker image. It will open a terminal on start up which you then have to run the command `/home/glue_user/jupyter/jupyter_start.sh` to startup the notebook. 