### PR TITLE
DPP-148 Use exact match for table names

### DIFF
--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -15,9 +15,9 @@ module "housing_interim_finance_database_ingestion" {
 
 locals {
   table_filter_expressions_housing_interim_finance = local.is_live_environment ? {
-    ma-tenancy-agreement       = "^sow2b_dbo_matenancyagreement",
-    uh-account-recovery-action = "^sow2b_dbo_uharaction",
-    ma-property                = "^sow2b_dbo_maproperty"
+    ma-tenancy-agreement       = "^sow2b_dbo_matenancyagreement$",
+    uh-account-recovery-action = "^sow2b_dbo_uharaction$",
+    ma-property                = "^sow2b_dbo_maproperty$"
   } : {}
 }
 


### PR DESCRIPTION
Current filters are not using exact matching for table names, so some backup tables and other unwanted tables get imported as well. This update tweaks the filter expression to use exact name matching.