### PR TITLE
Re-add manual copy landing to raw glue job and turn off g drive s3 lambda

### DIFF
--- a/terraform/25-aws-glue-job-parking.tf
+++ b/terraform/25-aws-glue-job-parking.tf
@@ -1,3 +1,34 @@
+module "manually_uploaded_parking_data_to_raw" {
+  source = "../modules/aws-glue-job"
+
+  count = local.is_live_environment ? 1 : 0
+
+  department                 = module.department_parking
+  job_name                   = "${local.short_identifier_prefix}Parking Copy Manually Uploaded CSVs to Raw"
+  helper_module_key          = aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key            = aws_s3_bucket_object.pydeequ.key
+  spark_ui_output_storage_id = module.spark_ui_output_storage.bucket_id
+  job_parameters = {
+    "--job-bookmark-option" = "job-bookmark-enable"
+    "--s3_bucket_target"    = module.raw_zone.bucket_id
+    "--s3_bucket_source"    = module.landing_zone.bucket_id
+    "--s3_prefix"           = "parking/manual/"
+    "--extra-py-files"      = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"
+  }
+  script_s3_object_key = aws_s3_bucket_object.copy_manually_uploaded_csv_data_to_raw.key
+  trigger_enabled      = false
+  crawler_details = {
+    database_name      = module.department_parking.raw_zone_catalog_database_name
+    s3_target_location = "s3://${module.raw_zone.bucket_id}/parking/manual/"
+    configuration = jsonencode({
+      Version = 1.0
+      Grouping = {
+        TableLevelConfiguration = 4
+      }
+    })
+  }
+}
+
 module "parking_pcn_denormalisation" {
   source                     = "../modules/aws-glue-job"
   department                 = module.department_parking

--- a/terraform/27-spreadsheet-imports-from-g-drive.tf
+++ b/terraform/27-spreadsheet-imports-from-g-drive.tf
@@ -186,417 +186,419 @@ module "env_enforcement_cc_tv" {
   }
 }
 
-module "parking_permits_consultation_survey" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1iLScmA-tIvyoqOj3smbzkvzRhnfkDxOS"
-  glue_job_name                  = "${title(module.department_parking.name)} Permits Consultation Survey"
-  output_folder_name             = "permits-consultation-survey"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "Permits Consultation Survey - export-2022-05-06-13-31-09 UTF-8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "2022-05-06-13-31-09"
-    }
-  }
-}
-
-module "puzzel_total_overview_10_05_2021_to_25_05_2021_UTF8" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1xZmbsPENv01chzZcP661pv1d2Kmg7y6r"
-  glue_job_name                  = "${title(module.department_parking.name)} Puzzel 20210526 - Total Overview"
-  output_folder_name             = "puzzel"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20210526 - Total Overview 10 05 2021 - 25 05 2021 - TotOview UTF8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20210526"
-    }
-  }
-}
-
-module "eta_decision_records_gds_or_qlik_data_load_records_20220209" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1oWAo5-hmTnBH5lEUzjNkBf7-GxxfVXMG"
-  glue_job_name                  = "${title(module.department_parking.name)} 20220209 - ETA_Decisions"
-  output_folder_name             = "eta_decision_records"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220209 - ETA_Decisions - GDS or Qlik data Load - records.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220209"
-    }
-  }
-}
-
-module "eta_decision_records_gds_or_qlik_data_load_records_20220317" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1BgC7fEHRpOHO1NwPc8_HuIa9hJvDFqbH"
-  glue_job_name                  = "${title(module.department_parking.name)} 20220317 - ETA_Decisions"
-  output_folder_name             = "eta_decision_records"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220317 - ETA_Decisions - GDS or Qlik data Load - records.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220317"
-    }
-  }
-}
-
-module "eta_decision_records_gds_or_qlik_data_load_records_20220401" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1XqnMJR7-rjLl2MbVKChqRWu-DVWIACyr"
-  glue_job_name                  = "${title(module.department_parking.name)} 20220401 - ETA_Decisions"
-  output_folder_name             = "eta_decision_records"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220401 - ETA_Decisions - GDS or Qlik data Load - records UTF8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220401"
-    }
-  }
-}
-
-module "eta_decision_records_gds_or_qlik_data_load_records_20220506" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1J_VdrUDgziXjYC6uy716jtFcEcZqjQP1"
-  glue_job_name                  = "${title(module.department_parking.name)} 20220506 - ETA_Decisions"
-  output_folder_name             = "eta_decision_records"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220506 - ETA_Decisions - GDS or Qlik data Load UTF-8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220506"
-    }
-  }
-}
-
-module "eta_decision_records_gds_or_qlik_data_load_records_20220420" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1FaBQhl-uoUMIIKppvcDsvctbqmiKzHen"
-  glue_job_name                  = "${title(module.department_parking.name)} 20220420 - ETA_Decisions"
-  output_folder_name             = "eta_decision_records"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220420 - ETA_Decisions - GDS or Qlik data Load - records.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220420"
-    }
-  }
-}
-
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220427" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1thn-BsMfvyUP0dzcEHM2eWSen9dASC-O"
-  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220427"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220427 - PCNs VRM match to Permits VRM and NLPG by Registered and Current addresses Post Code - 13 months - final in glue via athena no comma fields removed dups UTF8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220427"
-    }
-  }
-}
-
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220511" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1AEgRZdxPnALuXn4nqcqQtEBkvJPWXUh5"
-  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220511"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220511 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220511"
-    }
-  }
-}
-
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220512" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1sKnfS2xruU1ZKvnd1Cwcys2PAyC4zHOD"
-  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220512"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220512 - PCN Permits VRM NLPG LLPG matching - Last 3 months - UTF-8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220512"
-    }
-  }
-}
-
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220513" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1XWGudeZ3D5rbYXZL29sP_Q-n475yNP9e"
-  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220513"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220513 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220513"
-    }
-  }
-}
-
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220516" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "16PbpKwBUMFxUWyB3mEMWRWZzxzZtDhoU"
-  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220516"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220516 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220516"
-    }
-  }
-}
-module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220524" {
-  count                          = local.is_live_environment ? 1 : 0
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  department                     = module.department_parking
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
-  jars_key                       = aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  landing_zone_bucket_id         = module.landing_zone.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
-  google_sheets_document_id      = "1Nsly2YWLufSWpq6fRd-VWr2Tdkma7bQV"
-  glue_job_name                  = "${title(module.department_parking.name)} - PCN Permits VRM NLPG LLPG matching"
-  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
-  raw_zone_bucket_id             = module.raw_zone.bucket_id
-  input_file_name                = "20220524 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8 DP.csv"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 0
-      worksheet_name    = "20220524"
-    }
-  }
-}
+//module "parking_permits_consultation_survey" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1iLScmA-tIvyoqOj3smbzkvzRhnfkDxOS"
+//  glue_job_name                  = "${title(module.department_parking.name)} Permits Consultation Survey"
+//  output_folder_name             = "permits-consultation-survey"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "Permits Consultation Survey - export-2022-05-06-13-31-09 UTF-8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "2022-05-06-13-31-09"
+//    }
+//  }
+//}
+//
+////g-drive-Bens-Housing-Needs-PCN-Permits-VRM-NLPG-LLPG-matching
+//
+//module "puzzel_total_overview_10_05_2021_to_25_05_2021_UTF8" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1xZmbsPENv01chzZcP661pv1d2Kmg7y6r"
+//  glue_job_name                  = "${title(module.department_parking.name)} Puzzel 20210526 - Total Overview"
+//  output_folder_name             = "puzzel"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20210526 - Total Overview 10 05 2021 - 25 05 2021 - TotOview UTF8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20210526"
+//    }
+//  }
+//}
+//
+//module "eta_decision_records_gds_or_qlik_data_load_records_20220209" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1oWAo5-hmTnBH5lEUzjNkBf7-GxxfVXMG"
+//  glue_job_name                  = "${title(module.department_parking.name)} 20220209 - ETA_Decisions"
+//  output_folder_name             = "eta_decision_records"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220209 - ETA_Decisions - GDS or Qlik data Load - records.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220209"
+//    }
+//  }
+//}
+//
+//module "eta_decision_records_gds_or_qlik_data_load_records_20220317" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1BgC7fEHRpOHO1NwPc8_HuIa9hJvDFqbH"
+//  glue_job_name                  = "${title(module.department_parking.name)} 20220317 - ETA_Decisions"
+//  output_folder_name             = "eta_decision_records"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220317 - ETA_Decisions - GDS or Qlik data Load - records.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220317"
+//    }
+//  }
+//}
+//
+//module "eta_decision_records_gds_or_qlik_data_load_records_20220401" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1XqnMJR7-rjLl2MbVKChqRWu-DVWIACyr"
+//  glue_job_name                  = "${title(module.department_parking.name)} 20220401 - ETA_Decisions"
+//  output_folder_name             = "eta_decision_records"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220401 - ETA_Decisions - GDS or Qlik data Load - records UTF8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220401"
+//    }
+//  }
+//}
+//
+//module "eta_decision_records_gds_or_qlik_data_load_records_20220506" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1J_VdrUDgziXjYC6uy716jtFcEcZqjQP1"
+//  glue_job_name                  = "${title(module.department_parking.name)} 20220506 - ETA_Decisions"
+//  output_folder_name             = "eta_decision_records"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220506 - ETA_Decisions - GDS or Qlik data Load UTF-8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220506"
+//    }
+//  }
+//}
+//
+//module "eta_decision_records_gds_or_qlik_data_load_records_20220420" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1FaBQhl-uoUMIIKppvcDsvctbqmiKzHen"
+//  glue_job_name                  = "${title(module.department_parking.name)} 20220420 - ETA_Decisions"
+//  output_folder_name             = "eta_decision_records"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220420 - ETA_Decisions - GDS or Qlik data Load - records.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220420"
+//    }
+//  }
+//}
+//
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220427" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1thn-BsMfvyUP0dzcEHM2eWSen9dASC-O"
+//  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220427"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220427 - PCNs VRM match to Permits VRM and NLPG by Registered and Current addresses Post Code - 13 months - final in glue via athena no comma fields removed dups UTF8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220427"
+//    }
+//  }
+//}
+//
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220511" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1AEgRZdxPnALuXn4nqcqQtEBkvJPWXUh5"
+//  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220511"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220511 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220511"
+//    }
+//  }
+//}
+//
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220512" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1sKnfS2xruU1ZKvnd1Cwcys2PAyC4zHOD"
+//  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220512"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220512 - PCN Permits VRM NLPG LLPG matching - Last 3 months - UTF-8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220512"
+//    }
+//  }
+//}
+//
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220513" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1XWGudeZ3D5rbYXZL29sP_Q-n475yNP9e"
+//  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220513"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220513 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220513"
+//    }
+//  }
+//}
+//
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220516" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "16PbpKwBUMFxUWyB3mEMWRWZzxzZtDhoU"
+//  glue_job_name                  = "${title(module.department_parking.name)} PCN Permits VRM NLPG LLPG - 20220516"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220516 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220516"
+//    }
+//  }
+//}
+//module "parking_pcn_permit_nlpg_llpg_matching_via_athena_20220524" {
+//  count                          = local.is_live_environment ? 1 : 0
+//  source                         = "../modules/import-spreadsheet-file-from-g-drive"
+//  department                     = module.department_parking
+//  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
+//  glue_catalog_database_name     = module.department_parking.raw_zone_catalog_database_name
+//  glue_temp_storage_bucket_id    = module.glue_temp_storage.bucket_url
+//  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
+//  secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
+//  glue_role_arn                  = aws_iam_role.glue_role.arn
+//  helper_module_key              = aws_s3_bucket_object.helpers.key
+//  pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
+//  jars_key                       = aws_s3_bucket_object.jars.key
+//  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
+//  identifier_prefix              = local.short_identifier_prefix
+//  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+//  landing_zone_bucket_id         = module.landing_zone.bucket_id
+//  landing_zone_kms_key_arn       = module.landing_zone.kms_key_arn
+//  landing_zone_bucket_arn        = module.landing_zone.bucket_arn
+//  google_sheets_document_id      = "1Nsly2YWLufSWpq6fRd-VWr2Tdkma7bQV"
+//  glue_job_name                  = "${title(module.department_parking.name)} - PCN Permits VRM NLPG LLPG matching"
+//  output_folder_name             = "parking_pcn_permit_nlpg_llpg_matching_via_athena"
+//  raw_zone_bucket_id             = module.raw_zone.bucket_id
+//  input_file_name                = "20220524 - PCN Permits VRM NLPG LLPG matching - Last 3 months UTF-8 DP.csv"
+//  worksheets = {
+//    sheet1 : {
+//      header_row_number = 0
+//      worksheet_name    = "20220524"
+//    }
+//  }
+//}


### PR DESCRIPTION
Propose switching back to the old process whilst we investigate the issue below so we don’t block parking from getting their data. See full details in Jira ticket comments [here](https://hackney.atlassian.net/browse/DPP-101?focusedCommentId=24954)

When files are saved in Google drive their column formats get changed, for example the columns that are of timestamp format get converted to time format. There are 40+ columns on one spreadsheet that we know are impacted. We currently don’t know the scale / impact this issue will have without further investigation