### PR TITLE
Update crawler s3 path and table level to create one table for each output folder

### DIFF
--- a/modules/import-data-from-spreadsheet-job/03-input-derived.tf
+++ b/modules/import-data-from-spreadsheet-job/03-input-derived.tf
@@ -1,5 +1,4 @@
 locals {
   worksheet_key  = lower(replace(replace(trimspace(var.worksheet_name), ".", ""), " ", "-"))
   import_name    = "${var.department.identifier}-${local.worksheet_key}"
-  s3_output_path = "s3://${var.raw_zone_bucket_id}/${var.department.identifier}/${var.output_folder_name}/${var.data_set_name}"
 }

--- a/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
+++ b/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
@@ -9,7 +9,7 @@ module "spreadsheet_import" {
   glue_role_arn     = var.glue_role_arn
   job_parameters = {
     "--s3_bucket_source"  = "s3://${var.landing_zone_bucket_id}/${var.department.identifier}/${var.output_folder_name}/${var.input_file_name}"
-    "--s3_bucket_target"  = local.s3_output_path
+    "--s3_bucket_target"  = "s3://${var.raw_zone_bucket_id}/${var.department.identifier}/${var.output_folder_name}/${var.data_set_name}"
     "--header_row_number" = var.header_row_number
     "--worksheet_name"    = var.worksheet_name
   }
@@ -20,7 +20,13 @@ module "spreadsheet_import" {
   crawler_details = {
     table_prefix       = "${var.department.identifier_snake_case}_"
     database_name      = var.glue_catalog_database_name
-    s3_target_location = local.s3_output_path
+    s3_target_location = "s3://${var.raw_zone_bucket_id}/${var.department.identifier}/${var.output_folder_name}"
+    configuration = jsonencode({
+      Version = 1.0
+      Grouping = {
+        TableLevelConfiguration = 3
+      }
+    })
   }
   trigger_enabled = false
 }


### PR DESCRIPTION
This PR cleans up the tables that are created in the `parking_raw_zone` Glue catalog database
- After the files are copied from Google Drive to the respective folders in parking landing zone area, they get moved to the raw zone under the same folders in the parking raw zone where it is crawled and made available in `parking_raw_zone` Glue catalog database. Previously s3 paths were crawled up to the file level so there would be a table for each file which technically contained new versions of the same data. This update will ensure a table is created for each relevant parking output folder (as opposed to a table for each file) so that the data is grouped