### PR TITLE
DPP-265 Add basic scheduling for S3 copier lambda

### DIFF
--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -2,6 +2,8 @@ module "copy_from_s3_to_s3" {
   source = "../modules/copy-from-s3-to-s3"
   tags   = module.tags.values
 
+  is_live_environment = local.is_live_environment
+
   lambda_name                    = "rentsense-s3-to-s3-export-copy"
   identifier_prefix              = local.identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage

--- a/terraform/modules/copy-from-s3-to-s3/01-inputs-required.tf
+++ b/terraform/modules/copy-from-s3-to-s3/01-inputs-required.tf
@@ -44,3 +44,8 @@ variable "lambda_name" {
   description = "The name to give the lambda"
   type        = string
 }
+
+variable "is_live_environment" {
+  description = "A flag indicting if we are running in a live environment for setting up automation"
+  type        = bool
+}

--- a/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
@@ -3,3 +3,9 @@ variable "assume_role" {
   default     = false
   type        = string
 }
+
+variable "lambda_execution_cron_schedule" {
+  description = "CRON expression to schedule the Lambda"
+  type        = string
+  default     = "cron(0 9 * * ? *)"
+}


### PR DESCRIPTION
## Link to JIRA ticket
[DPP-265](https://hackney.atlassian.net/browse/DPP-265)

## Describe this PR

### *What is the problem we're trying to solve*

Currently the S3 to S3 copier lambda has to be run manually

### *What changes have we introduced*

This update adds basic scheduling support to the module so Lambdas can be run at set schedule. Default schedule is set at 9am UTC and it'll run on both pre-prod and prod environments, but it can be changed by setting the `lambda_execution_cron_schedule` value in the module.

### *How Has This Been Tested?*

Tested on development environment to ensure the setup works.

### *Follow up actions after merging PR*

Deploy to pre-prod and prod.