### PR TITLE
Use s3 object instead & base64-encoded hash instead

### DIFF
--- a/modules/api-ingestion-lambda/10-lambda.tf
+++ b/modules/api-ingestion-lambda/10-lambda.tf
@@ -120,12 +120,12 @@ data "archive_file" "lambda" {
   output_path = "../lambdas/${local.lambda_name_underscore}.zip"
 }
 
-resource "aws_s3_bucket_object" "lambda" {
+resource "aws_s3_object" "lambda" {
   bucket      = var.lambda_artefact_storage_bucket
   key         = "${local.lambda_name_underscore}.zip"
   source      = data.archive_file.lambda.output_path
   acl         = "private"
-  source_hash = data.archive_file.lambda.output_md5
+  source_hash = data.archive_file.lambda.output_base64sha256
 }
 
 resource "aws_lambda_function" "lambda" {
@@ -136,7 +136,7 @@ resource "aws_lambda_function" "lambda" {
   runtime          = "python3.8"
   function_name    = lower("${var.identifier_prefix}${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
-  s3_key           = aws_s3_bucket_object.lambda.key
+  s3_key           = aws_s3_object.lambda.key
   source_code_hash = data.archive_file.lambda.output_base64sha256
   timeout          = var.lambda_timeout
   memory_size      = var.lambda_memory_size


### PR DESCRIPTION
- Uses new s3_object resource instead and sets the source_hash as the archive_file's base64 encoded hash (see [StackOverflow post](https://stackoverflow.com/questions/54330751/terraform-s3-bucket-objects-etag-keeps-updating-on-each-apply#:~:text=To%20prevent%20an%20update%20on%20each%20apply%2C%20using%20the%20new%20aws_s3_object%20resource%2C%20you%20can%20use%20the%20output_base64sha256%20attribute%20reference.)). 
- Should prevent the s3 object from being re-uploaded on each apply even though nothing changes and since the install script doesn't get run unless something changes, it re-uploads without the required packages