### PR TITLE
Get av zone & vpc ID from the subnet used for the jdbc connection

### DIFF
--- a/modules/database-ingestion-via-jdbc-connection/01-inputs-required.tf
+++ b/modules/database-ingestion-via-jdbc-connection/01-inputs-required.tf
@@ -12,11 +12,6 @@ variable "jdbc_connection_description" {
   type        = string
 }
 
-variable "database_availability_zone" {
-  description = "Availability zone of the database to be used in the Glue connection"
-  type        = string
-}
-
 variable "database_secret_name" {
   description = "Name of secret for database credentials"
   type        = string
@@ -27,18 +22,16 @@ variable "tags" {
   type        = map(string)
 }
 
-variable "jdbc_connection_subnet_id" {
+variable "jdbc_connection_subnet" {
   description = "Subnet used for the JDBC connection"
-  type        = string
+  type = object({
+    id                = string
+    availability_zone = string
+    vpc_id            = string
+  })
 }
 
 variable "identifier_prefix" {
   description = "Project wide short resource identifier prefix"
   type        = string
 }
-
-variable "vpc_id" {
-  description = "Id of Data Platform VPC"
-  type        = string
-}
-

--- a/modules/database-ingestion-via-jdbc-connection/10-aws-glue-connection.tf
+++ b/modules/database-ingestion-via-jdbc-connection/10-aws-glue-connection.tf
@@ -16,7 +16,7 @@ locals {
 resource "aws_glue_connection" "jdbc_database_ingestion" {
   tags = var.tags
 
-  name        = "${var.identifier_prefix}${var.name}-${var.database_availability_zone}"
+  name        = "${var.identifier_prefix}${var.name}-${var.jdbc_connection_subnet.availability_zone}"
   description = var.jdbc_connection_description
   connection_properties = {
     JDBC_CONNECTION_URL = var.jdbc_connection_url
@@ -25,9 +25,9 @@ resource "aws_glue_connection" "jdbc_database_ingestion" {
   }
 
   physical_connection_requirements {
-    availability_zone      = var.database_availability_zone
+    availability_zone      = var.jdbc_connection_subnet.availability_zone
     security_group_id_list = [aws_security_group.ingestion_database_connection.id]
-    subnet_id              = var.jdbc_connection_subnet_id
+    subnet_id              = var.jdbc_connection_subnet.id
   }
 }
 
@@ -37,7 +37,7 @@ resource "aws_security_group" "ingestion_database_connection" {
   })
 
   name   = "${var.identifier_prefix}${var.name}-glue-connection"
-  vpc_id = var.vpc_id
+  vpc_id = var.jdbc_connection_subnet.vpc_id
 }
 
 resource "aws_security_group_rule" "ingestion_database_connection_allow_tcp_ingress" {

--- a/terraform/29-mssql-ingestion.tf
+++ b/terraform/29-mssql-ingestion.tf
@@ -7,12 +7,10 @@ module "academy_mssql_database_ingestion" {
   name                        = "academy-benefits-housing-needs-and-revenues"
   jdbc_connection_url         = "jdbc:sqlserver://10.120.23.22:1433;databaseName=LBHALiveRBViews"
   jdbc_connection_description = "JDBC connection to Academy Production Insights LBHALiveRBViews database"
-  jdbc_connection_subnet_id   = local.subnet_ids_list[local.subnet_ids_random_index]
-  database_availability_zone  = "eu-west-2a"
+  jdbc_connection_subnet      = data.aws_subnet.network[local.instance_subnet_id]
   database_secret_name        = "database-credentials/lbhaliverbviews-benefits-housing-needs-revenues"
   identifier_prefix           = local.short_identifier_prefix
   create_workflow             = false
-  vpc_id                      = data.aws_vpc.network.id
 }
 
 resource "aws_glue_catalog_database" "landing_zone_academy" {

--- a/terraform/29-parking-geolive-database-ingestion.tf
+++ b/terraform/29-parking-geolive-database-ingestion.tf
@@ -7,12 +7,10 @@ module "parking_geolive_database_ingestion" {
   name                        = "geolive-parking-schema"
   jdbc_connection_url         = "jdbc:postgresql://10.120.8.145:5432/geolive"
   jdbc_connection_description = "JDBC connection to Geolive PostgreSQL database, to access the parking schema only"
-  jdbc_connection_subnet_id   = local.subnet_ids_list[local.subnet_ids_random_index]
+  jdbc_connection_subnet      = data.aws_subnet.network[local.instance_subnet_id]
   schema_name                 = "parking"
-  database_availability_zone  = "eu-west-2a"
   database_secret_name        = "database-credentials/geolive-parking"
   identifier_prefix           = local.short_identifier_prefix
-  vpc_id                      = data.aws_vpc.network.id
 }
 
 module "parking_geolive_ingestion_job" {


### PR DESCRIPTION

Previously the subnet ID was randomly selected, but then the availability zone was hardcoded
to be eu-west-2a. In production, the subnet that was selected was in eu-west-2c, so the crawler was failing
when using the JDBC connection.