### PR TITLE
DPP-286 Add prevent destroy to glue catalog database resources

### DIFF
--- a/terraform/core/03-input-derived.tf
+++ b/terraform/core/03-input-derived.tf
@@ -49,4 +49,8 @@ data "aws_ssm_parameter" "aws_vpc_id" {
 // ==== LANDING ZONE ===========
 resource "aws_glue_catalog_database" "landing_zone_catalog_database" {
   name = "${local.identifier_prefix}-landing-zone-database"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -15,6 +15,10 @@ module "academy_mssql_database_ingestion" {
 
 resource "aws_glue_catalog_database" "landing_zone_academy" {
   name = "${local.short_identifier_prefix}academy-landing-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 locals {

--- a/terraform/etl/12-aws-glue-parking-manual-upload.tf
+++ b/terraform/etl/12-aws-glue-parking-manual-upload.tf
@@ -1,6 +1,10 @@
 resource "aws_glue_catalog_database" "parking_raw_zone_manual_catalog_database" {
   count = !local.is_production_environment ? 1 : 0
   name  = "${local.short_identifier_prefix}parking-raw-zone-manual"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 module "manually_uploaded_parking_data_to_raw" {

--- a/terraform/etl/24-aws-glue-tascomi-data.tf
+++ b/terraform/etl/24-aws-glue-tascomi-data.tf
@@ -47,12 +47,24 @@ locals {
 # Database resources
 resource "aws_glue_catalog_database" "raw_zone_tascomi" {
   name = "${local.identifier_prefix}-tascomi-raw-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 resource "aws_glue_catalog_database" "refined_zone_tascomi" {
   name = "${local.identifier_prefix}-tascomi-refined-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 resource "aws_glue_catalog_database" "trusted_zone_tascomi" {
   name = "${local.identifier_prefix}-tascomi-trusted-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # Columns type dictionary resources

--- a/terraform/etl/33-aws-glue-liberator-data.tf
+++ b/terraform/etl/33-aws-glue-liberator-data.tf
@@ -1,6 +1,10 @@
 // LIBERATOR LANDING ZONE
 resource "aws_glue_catalog_database" "landing_zone_liberator" {
   name = "${local.identifier_prefix}-liberator-landing-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_glue_trigger" "landing_zone_liberator_crawler_trigger" {
@@ -113,11 +117,19 @@ resource "aws_glue_job" "copy_env_enforcement_liberator_landing_to_raw" {
 
 resource "aws_glue_catalog_database" "raw_zone_liberator" {
   name = "${local.identifier_prefix}-liberator-raw-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 // LIBERATOR REFINED ZONE
 resource "aws_glue_catalog_database" "refined_zone_liberator" {
   name = "${local.identifier_prefix}-liberator-refined-zone"
+  
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_glue_crawler" "refined_zone_parking_liberator_crawler" {

--- a/terraform/etl/34-aws-glue-crawlers.tf
+++ b/terraform/etl/34-aws-glue-crawlers.tf
@@ -2,11 +2,19 @@ resource "aws_glue_catalog_database" "landing_zone_data_and_insight_address_matc
   count = local.is_live_environment ? 1 : 0
 
   name = "${local.identifier_prefix}-data-and-insight-address-matching-landing-zone"
+  
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 // ==== RAW ZONE ===========
 resource "aws_glue_catalog_database" "raw_zone_unrestricted_address_api" {
   name = "${local.identifier_prefix}-raw-zone-unrestricted-address-api"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_glue_crawler" "raw_zone_unrestricted_address_api_crawler" {

--- a/terraform/modules/database-ingestion-via-jdbc-connection/11-aws-glue-connection-crawler.tf
+++ b/terraform/modules/database-ingestion-via-jdbc-connection/11-aws-glue-connection-crawler.tf
@@ -1,5 +1,9 @@
 resource "aws_glue_catalog_database" "ingestion_connection" {
   name = "${var.identifier_prefix}${var.name}"
+  
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 locals {

--- a/terraform/modules/department/20-aws-glue-databases.tf
+++ b/terraform/modules/department/20-aws-glue-databases.tf
@@ -13,6 +13,10 @@ resource "aws_ssm_parameter" "raw_zone_catalog_database_name" {
 
 resource "aws_glue_catalog_database" "refined_zone_catalog_database" {
   name = "${var.short_identifier_prefix}${local.department_identifier}-refined-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_ssm_parameter" "refined_zone_catalog_database_name" {
@@ -26,6 +30,10 @@ resource "aws_ssm_parameter" "refined_zone_catalog_database_name" {
 
 resource "aws_glue_catalog_database" "trusted_zone_catalog_database" {
   name = "${var.short_identifier_prefix}${local.department_identifier}-trusted-zone"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_ssm_parameter" "trusted_zone_catalog_database_name" {


### PR DESCRIPTION
## Link to JIRA ticket
[DPP-286](https://hackney.atlassian.net/browse/DPP-286)

## Describe this PR

### *What is the problem we're trying to solve*

We have Glue catalog databases that have been deployed using Terraform. If for any reason Terraform detected a change in configuration that would result in those resources to be redeployed and therefore deleted we woud lose all tables and data in those databases. Some of that data could potentially be difficult and time consuming to recover. 

### *What changes have we introduced*

Terraform has a resource lifecycle management feature that can be used to prevent resources from being destroyed. 

When the below is added to a resource any Terraform plan that would cause this particular resources to be destroyed will fail and therefore prevents the resource from being deleted. 

`lifecycle {
    prevent_destroy = true
  }`

### *How Has This Been Tested?*

Please see the Jira ticket for test plan and results

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A