### PR TITLE
Dpp 294 alloy catalog fixes

### DIFF
--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -32,14 +32,24 @@ def api_response_json(response):
     return json.loads(response.text)
 
 
-def create_s3_key(s3_downloads_prefix, import_date, file):
+def create_s3_key(s3_downloads_prefix, import_date, file, prefix_to_remove=None):
     """
     creates the key argument for saving output files to s3
     """
     file_basename = os.path.basename(file)
     file_table_name = os.path.splitext(file_basename)
-    file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name[0])
+    file_table_name = file_table_name[0]
     file_table_name = file_table_name.lower()
+
+    for pre in prefix_to_remove:
+        pre = pre.lower()
+        if not file_table_name.startswith(pre):
+            pass
+        else:
+            file_table_name = file_table_name[len(pre) :]
+
+    file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name)
+
     raw_key = f"{s3_downloads_prefix}{file_table_name}/import_year={import_date: %Y}/import_month={import_date: %m}/import_day={import_date: %d}/import_date={import_date: %Y%m%d}/import{file_basename}"
     return raw_key
 
@@ -61,6 +71,7 @@ if __name__ == "__main__":
     aqs = get_glue_env_var("aqs", "")
     s3_raw_zone_bucket = get_glue_env_var("s3_raw_zone_bucket", "")
     s3_downloads_prefix = get_glue_env_var("s3_downloads_prefix", "")
+    prefix_to_remove = get_glue_env_var("prefix_to_remove", "")
 
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     region = "uk"
@@ -106,12 +117,13 @@ if __name__ == "__main__":
             file_list = zip.namelist()
 
             for file in file_list:
-                raw_key = create_s3_key(s3_downloads_prefix, import_date, file)
+                table_name = file
+                raw_key = create_s3_key(
+                    s3_downloads_prefix, import_date, file, prefix_to_remove
+                )
 
                 s3.meta.client.upload_fileobj(
-                    zip.open(file),
-                    Bucket=s3_raw_zone_bucket,
-                    Key=raw_key,
+                    zip.open(file), Bucket=s3_raw_zone_bucket, Key=raw_key,
                 )
 
     job.commit()

--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -58,7 +58,6 @@ if __name__ == "__main__":
     sc = SparkContext.getOrCreate()
     glueContext = GlueContext(sc)
     spark = glueContext.spark_session
-    job = Job(glueContext)
 
     args = getResolvedOptions(sys.argv, ["JOB_NAME"])
     job = Job(glueContext)

--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -117,7 +117,6 @@ if __name__ == "__main__":
             file_list = zip.namelist()
 
             for file in file_list:
-                table_name = file
                 raw_key = create_s3_key(
                     s3_downloads_prefix, import_date, file, prefix_to_remove
                 )

--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -46,7 +46,7 @@ def create_s3_key(s3_downloads_prefix, import_date, file, prefix_to_remove=None)
         if not file_table_name.startswith(pre):
             pass
         else:
-            file_table_name = file_table_name[len(pre) :]
+            file_table_name = file_table_name[len(pre):]
 
     file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name)
 

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -153,5 +153,9 @@ resource "aws_glue_crawler" "alloy_refined" {
     Grouping = {
       TableLevelConfiguration = 5
     }
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+      Tables     = { AddOrUpdateBehavior = "LOG" }
+    }
   })
 }

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -143,7 +143,7 @@ resource "aws_glue_crawler" "alloy_refined" {
   s3_target {
     path = "s3://${module.refined_zone_data_source.bucket_id}/env-services/alloy/${local.alloy_query_names_alphanumeric[count.index]}"
   }
-  table_prefix = "alloy_refined_"
+  table_prefix = "alloy_"
   configuration = jsonencode({
     Version = 1.0
     Grouping = {

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -83,6 +83,10 @@ resource "aws_glue_crawler" "alloy_export_crawler" {
     Grouping = {
       TableLevelConfiguration = 6
     }
+    CrawlerOutput = {
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+      Tables     = { AddOrUpdateBehavior = "LOG" }
+    }
   })
 }
 

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -12,7 +12,7 @@ resource "aws_glue_trigger" "alloy_daily_export" {
 
   name     = "${local.short_identifier_prefix} Alloy API Export Job Trigger ${local.alloy_query_names_alphanumeric[count.index]}"
   type     = "SCHEDULED"
-  schedule = "cron(0 23 ? * MON-FRI *)"
+  schedule = "cron(0 3 ? * MON-FRI *)"
 
   actions {
     job_name = module.alloy_api_export_raw_env_services[count.index].job_name

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -41,6 +41,7 @@ module "alloy_api_export_raw_env_services" {
     "--aqs"                     = file("${path.module}/../../scripts/jobs/env_services/aqs/${tolist(local.alloy_queries)[count.index]}")
     "--s3_raw_zone_bucket"      = module.raw_zone_data_source.bucket_id
     "--s3_downloads_prefix"     = "env-services/alloy/alloy_api_downloads/${local.alloy_query_names_alphanumeric[count.index]}/"
+    "--prefix_to_remove"        = "joineddesign_"
   }
 }
 

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -2,7 +2,7 @@ locals {
   # These values already exist in terraform\etl\25-aws-glue-job-env-services.tf
   #alloy_queries                     = local.is_live_environment ? fileset("${path.module}/../../scripts/jobs/env_services/aqs", "*json") : []
   #alloy_queries_max_concurrent_runs = local.is_live_environment ? length(local.alloy_queries) : 1
-  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in alloy_query_names : replace(i, "\\W", "_")] : []
+  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in local.alloy_query_names : replace(i, "\\W", "_")] : []
 }
 
 resource "aws_glue_trigger" "alloy_daily_export" {

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -84,8 +84,8 @@ resource "aws_glue_crawler" "alloy_export_crawler" {
       TableLevelConfiguration = 6
     }
     CrawlerOutput = {
-      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
-      Tables     = { AddOrUpdateBehavior = "LOG" }
+      Partitions = { UpdateBehavior = "InheritFromTable" }
+      Tables     = { UpdateBehavior = "LOG" }
     }
   })
 }
@@ -154,8 +154,8 @@ resource "aws_glue_crawler" "alloy_refined" {
       TableLevelConfiguration = 5
     }
     CrawlerOutput = {
-      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
-      Tables     = { AddOrUpdateBehavior = "LOG" }
+      Partitions = { UpdateBehavior = "InheritFromTable" }
+      Tables     = { UpdateBehavior = "LOG" }
     }
   })
 }

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -2,7 +2,7 @@ locals {
   # These values already exist in terraform\etl\25-aws-glue-job-env-services.tf
   #alloy_queries                     = local.is_live_environment ? fileset("${path.module}/../../scripts/jobs/env_services/aqs", "*json") : []
   #alloy_queries_max_concurrent_runs = local.is_live_environment ? length(local.alloy_queries) : 1
-  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in tolist(local.alloy_queries) : replace(i, "\\W", "_")] : []
+  alloy_query_names_alphanumeric = local.is_live_environment ? [for i in alloy_query_names : replace(i, "\\W", "_")] : []
 }
 
 resource "aws_glue_trigger" "alloy_daily_export" {


### PR DESCRIPTION
- change the terraform for the crawlers so they won't update the table definitions in the catalog once they're set

> - This prevents the crawlers in raw incorrectly ignoring the header row and updating the catalog with default values (col1, col2...)
> - This also allows the onward job creating refined data to read the correct metadata for the table from the raw catalog

- change the prefix for the refined crawlers from alloy_refined_ to alloy_
- remove prefixes from table names based on a list
- also includes a change to the scheduled trigger, for no reason other than to move it off the boundary between days