### PR TITLE
Update 24-aws-glue-tascomi-data.tf

### DIFF
--- a/terraform/etl/24-aws-glue-tascomi-data.tf
+++ b/terraform/etl/24-aws-glue-tascomi-data.tf
@@ -97,7 +97,7 @@ resource "aws_glue_trigger" "tascomi_tables_daily_ingestion_triggers" {
 
   name     = "${local.short_identifier_prefix}Tascomi ${title(replace(each.value, "_", " "))} Ingestion Trigger"
   type     = "SCHEDULED"
-  schedule = "cron(0 3 * * ? *)"
+  schedule = "cron(0 2 * * ? *)"
   enabled  = local.is_production_environment
 
   actions {
@@ -149,7 +149,7 @@ resource "aws_glue_trigger" "tascomi_api_response_crawler_trigger" {
 
   name     = "${local.short_identifier_prefix}Tascomi API response crawler Trigger"
   type     = "SCHEDULED"
-  schedule = "cron(0 4,5 * * ? *)"
+  schedule = "cron(0 4 * * ? *)"
   enabled  = local.is_live_environment
 
   actions {


### PR DESCRIPTION
Change Tascomi scheduling: Ingestion starts at 2am and transformation starts at 4am, only one transformation round.