### PR TITLE
Create s3 object for database ingestion jdbc script and pass to db ingestion jobs

### DIFF
--- a/terraform/22-aws-glue-scripts.tf
+++ b/terraform/22-aws-glue-scripts.tf
@@ -102,3 +102,10 @@ resource "aws_s3_bucket_object" "copy_liberator_landing_to_raw" {
   source_hash = filemd5("../scripts/jobs/copy_liberator_landing_to_raw.py")
 }
 
+resource "aws_s3_bucket_object" "ingest_database_tables_via_jdbc_connection" {
+  bucket      = module.glue_scripts.bucket_id
+  key         = "scripts/ingest_database_tables_via_jdbc_connection.py"
+  acl         = "private"
+  source      = "../scripts/jobs/ingest_database_tables_via_jdbc_connection.py"
+  source_hash = filemd5("../scripts/jobs/ingest_database_tables_via_jdbc_connection.py")
+}

--- a/terraform/29-mssql-ingestion.tf
+++ b/terraform/29-mssql-ingestion.tf
@@ -25,7 +25,7 @@ module "ingest_rev_bev_council_tax_to_landing_zone" {
   source = "../modules/aws-glue-job"
 
   job_name               = "${local.short_identifier_prefix}Revenue & Benefits and Council Tax Database Ingestion"
-  script_name            = "ingest_database_tables_via_jdbc_connection"
+  script_s3_object_key   = aws_s3_bucket_object.ingest_database_tables_via_jdbc_connection.key
   environment            = var.environment
   pydeequ_zip_key        = aws_s3_bucket_object.pydeequ.key
   helper_module_key      = aws_s3_bucket_object.helpers.key

--- a/terraform/29-parking-geolive-database-ingestion.tf
+++ b/terraform/29-parking-geolive-database-ingestion.tf
@@ -21,7 +21,7 @@ module "parking_geolive_ingestion_job" {
 
   department           = module.department_parking
   job_name             = "${local.short_identifier_prefix}geolive parking schema ingestion"
-  script_name          = "ingest_database_tables_via_jdbc_connection"
+  script_s3_object_key = aws_s3_bucket_object.ingest_database_tables_via_jdbc_connection.key
   helper_module_key    = aws_s3_bucket_object.helpers.key
   pydeequ_zip_key      = aws_s3_bucket_object.pydeequ.key
   jdbc_connections     = [module.parking_geolive_database_ingestion[0].jdbc_connection_name]


### PR DESCRIPTION
Build failed because it was looking in the department folder for this script.
Creates an s3 object containing the generic jdbc database ingestion script that can be passed into database ingestion Glue jobs