### PR TITLE
Increase glue job capacity to allocate more memory and storage

### DIFF
--- a/terraform/29-mssql-ingestion.tf
+++ b/terraform/29-mssql-ingestion.tf
@@ -133,6 +133,7 @@ module "copy_academy_benefits_housing_needs_to_raw_zone" {
   glue_temp_bucket_id             = module.glue_temp_storage.bucket_id
   glue_scripts_bucket_id          = module.glue_scripts.bucket_id
   spark_ui_output_storage_id      = module.spark_ui_output_storage.bucket_id
+  glue_job_worker_type            = "G.2X"
   glue_job_timeout                = 220
   max_concurrent_runs_of_glue_job = 2
   triggered_by_crawler            = aws_glue_crawler.academy_revenues_and_benefits_housing_needs_landing_zone.name
@@ -144,6 +145,7 @@ module "copy_academy_benefits_housing_needs_to_raw_zone" {
     "--glue_database_name_target" = module.department_benefits_and_housing_needs.raw_zone_catalog_database_name
     "--enable-glue-datacatalog"   = "true"
     "--job-bookmark-option"       = "job-bookmark-enable"
+    "--write-shuffle-files-to-s3" = "true"
   }
 }
 


### PR DESCRIPTION
Fixes failing Glue job `stg Copy Academy Benefits Housing Needs to raw zone` as it was running out of space
![image](https://user-images.githubusercontent.com/70905620/162151362-a78009cc-ef22-4884-a905-a86ebddd612b.png)

This tells Spark to use S3 to write and read shuffle data. "Shuffling" is a Spark feature where a job, whilst processing data, will write data to disk storage so is therefore constrained by available local disk capacity. In Glue, the workers write shuffle data on local disk volumes/storage attached to the Glue workers. So when processing a large amount of data it could result in too much shuffle and then the underlying storage gets filled up, hence the error No space left on device exception. But whilst this parameter is set to true it will use S3 storage to store the intermediate shuffle data and therefore it enables the Glue job to handle more data intensive workloads more reliably (see docs [here](https://aws.amazon.com/blogs/big-data/introducing-amazon-s3-shuffle-in-aws-glue/))