### PR TITLE
Dpp 294 alloy additional tables

### DIFF
--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -40,7 +40,7 @@ def create_s3_key(s3_downloads_prefix, import_date, file):
     file_table_name = os.path.splitext(file_basename)
     file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name[0])
     file_table_name = file_table_name.lower()
-    raw_key = f"{s3_downloads_prefix}{file_table_name}/import_year={import_date.year}/import_month={import_date.month}/import_day={import_date.day}/{file_basename}"
+    raw_key = f"{s3_downloads_prefix}{file_table_name}/import_year={import_date: %Y}/import_month={import_date: %m}/import_day={import_date: %d}/import_date={import_date: %Y%m%d}/import{file_basename}"
     return raw_key
 
 

--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -1,0 +1,117 @@
+import io
+import json
+import os
+import re
+import sys
+import time
+import zipfile
+from datetime import date
+
+import boto3
+import requests
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from scripts.helpers.helpers import get_glue_env_var, get_secret
+
+
+def api_response_json(response):
+    """
+    checks the api response for exceptions, returns the response as json
+    """
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as ehttp:
+        logger.info(f"Http Error: {ehttp} \n {response.json()}")
+
+    except requests.exceptions.RequestException as e:
+        logger.info(str(e))
+        raise
+    return json.loads(response.text)
+
+
+def create_s3_key(s3_downloads_prefix, import_date, file):
+    """
+    creates the key argument for saving output files to s3
+    """
+    file_basename = os.path.basename(file)
+    file_table_name = os.path.splitext(file_basename)
+    file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name[0])
+    file_table_name = file_table_name.lower()
+    raw_key = f"{s3_downloads_prefix}{file_table_name}/import_year={import_date.year}/import_month={import_date.month}/import_day={import_date.day}/{file_basename}"
+    return raw_key
+
+
+if __name__ == "__main__":
+    sc = SparkContext.getOrCreate()
+    glueContext = GlueContext(sc)
+    spark = glueContext.spark_session
+    job = Job(glueContext)
+
+    args = getResolvedOptions(sys.argv, ["JOB_NAME"])
+    job = Job(glueContext)
+    job.init(args["JOB_NAME"], args)
+
+    logger = glueContext.get_logger()
+    s3 = boto3.resource("s3")
+
+    secret_name = get_glue_env_var("secret_name", "")
+    aqs = get_glue_env_var("aqs", "")
+    s3_raw_zone_bucket = get_glue_env_var("s3_raw_zone_bucket", "")
+    s3_downloads_prefix = get_glue_env_var("s3_downloads_prefix", "")
+
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    region = "uk"
+    api_key = get_secret(secret_name, "eu-west-2")
+
+    post_url = f"https://api.{region}.alloyapp.io/api/export/?token={api_key}"
+
+    aqs = json.loads(aqs)
+
+    response = requests.post(post_url, data=json.dumps(aqs), headers=headers)
+    response = api_response_json(response)
+
+    task_id = response["backgroundTaskId"]
+
+    logger.info(f"task id: {task_id}")
+
+    url = f"https://api.{region}.alloyapp.io/api/task/{task_id}?token={api_key}"
+    task_status = ""
+    file_id = ""
+
+    while task_status != "Complete":
+        time.sleep(60)
+        response = requests.get(url)
+
+        response = api_response_json(response)
+        task_status = response["task"]["status"]
+
+    else:
+        url = f"https://api.{region}.alloyapp.io/api/export/{task_id}/file?token={api_key}"
+        response = requests.get(url)
+        response = api_response_json(response)
+        file_id = response["fileItemId"]
+
+        logger.info(f"file id: {file_id}")
+
+        url_download = f"https://api.uk.alloyapp.io/api/file/{file_id}?token={api_key}"
+        r = requests.get(url_download, headers=headers)
+
+        import_date = date.today()
+
+        with io.BytesIO(r.content) as z:
+            zip = zipfile.ZipFile(z, mode="r")
+            file_list = zip.namelist()
+
+            for file in file_list:
+                raw_key = create_s3_key(s3_downloads_prefix, import_date, file)
+
+                s3.meta.client.upload_fileobj(
+                    zip.open(file),
+                    Bucket=s3_raw_zone_bucket,
+                    Key=raw_key,
+                )
+
+    job.commit()

--- a/scripts/jobs/env_services/alloy_raw_to_refined.py
+++ b/scripts/jobs/env_services/alloy_raw_to_refined.py
@@ -3,6 +3,7 @@ import sys
 
 import boto3
 import botocore
+import pyspark.sql.functions as F
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.transforms import *

--- a/scripts/jobs/env_services/alloy_raw_to_refined.py
+++ b/scripts/jobs/env_services/alloy_raw_to_refined.py
@@ -1,0 +1,94 @@
+import json
+import sys
+
+import boto3
+import botocore
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from scripts.helpers.helpers import get_glue_env_var
+
+
+def get_table_names(glue_database, glue_table_prefix):
+    """
+    Returns a list of tables from a glue catalog database that begin with a common prefix
+    """
+    glue_client = boto3.client("glue", region_name="eu-west-2")
+    response = glue_client.get_tables(
+        DatabaseName=glue_database, Expression=f"^{glue_table_prefix}*"
+    )
+
+    table_names = [t["Name"] for t in response["TableList"]]
+    return table_names
+
+
+def rename_columns(df, columns):
+    """
+    Renames columns of a dataframe as described by a dictionary of "old_name": "new_name"
+    """
+    if isinstance(columns, dict):
+        return df.select(
+            *[
+                F.col(col_name).alias(columns.get(col_name, col_name))
+                for col_name in df.columns
+            ]
+        )
+    else:
+        raise ValueError(
+            "'columns' should be a dict, like {'old_name_1': 'new_name_1', 'old_name_2': 'new_name_2'}"
+        )
+
+
+if __name__ == "__main__":
+    args = getResolvedOptions(sys.argv, ["JOB_NAME"])
+    sc = SparkContext()
+    glueContext = GlueContext(sc)
+    spark = glueContext.spark_session
+
+    logger = glueContext.get_logger()
+
+    s3 = boto3.resource("s3")
+
+    job = Job(glueContext)
+    job.init(args["JOB_NAME"], args)
+
+    glue_database = get_glue_env_var("glue_database", "")
+    glue_table_prefix = get_glue_env_var("glue_table_prefix", "")
+    s3_raw_zone_bucket = get_glue_env_var("s3_raw_zone_bucket", "")
+    s3_mapping_location = get_glue_env_var("s3_mapping_location", "")
+    s3_downloads_prefix = get_glue_env_var("s3_downloads_prefix", "")
+    redshift_database = get_glue_env_var("redshift_database", "")
+
+    table_names = get_table_names(glue_database, glue_table_prefix)
+
+    for table in table_names:
+        daily_df = glueContext.create_dynamic_frame.from_catalog(
+            database=glue_database,
+            table_name=table,
+            transformation_ctx=f"datasource_{table}",
+        )
+
+        mapping_file_key = f"{s3_mapping_location}{table}.json"
+
+        try:
+            s3.Object(s3_mapping_location, mapping_file_key).load()
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "404":
+                logger.info(f"No mapping file for {table} found, {e.response}")
+            else:
+                logger.info(f"Error retrieving mapping file {e.response}")
+        else:
+            obj = s3.Object(s3_mapping_location, mapping_file_key).get()
+            mapping = json.loads(obj["Body"].read())
+            daily_df = rename_columns(daily_df, mapping)
+
+        glueContext.write_dynamic_frame.from_jdbc_conf(
+            frame=daily_df,
+            catalog_connection="redshift",
+            connection_options={"dbtable": table, "database": redshift_database},
+            redshift_tmp_dir="s3://redshift_tmp_dir_path",
+        )
+
+    job.commit()

--- a/scripts/jobs/env_services/alloy_raw_to_refined.py
+++ b/scripts/jobs/env_services/alloy_raw_to_refined.py
@@ -62,10 +62,8 @@ if __name__ == "__main__":
 
     glue_database = get_glue_env_var("glue_database", "")
     glue_table_prefix = get_glue_env_var("glue_table_prefix", "")
-    s3_raw_zone_bucket = get_glue_env_var("s3_raw_zone_bucket", "")
     s3_refined_zone_bucket = get_glue_env_var("s3_refined_zone_bucket", "")
     s3_mapping_location = get_glue_env_var("s3_mapping_location", "")
-    s3_downloads_prefix = get_glue_env_var("s3_downloads_prefix", "")
     s3_target_prefix = get_glue_env_var("s3_target_prefix", "")
 
     table_names = get_table_names(glue_database, glue_table_prefix)

--- a/scripts/jobs/env_services/alloy_raw_to_refined.py
+++ b/scripts/jobs/env_services/alloy_raw_to_refined.py
@@ -11,11 +11,11 @@ from pyspark.context import SparkContext
 from scripts.helpers.helpers import get_glue_env_var
 
 
-def get_table_names(glue_database, glue_table_prefix):
+def get_table_names(glue_database, glue_table_prefix, region_name="eu-west=2"):
     """
     Returns a list of tables from a glue catalog database that begin with a common prefix
     """
-    glue_client = boto3.client("glue", region_name="eu-west-2")
+    glue_client = boto3.client("glue", region_name=region_name)
     response = glue_client.get_tables(
         DatabaseName=glue_database, Expression=f"^{glue_table_prefix}*"
     )

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -54,7 +54,7 @@ resource "aws_glue_trigger" "alloy_export_crawler" {
   enabled = local.is_production_environment
 
   actions {
-    crawler_name = aws_glue_crawler.alloy_daily_table_ingestion[count.index].name
+    crawler_name = aws_glue_crawler.alloy_export_crawler[count.index].name
   }
 
   predicate {
@@ -120,12 +120,12 @@ resource "aws_glue_trigger" "alloy_refined_crawler" {
   enabled = local.is_production_environment
 
   actions {
-    crawler_name = aws_glue_crawler.alloy_raw_to_refined_env_services[count.index].name
+    crawler_name = aws_glue_crawler.alloy_refined[count.index].name
   }
 
   predicate {
     conditions {
-      job_name = module.alloy_daily_snapshot_env_services[count.index].job_name
+      job_name = module.alloy_raw_to_refined_env_services[count.index].job_name
       state    = "SUCCEEDED"
     }
   }
@@ -142,7 +142,7 @@ resource "aws_glue_crawler" "alloy_refined" {
   s3_target {
     path = "s3://${module.refined_zone_data_source.bucket_id}/env-services/alloy/${local.alloy_query_names_alphanumeric[count.index]}"
   }
-  able_prefix = "alloy_refined_"
+  table_prefix = "alloy_refined_"
   configuration = jsonencode({
     Version = 1.0
     Grouping = {

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -1,0 +1,151 @@
+locals {
+  alloy_queries                     = local.is_live_environment ? fileset("${path.module}/../../scripts/jobs/env_services/aqs", "*json") : []
+  alloy_query_names                 = local.is_live_environment ? [for i in tolist(local.alloy_queries) : replace(trimsuffix(i, ".json"), "\\W", "_")] : []
+  alloy_queries_max_concurrent_runs = local.is_live_environment ? length(local.alloy_queries) : 1
+}
+
+resource "aws_glue_trigger" "alloy_daily_export" {
+  count   = !local.is_production_environment ? length(local.alloy_queries) : 0
+  tags    = module.tags.values
+  enabled = local.is_production_environment
+
+  name     = "${local.short_identifier_prefix} ${local.alloy_query_names[count.index]} Alloy API Export Job"
+  type     = "SCHEDULED"
+  schedule = "cron(0 23 ? * MON-FRI *)"
+
+  actions {
+    job_name = module.alloy_api_export_raw_env_services[count.index].job_name
+  }
+}
+
+module "alloy_api_export_raw_env_services" {
+  source                    = "../modules/aws-glue-job"
+  is_live_environment       = local.is_live_environment
+  is_production_environment = local.is_production_environment
+  count                     = !local.is_production_environment ? length(local.alloy_queries) : 0
+
+  job_description = "This job queries the Alloy API and saves the exported csvs to s3"
+  department      = module.department_environmental_services_data_source
+  job_name        = "${local.short_identifier_prefix}_alloy_api_export_${local.alloy_query_names[count.index]}_env_services"
+
+  helper_module_key          = data.aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key            = data.aws_s3_bucket_object.pydeequ.key
+  spark_ui_output_storage_id = module.spark_ui_output_storage_data_source.bucket_id
+  trigger_enabled            = false
+  script_name                = "alloy_api_export"
+  job_parameters = {
+    "--job-bookmark-option"     = "job-bookmark-enable"
+    "--enable-glue-datacatalog" = "true"
+    "--secret_name"             = "${local.identifier_prefix}/env-services/alloy-api-key"
+    "--aqs"                     = file("${path.module}/../../scripts/jobs/env_services/aqs/${tolist(local.alloy_queries)[count.index]}")
+    "--s3_raw_zone_bucket"      = module.raw_zone_data_source.bucket_id
+    "--s3_downloads_prefix"     = "env-services/alloy/alloy_api_downloads/${local.alloy_query_names[count.index]}/"
+  }
+}
+
+
+
+resource "aws_glue_trigger" "alloy_export_crawler" {
+  count   = !local.is_production_environment ? length(local.alloy_queries) : 0
+  tags    = module.tags.values
+  name    = "${local.short_identifier_prefix} ${local.alloy_query_names[count.index]} Alloy Export Crawler"
+  type    = "CONDITIONAL"
+  enabled = local.is_production_environment
+
+  actions {
+    crawler_name = aws_glue_crawler.alloy_daily_table_ingestion[count.index].name
+  }
+
+  predicate {
+    conditions {
+      job_name = module.alloy_api_export_raw_env_services[count.index].job_name
+      state    = "SUCCEEDED"
+    }
+  }
+}
+
+resource "aws_glue_crawler" "alloy_export_crawler" {
+  count = !local.is_production_environment ? length(local.alloy_queries) : 0
+  tags  = module.tags.values
+
+  database_name = module.department_environmental_services_data_source.raw_zone_catalog_database_name
+  name          = "${local.short_identifier_prefix}Alloy Export Crawler ${local.alloy_query_names[count.index]}"
+  role          = module.department_environmental_services_data_source.glue_role_arn
+
+  s3_target {
+    path = "s3://${module.raw_zone_data_source.bucket_id}/env-services/alloy/alloy_api_downloads/${local.alloy_query_names[count.index]}/"
+  }
+  table_prefix = local.alloy_query_names[count.index]
+
+  configuration = jsonencode({
+    Version = 1.0
+    Grouping = {
+      TableLevelConfiguration = 6
+    }
+  })
+}
+
+module "alloy_raw_to_refined_env_services" {
+  source                    = "../modules/aws-glue-job"
+  is_live_environment       = local.is_live_environment
+  is_production_environment = local.is_production_environment
+  count                     = local.is_production_environment ? length(local.alloy_queries) : 0
+
+  job_description = "This job transforms the daily csv exports and saves them to the refined zone"
+  department      = module.department_environmental_services_data_source
+  job_name        = "${local.short_identifier_prefix}_${local.alloy_query_names[count.index]}_alloy_daily_raw_to_refined_env_services"
+
+  helper_module_key          = data.aws_s3_bucket_object.helpers.key
+  pydeequ_zip_key            = data.aws_s3_bucket_object.pydeequ.key
+  spark_ui_output_storage_id = module.spark_ui_output_storage_data_source.bucket_id
+  triggered_by_crawler       = aws_glue_crawler.alloy_export_crawler[count.index].name
+  script_name                = "alloy_raw_to_refined"
+  job_parameters = {
+    "--job-bookmark-option"     = "job-bookmark-enable"
+    "--enable-glue-datacatalog" = "true"
+    "--glue_database"           = "env-services-raw-zone"
+    "--glue_table_prefix"       = local.alloy_query_names[count.index]
+    "--s3_refined_zone_bucket"  = "s3://${module.refined_zone_data_source.bucket_id}/env-services/alloy/snapshots/"
+    "--s3_mapping_location"     = "s3://${module.raw_zone_data_source.bucket_id}env-services/alloy/mapping-files/"
+  }
+}
+
+resource "aws_glue_trigger" "alloy_snapshot_crawler" {
+  count   = !local.is_production_environment ? length(local.alloy_queries) : 0
+  tags    = module.tags.values
+  name    = "${local.short_identifier_prefix} ${local.alloy_query_names[count.index]} Alloy Snapshot Crawler"
+  type    = "CONDITIONAL"
+  enabled = local.is_production_environment
+
+  actions {
+    crawler_name = aws_glue_crawler.alloy_snapshot[count.index].name
+  }
+
+  predicate {
+    conditions {
+      job_name = module.alloy_daily_snapshot_env_services[count.index].job_name
+      state    = "SUCCEEDED"
+    }
+  }
+}
+
+resource "aws_glue_crawler" "alloy_snapshot" {
+  count = !local.is_production_environment ? length(local.alloy_queries) : 0
+  tags  = module.tags.values
+
+  database_name = module.department_environmental_services_data_source.refined_zone_catalog_database_name
+  name          = "${local.short_identifier_prefix}Alloy Snapshot ${local.alloy_query_names[count.index]}"
+  role          = module.department_environmental_services_data_source.glue_role_arn
+
+  s3_target {
+    path = "s3://${module.refined_zone_data_source.bucket_id}/env-services/alloy/snapshots/"
+  }
+  table_prefix = "alloy_snapshot_"
+
+  configuration = jsonencode({
+    Version = 1.0
+    Grouping = {
+      TableLevelConfiguration = 5
+    }
+  })
+}

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -90,7 +90,7 @@ module "alloy_raw_to_refined_env_services" {
   source                    = "../modules/aws-glue-job"
   is_live_environment       = local.is_live_environment
   is_production_environment = local.is_production_environment
-  count                     = local.is_production_environment ? length(local.alloy_queries) : 0
+  count                     = !local.is_production_environment ? length(local.alloy_queries) : 0
 
   job_description = "This job transforms the daily csv exports and saves them to the refined zone"
   department      = module.department_environmental_services_data_source


### PR DESCRIPTION
## [DPP-294 Ingest additional files from Alloy exports](https://hackney.atlassian.net/browse/DPP-294?atlOrigin=eyJpIjoiNzU0MjI1YjdkMGZhNGE1Mzk1ZDMyMTRhOWQ0MDFkY2MiLCJwIjoiaiJ9)


## Describe this PR
PR to create new Alloy pipeline in Pre-prod.

<img width="893" alt="image" src="https://user-images.githubusercontent.com/61045197/194552434-138d268e-bd1e-43c3-ab2b-caef76ae82c9.png">

### *What is the problem we're trying to solve*
Previous implementation only ingested the parent table for each query.

### *What changes have we introduced*

### *How Has This Been Tested?*
Deploying this to pre-prod in order to test data catalog functionality

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*
unit tests - I know...!
needs a way to handle invalid / empty tables that might be present in the data catalog
structure of env-services terraform (this creates a new .tf file for this pipeline, but there are shared values with previous implementation)

