### PR TITLE
Create Qlik department to create service account

### DIFF
--- a/terraform/05-departments.tf
+++ b/terraform/05-departments.tf
@@ -400,7 +400,7 @@ module "department_qlik" {
   application                     = local.application_snake
   short_identifier_prefix         = local.short_identifier_prefix
   identifier_prefix               = local.identifier_prefix
-  name                            = "Qlik"
+  name                            = "Qlik Data Insight"
   landing_zone_bucket             = module.landing_zone
   raw_zone_bucket                 = module.raw_zone
   refined_zone_bucket             = module.refined_zone


### PR DESCRIPTION
Jira ticket: [DPP-39](https://hackney.atlassian.net/jira/software/projects/DPP/boards/83?selectedIssue=DPP-39)
Creates a Qlik service account and credentials so that all Google sheet data shared with Qlik can be shared with one account rather than different users.

There is no requirement for a Qlik department specific area in the Data Platform yet so have not requested a Google group be created but it might be required later on - which will then need to be shared with Data & Insight team