### PR TITLE
change path format in testconf.py

### DIFF
--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -4,7 +4,7 @@ import os
 
 @pytest.fixture(scope='session')
 def spark():
-  event_log_dir = 'file://' + os.path.dirname(__file__) + '/../spark_events'
+  event_log_dir = os.path.dirname(__file__) + '/../spark_events'
   s = SparkSession.builder.config("spark.eventLog.dir", event_log_dir).config("spark.eventLog.enabled", True).master("local").getOrCreate()
   yield s
   s.stop()


### PR DESCRIPTION
The string 'file://' at the beginning of the path was making the path invalid on Windows. Change tested on Windows and Mac.