### PR TITLE
remove table prefix

### DIFF
--- a/terraform/etl/25-aws-glue-job-env-services.tf
+++ b/terraform/etl/25-aws-glue-job-env-services.tf
@@ -150,7 +150,6 @@ resource "aws_glue_crawler" "alloy_snapshot" {
   s3_target {
     path = "s3://${module.refined_zone_data_source.bucket_id}/env-services/alloy/snapshots/"
   }
-  table_prefix = "alloy_snapshot_"
 
   configuration = jsonencode({
     Version = 1.0


### PR DESCRIPTION
fixes a duplicate prefix that was being added to tables in the glue catalog that was already being added to the tables. This has the knock on effect of tables not being read from the glue catalog preventing the increment being applied. 