### PR TITLE
Upload secret as secret_string instead of secret_binary

### DIFF
--- a/modules/google-service-account/53-secrets-manager.tf
+++ b/modules/google-service-account/53-secrets-manager.tf
@@ -14,5 +14,5 @@ resource "aws_secretsmanager_secret_version" "json_credentials" {
   count = var.is_live_environment ? 1 : 0
 
   secret_id     = aws_secretsmanager_secret.sheets_credentials.id
-  secret_binary = google_service_account_key.json_credentials[0].private_key
+  secret_string = google_service_account_key.json_credentials[0].private_key
 }


### PR DESCRIPTION
Uploads a json secret value
The secrets don't seem to get stored in secrets manager as the lambda finds the secret but can't pick up the secret value so trying this to see if it uploads correctly