### PR TITLE
DPP-202 fix import day/month prefix bug

### DIFF
--- a/lambdas/icaseworks_api_ingestion/main.py
+++ b/lambdas/icaseworks_api_ingestion/main.py
@@ -76,8 +76,8 @@ def get_icaseworks_report_from(report_id, from_date, auth_headers, auth_payload)
 def write_dataframe_to_s3(s3_client, data, s3_bucket, output_folder, filename):
     filename = re.sub('[^a-zA-Z0-9]+', '-', filename).lower()
     current_date = datetime.datetime.now()
-    day = str(current_date.day) if current_date.day > 10 else '0' + str(current_date.day)
-    month = str(current_date.month) if current_date.month > 10 else '0' + str(current_date.month)
+    day = single_digit_to_zero_prefixed_string(current_date.day)
+    month = single_digit_to_zero_prefixed_string(current_date.month)
     year = str(current_date.year)
     date = year + month + day
     return s3_client.put_object(
@@ -178,3 +178,6 @@ def lambda_handler(event, lambda_context):
     glue_client = boto3.client('glue')
     job_run_id = glue_client.start_job_run(JobName=glue_job_name)
     logger.info(f"Glue job run ID: {job_run_id}")
+
+def single_digit_to_zero_prefixed_string(value):
+    return str(value) if value > 9 else '0' + str(value)

--- a/lambdas/icaseworks_api_ingestion/test.py
+++ b/lambdas/icaseworks_api_ingestion/test.py
@@ -6,7 +6,7 @@ import requests
 import botocore.session
 from botocore.stub import Stubber
 from datetime import datetime
-from icaseworks_api_ingestion.main import get_icaseworks_report_from, get_token, encode_string, remove_illegal_characters, write_dataframe_to_s3, dictionary_to_string, retrieve_credentials_from_secrets_manager
+from icaseworks_api_ingestion.main import get_icaseworks_report_from, get_token, encode_string, remove_illegal_characters, write_dataframe_to_s3, dictionary_to_string, retrieve_credentials_from_secrets_manager, single_digit_to_zero_prefixed_string
 from icaseworks_api_ingestion.helpers import MockResponse
 
 BASE_URL = "https://hackneyreports.icasework.com/getreport?"
@@ -142,3 +142,11 @@ class TestCaseWorksApiIngestion(TestCase):
 
         service_response = write_dataframe_to_s3(self.s3, data, bucket, output_folder, filename)
         self.assertEqual(service_response, response)
+
+    def test_single_digit_to_zero_prefixed_string_prefixes_single_digit_with_zero(self):
+        result_with_zero_prefix = single_digit_to_zero_prefixed_string(9)
+        self.assertEqual(result_with_zero_prefix, "09")
+
+    def test_single_digit_to_zero_prefixed_does_not_prefix_double_digits_with_zero(self):
+        result_without_zero_prefix = single_digit_to_zero_prefixed_string(10)
+        self.assertEqual(result_without_zero_prefix, "10")


### PR DESCRIPTION
Fix an issue with import day/month value handling that's causing problems for partitions.

Current implementation is causing day and month number ten to be prefixed with a leading zero, so S3 object keys and therefore partitions end up with wrong values.