### PR TITLE
Add CopyObject to list of watched events

### DIFF
--- a/modules/sql-to-rds-snapshot/40-cloudwatch-event.tf
+++ b/modules/sql-to-rds-snapshot/40-cloudwatch-event.tf
@@ -77,7 +77,8 @@ resource "aws_cloudwatch_event_rule" "new_s3_object" {
       ],
       "eventName" : [
         "PutObject",
-        "CompleteMultipartUpload"
+        "CompleteMultipartUpload",
+        "CopyObject"
       ],
       "requestParameters" : {
         "bucketName" : [


### PR DESCRIPTION
 from the liberator SQL to rds cloud watch event trigger.

Now that the zip files are being copied from production to pre-production we need to trigger the workflow when an object is copied.