### PR TITLE
DPP-295 Update configuration to use correct S3 locations

### DIFF
--- a/scripts/jobs/parking/parking_copy_ringgo_sftp_data_to_raw.py
+++ b/scripts/jobs/parking/parking_copy_ringgo_sftp_data_to_raw.py
@@ -1,0 +1,56 @@
+import sys
+from awsglue.transforms import *
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from awsglue.context import GlueContext
+from awsglue.job import Job
+from pyspark.sql.functions import col, lit, when, concat
+from pyspark.sql.types import IntegerType
+from pyspark.sql import SparkSession
+import boto3
+
+from scripts.helpers.helpers import get_glue_env_var, add_import_time_columns, get_s3_subfolders, PARTITION_KEYS, \
+    clean_column_names, get_latest_partitions
+
+s3_client = boto3.client('s3')
+sc = SparkContext.getOrCreate()
+spark = SparkSession.builder.getOrCreate()
+glue_context = GlueContext(sc)
+
+logger = glue_context.get_logger()
+
+
+def data_source_landing_to_raw(bucket_source, bucket_target, s3_prefix):
+    logger.info("bucket_target" + bucket_target)
+    logger.info("s3_prefix" + s3_prefix)
+    data_source = spark.read.option("multiline", "true").csv(bucket_source + "/" + s3_prefix)
+    latest_data = get_latest_partitions(data_source)
+    logger.info(f"latest_data: {latest_data}")
+
+    logger.info(f"Retrieved data source from s3 path {bucket_source}/{s3_prefix}")
+
+    data_frame = clean_column_names(latest_data)
+    logger.info("Using Columns: " + str(data_frame.columns))
+
+    date_partition_formatted = data_frame.withColumn("import_month", col("import_month").cast(IntegerType())) \
+        .withColumn("import_day", col("import_day").cast(IntegerType())) \
+        .withColumn("import_month", when(col("import_month") < 10, concat(lit("0"), col("import_month"))).otherwise(
+        col("import_month"))) \
+        .withColumn("import_day",
+                    when(col("import_day") < 10, concat(lit("0"), col("import_day"))).otherwise(col("import_day")))
+
+    date_partition_formatted.write.mode("append").partitionBy(*PARTITION_KEYS).parquet(bucket_target + "/" + s3_prefix)
+
+
+args = getResolvedOptions(sys.argv, ['JOB_NAME'])
+
+job = Job(glue_context)
+job.init(args['JOB_NAME'], args)
+
+s3_bucket_target = get_glue_env_var('s3_bucket_target', '')
+s3_prefix = get_glue_env_var('s3_prefix', '')
+s3_bucket_source = get_glue_env_var('s3_bucket_source', '')
+
+data_source_landing_to_raw("s3://" + s3_bucket_source, "s3://" + s3_bucket_target, s3_prefix)
+
+job.commit()

--- a/terraform/core/12-aws-s3-scripts.tf
+++ b/terraform/core/12-aws-s3-scripts.tf
@@ -86,3 +86,10 @@ resource "aws_s3_bucket_object" "copy_manually_uploaded_csv_data_to_raw" {
   source_hash = filemd5("../../scripts/jobs/copy_manually_uploaded_csv_data_to_raw.py")
 }
 
+resource "aws_s3_bucket_object" "parking_copy_ringgo_sftp_data_to_raw" {
+  bucket      = module.glue_scripts.bucket_id
+  key         = "scripts/parking/parking_copy_ringgo_sftp_data_to_raw.py"
+  acl         = "private"
+  source      = "../../scripts/jobs/parking/parking_copy_ringgo_sftp_data_to_raw.py"
+  source_hash = filemd5("../../scripts/jobs/parking/parking_copy_ringgo_sftp_data_to_raw.py")
+}

--- a/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
+++ b/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
@@ -65,11 +65,11 @@ module "ringgo_sftp_data_to_raw" {
   glue_scripts_bucket_id     = module.glue_scripts.bucket_id
   glue_temp_bucket_id        = module.glue_temp_storage.bucket_id
   glue_role_arn              = aws_iam_role.glue_role.arn
-  script_s3_object_key       = aws_s3_bucket_object.copy_manually_uploaded_csv_data_to_raw.key
+  script_s3_object_key       = aws_s3_bucket_object.parking_copy_ringgo_sftp_data_to_raw.key
   
   job_parameters = {
     "--job-bookmark-option" = "job-bookmark-enable"
-    "--s3_bucket_target"    = module.raw_zone.bucket_id
+    "--s3_bucket_target"    = "${module.raw_zone.bucket_id}/parking"
     "--s3_bucket_source"    = module.landing_zone.bucket_id
     "--s3_prefix"           = "ringgo/sftp/"
     "--extra-py-files"      = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"
@@ -79,11 +79,11 @@ module "ringgo_sftp_data_to_raw" {
   
   crawler_details = {
     database_name      = aws_glue_catalog_database.parking_ringgo_sftp_catalog_database[0].name
-    s3_target_location = "s3://${module.raw_zone.bucket_id}/ringgo/sftp/"
+    s3_target_location = "s3://${module.raw_zone.bucket_id}/parking/ringgo/"
     configuration = jsonencode({
       Version = 1.0
       Grouping = {
-        TableLevelConfiguration = 3
+        TableLevelConfiguration = 4
       }
     })
   }


### PR DESCRIPTION
This update fixes some issues with the initial RingGo ingestion setup:

1. New script for copying data from landing to raw zone. This is almost identical to the iCaseworks script, so there's a lot of duplication. This can be improved by developing some common helpers for functions used by different jobs, but we don't have those available at the moment
2.  Add new S3 bucket object for the script
3. Fix the copy job to use correct S3 target, so parking can query the data

Please note this is for pre-prod deployment only for now.
