### PR TITLE
Remove table that is no longer required

### DIFF
--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -14,7 +14,7 @@ module "housing_interim_finance_database_ingestion" {
 }
 
 locals {
-  table_filter_expressions_housing_interim_finance = local.is_live_environment ? "(^sow2b_dbo_matenancyagreement$|^sow2b_dbo_uharaction$|^sow2b_dbo_maproperty$|^sow2b_dbo_uhminitransaction$|^sow2b_dbo_ssminitransaction$)" : ""
+  table_filter_expressions_housing_interim_finance = local.is_live_environment ? "(^sow2b_dbo_matenancyagreement$|^sow2b_dbo_uharaction$|^sow2b_dbo_maproperty$|^sow2b_dbo_ssminitransaction$)" : ""
 }
 
 resource "aws_glue_trigger" "housing_interim_finance_filter_ingestion_tables" {


### PR DESCRIPTION
`sow2b_dbo_uhminitransaction` table holds historical transactions only and now that we have the data on production there's no need to ingest that table again.