### PR TITLE
Increase cpu and memory capacity for raw zone ecs sync task

### DIFF
--- a/modules/aws-ecs-fargate-task/01-inputs-required.tf
+++ b/modules/aws-ecs-fargate-task/01-inputs-required.tf
@@ -29,6 +29,8 @@ variable "tasks" {
     task_prefix                         = optional(string)
     cloudwatch_rule_schedule_expression = optional(string)
     cloudwatch_rule_event_pattern       = optional(string)
+    task_cpu                            = optional(number)
+    task_memory                         = optional(number)
     environment_variables = list(object({
       name  = string
       value = string

--- a/modules/sql-to-rds-snapshot/10-ecs.tf
+++ b/modules/sql-to-rds-snapshot/10-ecs.tf
@@ -63,6 +63,8 @@ module "sql_to_parquet" {
   tasks = [
     {
       cloudwatch_rule_event_pattern = local.event_pattern
+      task_cpu                      = 256
+      task_memory                   = 512
       environment_variables = [
         { "name" : "MYSQL_HOST", "value" : aws_db_instance.ingestion_db.address },
         { "name" : "MYSQL_USER", "value" : aws_db_instance.ingestion_db.username },

--- a/terraform/86-sync-production-to-pre-production.tf
+++ b/terraform/86-sync-production-to-pre-production.tf
@@ -90,6 +90,8 @@ module "sync_production_to_pre_production" {
   tasks = [
     {
       task_prefix = "raw-zone-"
+      task_cpu                            = 2048
+      task_memory                         = 15259
       environment_variables = [
         { "name" = "NUMBER_OF_DAYS_TO_RETAIN", "value" = "90" },
         { "name" = "S3_SYNC_SOURCE", "value" = module.raw_zone.bucket_id },
@@ -99,6 +101,8 @@ module "sync_production_to_pre_production" {
     },
     {
       task_prefix = "refined-zone-"
+      task_cpu                            = 256
+      task_memory                         = 512
       environment_variables = [
         { "name" = "NUMBER_OF_DAYS_TO_RETAIN", "value" = "90" },
         { "name" = "S3_SYNC_SOURCE", "value" = module.refined_zone.bucket_id },
@@ -108,6 +112,8 @@ module "sync_production_to_pre_production" {
     },
     {
       task_prefix = "trusted-zone-"
+      task_cpu                            = 256
+      task_memory                         = 512
       environment_variables = [
         { "name" = "NUMBER_OF_DAYS_TO_RETAIN", "value" = "90" },
         { "name" = "S3_SYNC_SOURCE", "value" = module.trusted_zone.bucket_id },


### PR DESCRIPTION
This task has been known to take a substantial amount of time. Will monitor and iterate to get the configuration to an adequate setting.

Updates aws-ecs-fargate-task to allow task capacity to be configured