### PR TITLE
added shuffle spills to s3 to resolve no space left error

### DIFF
--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -169,5 +169,6 @@ module "copy_academy_revenues_to_raw_zone" {
     "--enable-continuous-cloudwatch-log" = "true"
     "--job-bookmark-option"              = "job-bookmark-enable"
     "--write-shuffle-files-to-s3"        = "true"
+    "--write-shuffle-spills-to-s3"       = "true"
   }
 }


### PR DESCRIPTION
Bug Fix, using information from this [Stack Overflow question](https://stackoverflow.com/questions/65478510/how-to-overcome-spark-no-space-left-on-the-device-error-in-aws-glue-job
)