### PR TITLE
Helper function to get multiple glue environment variables at once

### DIFF
--- a/scripts/helpers/helpers.py
+++ b/scripts/helpers/helpers.py
@@ -33,11 +33,30 @@ def normalize_column_name(column: str) -> str:
     return unicodedata.normalize('NFKD', formatted_name).encode('ASCII', 'ignore').decode()
 
 def get_glue_env_var(key, default=None):
+    """
+    Looks for a single variable passed in as a job parameters.
+    The key given will match to any parameter that the key is a sub string of.
+    So if you have two parameter keys where one is a substring of another it could return the wrong value.
+    :param key: The key of the parameter to retrieve
+    :param default: A value to return if the given key doesn't exist. Optional.
+    :return: The value of the parameter
+    Example of applying: source_catalog_database = get_glue_env_var("source_catalog_database", "")
+    """
     if f'--{key}' in sys.argv:
         return getResolvedOptions(sys.argv, [key])[key]
     else:
         return default
 
+def get_glue_env_vars(*keys):
+    """
+    Retrieves values for the given keys passed in as job parameters.
+    This will error if a given key can't be found in the job parameters.
+    :param keys: The keys of the parameters to retrieve passed as separate arguments
+    :return: A tuple containing the values for the parameters
+    Example of applying: (source_catalog_database, source_catalog_table) = get_glue_env_vars("source_catalog_database", "source_catalog_table")
+    """
+    vars = getResolvedOptions(sys.argv, [*keys])
+    return (vars[key] for key in keys)
 
 def get_secret(secret_name, region_name):
     session = boto3.session.Session()

--- a/scripts/jobs/sandbox/job_script_template.py
+++ b/scripts/jobs/sandbox/job_script_template.py
@@ -12,7 +12,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from pyspark.sql.functions import col, max, lit
 from awsglue.dynamicframe import DynamicFrame
-from helpers.helpers import get_glue_env_var, get_latest_partitions, create_pushdown_predicate, add_import_time_columns, PARTITION_KEYS
+from helpers.helpers import get_glue_env_vars, get_latest_partitions, create_pushdown_predicate, add_import_time_columns, PARTITION_KEYS
 
 # Define the functions that will be used in your job (optional). For Production jobs, these functions should be tested via unit testing.
 def someDataProcessing(df):
@@ -24,9 +24,11 @@ if __name__ == "__main__":
     
     # read job parameters
     args = getResolvedOptions(sys.argv, ['JOB_NAME'])
-    source_catalog_table = get_glue_env_var('source_catalog_table','')
-    source_catalog_database = get_glue_env_var('source_catalog_database', '')
-    s3_bucket_target = get_glue_env_var('s3_bucket_target', '')
+    (
+        source_catalog_table,
+        source_catalog_database,
+        s3_bucket_target
+    ) = get_glue_env_vars('source_catalog_table', 'source_catalog_database', 's3_bucket_target')
  
     # start the Spark session and the logger
     glueContext = GlueContext(SparkContext.getOrCreate()) 

--- a/scripts/tests/test_get_glue_env_var.py
+++ b/scripts/tests/test_get_glue_env_var.py
@@ -1,0 +1,67 @@
+from helpers.helpers import get_glue_env_var, get_glue_env_vars
+from unittest.mock import patch
+
+
+class TestGetGlueEnvVar:
+  def test_can_get_an_env_var(self):
+    args = [
+        '/tmp/LLPG raw to trusted.py',
+        '--source_catalog_database', 'dataplatform-stg-raw-zone-unrestricted-address-api',
+        '--JOB_ID', 'j_7e089a7aab766580dd648928aa0abe6978e074912309f37950c21d855e4c48d0',
+        '--JOB_RUN_ID', 'jr_ff2410b9b96fa1e6342ea1774d6e8335092b1a97ac600703d3fb07d19136d3bf',
+        '--source_catalog_table', 'unrestricted_address_api_dbo_hackney_address',
+        '--s3_bucket_target', 's3://dataplatform-stg-trusted-zone/unrestricted/llpg/latest_llpg',
+        '--JOB_NAME', 'LLPG raw to trusted',
+        '--TempDir', 's3://dataplatform-stg-glue-temp-storage/sandbox/'
+    ]
+    with patch("sys.argv", args):
+        assert get_glue_env_var("source_catalog_database") == "dataplatform-stg-raw-zone-unrestricted-address-api"
+
+class TestGetGlueEnvVars:
+  def test_can_get_one_variable(self):
+    args = [
+        '/tmp/LLPG raw to trusted.py',
+        '--source_catalog_database', 'dataplatform-stg-raw-zone-unrestricted-address-api',
+        '--JOB_ID', 'j_7e089a7aab766580dd648928aa0abe6978e074912309f37950c21d855e4c48d0',
+        '--JOB_RUN_ID', 'jr_ff2410b9b96fa1e6342ea1774d6e8335092b1a97ac600703d3fb07d19136d3bf',
+        '--source_catalog_table', 'unrestricted_address_api_dbo_hackney_address',
+        '--s3_bucket_target', 's3://dataplatform-stg-trusted-zone/unrestricted/llpg/latest_llpg',
+        '--JOB_NAME', 'LLPG raw to trusted',
+        '--TempDir', 's3://dataplatform-stg-glue-temp-storage/sandbox/'
+    ]
+    with patch("sys.argv", args):
+        source_catalog_database, = get_glue_env_vars("source_catalog_database")
+        assert source_catalog_database == "dataplatform-stg-raw-zone-unrestricted-address-api"
+
+  def test_can_get_multiple_variables(self):
+    args = [
+        '/tmp/LLPG raw to trusted.py',
+        '--source_catalog_database', 'dataplatform-stg-raw-zone-unrestricted-address-api',
+        '--JOB_ID', 'j_7e089a7aab766580dd648928aa0abe6978e074912309f37950c21d855e4c48d0',
+        '--JOB_RUN_ID', 'jr_ff2410b9b96fa1e6342ea1774d6e8335092b1a97ac600703d3fb07d19136d3bf',
+        '--source_catalog_table', 'unrestricted_address_api_dbo_hackney_address',
+        '--s3_bucket_target', 's3://dataplatform-stg-trusted-zone/unrestricted/llpg/latest_llpg',
+        '--JOB_NAME', 'LLPG raw to trusted',
+        '--TempDir', 's3://dataplatform-stg-glue-temp-storage/sandbox/'
+    ]
+    with patch("sys.argv", args):
+        source_catalog_database, source_catalog_table = get_glue_env_vars("source_catalog_database", "source_catalog_table")
+        assert source_catalog_database == "dataplatform-stg-raw-zone-unrestricted-address-api"
+        assert source_catalog_table == "unrestricted_address_api_dbo_hackney_address"
+
+  def test_gets_correct_variables_when_one_is_a_substring_of_another(self):
+    args = [
+        '/tmp/LLPG raw to trusted.py',
+        '--source_catalog_database2', 'unrestricted-refined-zone',
+        '--source_catalog_database', 'dataplatform-stg-raw-zone-unrestricted-address-api',
+        '--JOB_ID', 'j_7e089a7aab766580dd648928aa0abe6978e074912309f37950c21d855e4c48d0',
+        '--JOB_RUN_ID', 'jr_ff2410b9b96fa1e6342ea1774d6e8335092b1a97ac600703d3fb07d19136d3bf',
+        '--source_catalog_table', 'unrestricted_address_api_dbo_hackney_address',
+        '--s3_bucket_target', 's3://dataplatform-stg-trusted-zone/unrestricted/llpg/latest_llpg',
+        '--JOB_NAME', 'LLPG raw to trusted',
+        '--TempDir', 's3://dataplatform-stg-glue-temp-storage/sandbox/'
+    ]
+    with patch("sys.argv", args):
+        source_catalog_database2, source_catalog_database = get_glue_env_vars("source_catalog_database2", "source_catalog_database")
+        assert source_catalog_database == "dataplatform-stg-raw-zone-unrestricted-address-api"
+        assert source_catalog_database2 == "unrestricted-refined-zone"


### PR DESCRIPTION
When you try and get an argment from the job parameters if there are two where one is a substring of another it can return the wrong values as it will match the first argument whether it's an exact match or a sub string match.

We had a glue job with parameter keys, source_catalog_database and source_catalog_database2 and it was mixing up the values. 

I've added a method so you can retrieve multiple parameters at once, It seems to get the correct values successfully if you parse them together. 