### PR TITLE
DPP-305 Add test setup for academy raw zone data

### DIFF
--- a/terraform/core/82-academy-pre-production-raw-zone-data-test.tf
+++ b/terraform/core/82-academy-pre-production-raw-zone-data-test.tf
@@ -1,0 +1,55 @@
+#pre-prod setup for testing Academy data
+
+#revenues raw zone test database
+resource "aws_glue_catalog_database" "revenues_raw_zone_test" {
+    count = !local.is_production_environment ? 1 : 0
+    name = "${local.short_identifier_prefix}revenues-raw-zone-test"
+}
+
+#revenues raw zone test crawler
+resource "aws_glue_crawler" "revenue_raw_zone_test" {
+    count = !local.is_production_environment ? 1 : 0
+    tags = module.tags.values
+    
+    database_name = aws_glue_catalog_database.revenues_raw_zone_test[0].name
+    name = "${local.short_identifier_prefix}revenues-raw-zone-test"
+    role = aws_iam_role.glue_role.arn
+
+    s3_target {
+        path = "s3://${module.raw_zone.bucket_id}/revenues/"
+    }
+
+    configuration = jsonencode({
+        Version = 1.0
+        Grouping = {
+            TableLevelConfiguration = 3
+        }
+    })
+}
+
+#benefits and housing needs raw zone test database
+resource "aws_glue_catalog_database" "bens_housing_needs_raw_zone_test" {
+    count = !local.is_production_environment ? 1 : 0
+    name = "${local.short_identifier_prefix}bens-housing-needs-raw-zone-test"
+}
+
+#benefits and housing needs raw zone test crawler
+resource "aws_glue_crawler" "bens_housing_needs_raw_zone_test" {
+    count = !local.is_production_environment ? 1 : 0
+    tags = module.tags.values
+
+    database_name = aws_glue_catalog_database.bens_housing_needs_raw_zone_test[0].name
+    name = "${local.short_identifier_prefix}bens-housing-needs-raw-zone-test"
+    role = aws_iam_role.glue_role.arn
+
+    s3_target {
+        path = "s3://${module.raw_zone.bucket_id}/benefits-housing-needs/"
+    }
+
+     configuration = jsonencode({
+        Version = 1.0
+        Grouping = {
+            TableLevelConfiguration = 3
+        }
+    })
+}


### PR DESCRIPTION
In order to investigate the state of Academy data in raw zone on pre-production we want to add a test setup for both revenues and benefits and housing needs data. This will help us to work out the best way forward for working with Academy data on pre-prod.

This update adds new test glue catalogue database and crawler for both datasets.

