### PR TITLE
Update G Drive lambda to retrieve secret value correctly

### DIFF
--- a/lambdas/g_drive_to_s3/main.py
+++ b/lambdas/g_drive_to_s3/main.py
@@ -67,7 +67,6 @@ def lambda_handler(event, lambda_context):
     scopes = [
         'https://www.googleapis.com/auth/drive.file',
         'https://www.googleapis.com/auth/drive',
-        'https://www.googleapis.com/auth/drive.file',
         'https://www.googleapis.com/auth/drive.metadata'
     ]
 


### PR DESCRIPTION
Service account credentials get uploaded as `SecretBinary`