### PR TITLE
DPP-310 Update google-auth package to latest version

### DIFF
--- a/terraform/modules/google-sheets-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/google-sheets-glue-job/10-aws-glue-job.tf
@@ -13,7 +13,7 @@ module "google_sheet_import" {
   spark_ui_output_storage_id = var.spark_ui_output_storage_id
 
   job_parameters = {
-    "--additional-python-modules" = "gspread==3.7.0, google-auth==1.27.1, pyspark==3.1.1"
+    "--additional-python-modules" = "gspread==3.7.0, google-auth==2.13.0, pyspark==3.1.1"
     "--document_key"              = var.google_sheets_document_id
     "--worksheet_name"            = var.google_sheets_worksheet_name
     "--header_row_number"         = var.google_sheet_header_row_number


### PR DESCRIPTION
Google sheet import jobs have started failing with `ImportError: cannot import name 'external_account_authorized_user' from 'google.auth'` error.

This updates the google-auth package to the latest version which resolves the issue.

This has been tested manually on pre-prod.