### PR TITLE
Update 15-unrestricted-geolive-database-ingestion.tf

### DIFF
--- a/terraform/core/15-unrestricted-geolive-database-ingestion.tf
+++ b/terraform/core/15-unrestricted-geolive-database-ingestion.tf
@@ -6,11 +6,10 @@ module "boundaries_geolive_database_ingestion" {
 
   name                        = "geolive-boundaries-schema"
   jdbc_connection_url         = "jdbc:postgresql://geolive-db-prod.cjgyygrtgrhl.eu-west-2.rds.amazonaws.com:5432/geolive"
-  jdbc_connection_description = "JDBC connection to Geolive PostgreSQL database, to access the boundaries schema only"
+  jdbc_connection_description = "JDBC connection to Geolive PostgreSQL database, to access boundaries layers from various schemas (boundaries, health, recycling)"
   jdbc_connection_subnet      = data.aws_subnet.network[local.instance_subnet_id]
   identifier_prefix           = local.short_identifier_prefix
   database_secret_name        = "database-credentials/geolive-boundaries"
-  schema_name                 = "boundaries"
 }
 
 module "boundaries_geolive_ingestion_job" {


### PR DESCRIPTION
Remove schema from Geolive connection module, so we can ingest from several schemas into the unrestricted department. The accessed schemas and tables are set by the permissions assigned to the database user called data_platform_boundaries.