### PR TITLE
Disable glue job triggers on sandbox Glue jobs

### DIFF
--- a/terraform/26-google-sheets-imports.tf
+++ b/terraform/26-google-sheets-imports.tf
@@ -219,6 +219,7 @@ module "sandbox_daro_covid_locations" {
   department                      = module.department_sandbox
   dataset_name                    = "daro_covid_locations"
   google_sheet_import_schedule    = "cron(0 6 ? * * *)"
+  enable_glue_trigger             = false
   spark_ui_output_storage_id      = module.spark_ui_output_storage.bucket_id
 }
 
@@ -240,6 +241,7 @@ module "sandbox_daro_covid_vaccinations" {
   department                      = module.department_sandbox
   dataset_name                    = "daro_covid_vaccinations"
   google_sheet_import_schedule    = "cron(0 6 ? * * *)"
+  enable_glue_trigger             = false
   spark_ui_output_storage_id      = module.spark_ui_output_storage.bucket_id
 }
 module "covid_locations_lisa" {
@@ -566,6 +568,7 @@ module "sandbox_stevefarr_covid_vaccinations" {
   google_sheets_worksheet_name    = "vaccinations"
   department                      = module.department_sandbox
   dataset_name                    = "stevefarr_covid_vaccinations"
+  enable_glue_trigger             = false
   spark_ui_output_storage_id      = module.spark_ui_output_storage.bucket_id
 }
 
@@ -586,5 +589,6 @@ module "sandbox_stevefarr_covid_locations" {
   google_sheets_worksheet_name    = "locations"
   department                      = module.department_sandbox
   dataset_name                    = "stevefarr_covid_locations"
+  enable_glue_trigger             = false
   spark_ui_output_storage_id      = module.spark_ui_output_storage.bucket_id
 }


### PR DESCRIPTION
Stops the Sandbox Glue jobs from running in pre-prod and prod (after release is published) as it's not necessary since these were used for training