### PR TITLE
Revert "Disable geolive sql ingestion to unrestricted raw zone"

### DIFF
--- a/terraform/10-aws-s3-buckets.tf
+++ b/terraform/10-aws-s3-buckets.tf
@@ -17,7 +17,7 @@ module "raw_zone" {
   bucket_name       = "Raw Zone"
   bucket_identifier = "raw-zone"
   role_arns_to_share_access_with = [
-//    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn,
+    module.db_snapshot_to_s3.s3_to_s3_copier_lambda_role_arn,
     var.sync_production_to_pre_production_task_role
   ]
 }

--- a/terraform/60-db-snapshot-to-s3.tf
+++ b/terraform/60-db-snapshot-to-s3.tf
@@ -12,20 +12,20 @@ module "lambda_artefact_storage_for_api_account" {
   }
 }
 
-//module "db_snapshot_to_s3" {
-//  source                         = "../modules/db-snapshot-to-s3"
-//  tags                           = module.tags.values
-//  project                        = var.project
-//  environment                    = var.environment
-//  identifier_prefix              = local.identifier_prefix
-//  lambda_artefact_storage_bucket = module.lambda_artefact_storage_for_api_account.bucket_id
-//  zone_kms_key_arn               = module.raw_zone.kms_key_arn
-//  zone_bucket_arn                = module.raw_zone.bucket_arn
-//  zone_bucket_id                 = module.raw_zone.bucket_id
-//  service_area                   = "unrestricted"
-//  rds_instance_ids               = var.rds_instance_ids
-//
-//  providers = {
-//    aws = aws.aws_api_account
-//  }
-//}
+module "db_snapshot_to_s3" {
+  source                         = "../modules/db-snapshot-to-s3"
+  tags                           = module.tags.values
+  project                        = var.project
+  environment                    = var.environment
+  identifier_prefix              = local.identifier_prefix
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage_for_api_account.bucket_id
+  zone_kms_key_arn               = module.raw_zone.kms_key_arn
+  zone_bucket_arn                = module.raw_zone.bucket_arn
+  zone_bucket_id                 = module.raw_zone.bucket_id
+  service_area                   = "unrestricted"
+  rds_instance_ids               = var.rds_instance_ids
+
+  providers = {
+    aws = aws.aws_api_account
+  }
+}


### PR DESCRIPTION
Reverts LBHackney-IT/Data-Platform#689

The `db-snapshot-to-s3` module is set up to create a bucket `rds-export-storage` so when Terraform tried to destroy this module and it's resources, it tried to delete the entire bucket as well which contains other data which we don't want to delete