### PR TITLE
Create a unique cloudwatch rule for each lambda to register targets against

### DIFF
--- a/modules/g-drive-to-s3/10-lambda.tf
+++ b/modules/g-drive-to-s3/10-lambda.tf
@@ -125,7 +125,7 @@ resource "aws_lambda_function_event_invoke_config" "g_drive_to_s3_copier_lambda"
 }
 
 resource "aws_cloudwatch_event_rule" "every_day_at_6" {
-  name                = "g-drive-to-s3-copier-every-day-at-6"
+  name_prefix         = "g-drive-to-s3-copier-every-day-at-6-"
   description         = "Fires every dat at "
   schedule_expression = "cron(0 6 * * ? *)"
 }


### PR DESCRIPTION
Use `name_prefix` so that a unique CloudWatch rule is created for each Lambda.
Previously only one CloudWatch Event rule was being created from this module and therefore none of the g-drive lambdas were being invoked as they weren't registered as targets to a CloudWatch rule.