### PR TITLE
DPP-170 enable production deployment for RingGo ingestion

### DIFF
--- a/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
+++ b/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
@@ -1,5 +1,5 @@
 module "sftp_to_s3_ingestion" {
-  count                     = local.is_production_environment ? 0 : 1
+  count                     = local.is_live_environment ? 1 : 0
   source                    = "../modules/api-ingestion-lambda"
   tags                      = module.tags.values
   is_production_environment = local.is_production_environment
@@ -44,7 +44,7 @@ locals {
 }
 
 resource "aws_glue_catalog_database" "parking_ringgo_sftp_catalog_database" {
-  count = !local.is_production_environment ? 1 : 0
+  count = local.is_live_environment ? 1 : 0
   name  = "${local.short_identifier_prefix}parking-ringgo-sftp-raw-zone"
   
   lifecycle {
@@ -54,7 +54,7 @@ resource "aws_glue_catalog_database" "parking_ringgo_sftp_catalog_database" {
 
 module "ringgo_sftp_data_to_raw" {
   source = "../modules/aws-glue-job"
-  count                      = !local.is_production_environment ? 1 : 0
+  count                      = local.is_live_environment ? 1 : 0
   is_production_environment  = local.is_production_environment
   is_live_environment        = local.is_live_environment
   job_name                   = "${local.short_identifier_prefix}Parking copy RingGo SFTP data to raw"
@@ -75,7 +75,7 @@ module "ringgo_sftp_data_to_raw" {
     "--extra-py-files"      = "s3://${module.glue_scripts.bucket_id}/${aws_s3_bucket_object.helpers.key}"
   }
   
-  trigger_enabled      = false
+  trigger_enabled      = local.is_production_environment
   
   crawler_details = {
     database_name      = aws_glue_catalog_database.parking_ringgo_sftp_catalog_database[0].name


### PR DESCRIPTION
Update configuration to enable production deployment

- Deploy SFTP ingestion lambda
- Setup Glue catalog database
- Deploy landing to raw copy glue job (trigger is enabled on prod only)  