### PR TITLE
Remove recov_event table

### DIFF
--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -31,7 +31,6 @@ locals {
     current_ctax     = "^lbhaliverbviews_current_ctax.*",
     current_hbn      = "^lbhaliverbviews_current_[hbn].*",
     core_ct          = "^lbhaliverbviews_core_ct[abcefghijklmnopqrsvw].*",
-    core_recov       = "^lbhaliverbviews_core_recov_event", 
     mix              = "(^lbhaliverbviews_core_cr.*|^lbhaliverbviews_core_[ins].*|^lbhaliverbviews_xdbvw.*|^lbhaliverbviews_current_im.*)"
   } : {}
   academy_ingestion_max_concurrent_runs = local.is_live_environment ? length(local.table_filter_expressions) : 1


### PR DESCRIPTION
Revert the table filter for now until we have confirmed that we can handle more simultaneous ingestion jobs for Academy 