### PR TITLE
DPP-265 run s3 file transfer on glue job success

### DIFF
--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -2,8 +2,9 @@ module "copy_from_s3_to_s3" {
   source = "../modules/copy-from-s3-to-s3"
   tags   = module.tags.values
 
-  is_live_environment = local.is_live_environment
-
+  is_live_environment            = local.is_live_environment
+  environment                    = local.environment
+  is_production_environment      = local.is_production_environment
   lambda_name                    = "rentsense-s3-to-s3-export-copy"
   identifier_prefix              = local.identifier_prefix
   short_identifier_prefix        = local.short_identifier_prefix

--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -6,6 +6,7 @@ module "copy_from_s3_to_s3" {
 
   lambda_name                    = "rentsense-s3-to-s3-export-copy"
   identifier_prefix              = local.identifier_prefix
+  short_identifier_prefix        = local.short_identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage
   origin_bucket                  = module.refined_zone
   origin_path                    = "housing/rentsense/export/"
@@ -18,4 +19,3 @@ module "copy_from_s3_to_s3" {
   target_path = var.rentsense_target_path
   assume_role = "arn:aws:iam::971933469343:role/customer-midas-roles-pluto-HackneyMidasRole-1M6PTJ5VS8104"
 }
-#

--- a/terraform/modules/copy-from-s3-to-s3/01-inputs-required.tf
+++ b/terraform/modules/copy-from-s3-to-s3/01-inputs-required.tf
@@ -49,3 +49,19 @@ variable "is_live_environment" {
   description = "A flag indicting if we are running in a live environment for setting up automation"
   type        = bool
 }
+
+variable "short_identifier_prefix" {
+  description = "Environment based identifier prefix"
+  type        = string
+}
+
+variable "environment" {
+  description = "Name of the current environment"
+  type        = string
+}
+
+variable "is_production_environment" {
+  description = "A flag indicating if we are running in production environment"
+  type        = string
+}
+

--- a/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
@@ -9,3 +9,8 @@ variable "lambda_execution_cron_schedule" {
   type        = string
   default     = "cron(0 9 * * ? *)"
 }
+
+variable "short_identifier_prefix" {
+  description = "Environment based identifier prefix"
+  type        = string
+}

--- a/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
@@ -10,7 +10,3 @@ variable "lambda_execution_cron_schedule" {
   default     = "cron(0 9 * * ? *)"
 }
 
-variable "short_identifier_prefix" {
-  description = "Environment based identifier prefix"
-  type        = string
-}

--- a/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
+++ b/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
@@ -176,15 +176,34 @@ resource "aws_lambda_function_event_invoke_config" "copy_from_s3_to_s3_lambda" {
   ]
 }
 
-resource "aws_cloudwatch_event_rule" "run_s3_copier_lambda" {
-  name_prefix         = "${var.lambda_name}-lambda-"
-  description         = "Runs on the following schedule: ${var.lambda_execution_cron_schedule}"
-  schedule_expression = var.lambda_execution_cron_schedule
-  is_enabled          = var.is_live_environment
+resource "aws_cloudwatch_event_rule" "run_s3_copier_lambda_on_glue_job_success" {
+  name_prefix = "${var.lambda_name}-lambda-"
+  description = "Runs when RentSense outputs Glue job succeeds"
+
+  event_pattern = <<EOF
+  {
+    "source": [
+      "aws.glue"
+    ],
+    "detail-type":[
+      "Glue Job State Change"
+    ],
+    "detail": {
+      "state": [
+        "SUCCEEDED"
+      ],
+      "jobName": [
+          "${var.short_identifier_prefix}Rentsense outputs"
+      ]
+    }
+  }
+  EOF
+
+  is_enabled = var.is_live_environment
 }
 
 resource "aws_cloudwatch_event_target" "run_s3_copier_lambda" {
-  rule      = aws_cloudwatch_event_rule.run_s3_copier_lambda.name
+  rule      = aws_cloudwatch_event_rule.run_s3_copier_lambda_on_glue_job_success.name
   target_id = "${var.lambda_name}-"
   arn       = aws_lambda_function.copy_from_s3_to_s3_lambda.arn
 }
@@ -194,5 +213,5 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_s3_copier_lambda" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.copy_from_s3_to_s3_lambda.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.run_s3_copier_lambda.arn
+  source_arn    = aws_cloudwatch_event_rule.run_s3_copier_lambda_on_glue_job_success.arn
 }

--- a/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
+++ b/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
@@ -193,7 +193,7 @@ resource "aws_cloudwatch_event_rule" "run_s3_copier_lambda_on_glue_job_success" 
         "SUCCEEDED"
       ],
       "jobName": [
-          "${var.short_identifier_prefix}Rentsense outputs"
+          "${var.is_production_environment ? "" : var.environment}${var.is_live_environment && !var.is_production_environment ? " " : "-"}Rentsense outputs"
       ]
     }
   }


### PR DESCRIPTION
Update RentSense file transfer to trigger on Glue job (Rentsense outputs) status change (SUCCEEDED) rather that on set schedule.

This will be active on per-prod and prod.