### PR TITLE
Enable cloudwatch event rule to invoke lambda at 6 everyday

### DIFF
--- a/modules/g-drive-to-s3/10-lambda.tf
+++ b/modules/g-drive-to-s3/10-lambda.tf
@@ -128,7 +128,6 @@ resource "aws_cloudwatch_event_rule" "every_day_at_6" {
   name                = "g-drive-to-s3-copier-every-day-at-6"
   description         = "Fires every dat at "
   schedule_expression = "cron(0 6 * * ? *)"
-  is_enabled          = false
 }
 
 resource "aws_cloudwatch_event_target" "run_lambda_every_day_at_6" {


### PR DESCRIPTION
Once CloudWatch Event Rule is enabled (enabled by default), will check that the lambda functions get added as targets. If not, will investigate further.

**Context:** This rule is to run the lambda that imports parking "manual" files from G drive to the parking landing zone (instead of having them uploading to S3 directly) where a spreadsheet import job then copies and outputs the data to the relevant directory in the departments bucket in the raw zone