### PR TITLE
modify schema change policy

### DIFF
--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -85,10 +85,13 @@ resource "aws_glue_crawler" "alloy_export_crawler" {
       TableLevelConfiguration = 6
     }
     CrawlerOutput = {
-      Partitions = { UpdateBehavior = "InheritFromTable" }
-      Tables     = { UpdateBehavior = "LOG" }
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
     }
-  })
+    }
+  )
+  schema_change_policy = {
+    update_behavior = "LOG"
+  }
 }
 
 module "alloy_raw_to_refined_env_services" {
@@ -155,8 +158,9 @@ resource "aws_glue_crawler" "alloy_refined" {
       TableLevelConfiguration = 5
     }
     CrawlerOutput = {
-      Partitions = { UpdateBehavior = "InheritFromTable" }
-      Tables     = { UpdateBehavior = "LOG" }
+      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
+      Tables     = { AddOrUpdateBehavior = "MergeNewColumns" }
     }
   })
+
 }

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -89,7 +89,7 @@ resource "aws_glue_crawler" "alloy_export_crawler" {
     }
     }
   )
-  schema_change_policy = {
+  schema_change_policy {
     update_behavior = "LOG"
   }
 }


### PR DESCRIPTION
Previous merged tf failed to apply with this error:
`CrawlerOutput.Partitions contains unsupported keys: UpdateBehavior.`
But I don't think even with the correct key (AddOrUpdateBehavior) it would take the LOG value.

This is the configuration I'm intending to create for the first crawler (alloy_export_crawler):

>  If the built-in CSV classifier does not create your AWS Glue table as you want, you might be able to use one of the following alternatives:
> 
>- Change the column names in the Data Catalog, set the SchemaChangePolicy to LOG, and set the partition output configuration to InheritFromTable for future crawler runs.

[From: Adding classifiers to a crawler in AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/add-classifier.html)