### PR TITLE
Run academy ingestion crawler once instead at a slightly later time

### DIFF
--- a/terraform/29-mssql-ingestion.tf
+++ b/terraform/29-mssql-ingestion.tf
@@ -108,7 +108,7 @@ resource "aws_glue_trigger" "academy_revenues_and_benefits_housing_needs_landing
 
   name     = "${local.short_identifier_prefix}academy-revenues-benefits-housing-needs-database-ingestion-crawler-trigger"
   type     = "SCHEDULED"
-  schedule = "cron(15 8 ? * MON,TUE,WED,THU,FRI *)"
+  schedule = "cron(15 8,12 ? * MON,TUE,WED,THU,FRI *)"
   enabled  = local.is_live_environment
 
   actions {


### PR DESCRIPTION
This is so the copy landing to raw jobs don't get version mismatch errors as jobs can't run concurrently with job bookmarking enabled