### PR TITLE
Dpp 294 combine alloy jobs

### DIFF
--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -2,7 +2,7 @@ locals {
   # These values already exist in terraform\etl\25-aws-glue-job-env-services.tf
   #alloy_queries                     = local.is_live_environment ? fileset("${path.module}/../../scripts/jobs/env_services/aqs", "*json") : []
   #alloy_queries_max_concurrent_runs = local.is_live_environment ? length(local.alloy_queries) : 1
-  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in tolist(local.alloy_queries) : replace(i, "\\W", "_")] : []
+  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in local.alloy_query_names : replace(i, "\\W", "_")] : []
 }
 
 resource "aws_glue_trigger" "alloy_daily_export" {


### PR DESCRIPTION
Moves the functionality previously in [alloy_raw_to_refined.py](https://github.com/LBHackney-IT/Data-Platform/blob/b302dbb6fc12a8e892aca4245948030b46a8880a/scripts/jobs/env_services/alloy_raw_to_refined.py ) to write the exported csv to the refined zone in parquet format, conditionally renaming columns with a json dictionary. 

This removes the dependency on the the raw crawler to correctly identify the headers in the csv (that wasn't consistent). 