### PR TITLE
Dpp 315 alloy

### DIFF
--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -48,7 +48,9 @@ def create_s3_key(s3_prefix, file, prefix_to_remove=None, import_date=False):
     file_table_name = file_table_name[0]
     file_table_name = file_table_name.lower()
 
-    if not prefix_to_remove == None:
+    if prefix_to_remove == None:
+        pass
+    else:
         pre = prefix_to_remove.lower()
 
         if not file_table_name.startswith(pre):
@@ -144,15 +146,18 @@ if __name__ == "__main__":
                     .option("multiline", "true")
                     .csv(f"s3://{s3_raw_zone_bucket}/{raw_key}")
                 )
+
                 df = clean_column_names(df)
                 df = add_import_time_columns(df)
 
                 s3_parquet_key = create_s3_key(
                     s3_parquet_prefix, file, prefix_to_remove
                 )
+
                 df = (
                     df.write.partitionBy(PARTITION_KEYS)
                     .mode("append")
                     .parquet(f"s3://{s3_raw_zone_bucket}/{s3_parquet_key}")
                 )
+
     job.commit()

--- a/scripts/jobs/env_services/alloy_api_export.py
+++ b/scripts/jobs/env_services/alloy_api_export.py
@@ -39,7 +39,9 @@ def api_response_json(response):
     return json.loads(response.text)
 
 
-def create_s3_key(s3_prefix, file, prefix_to_remove=None, import_date=False):
+def create_s3_key(
+    s3_prefix, file, prefix_to_remove=None, import_date=False, include_file_name=False
+):
     """
     creates the key argument for saving output files to s3
     """
@@ -60,8 +62,10 @@ def create_s3_key(s3_prefix, file, prefix_to_remove=None, import_date=False):
 
     file_table_name = re.sub(r"[^A-Za-z0-9]+", "_", file_table_name)
 
-    if import_date:
-        s3_key = f"{s3_prefix}{file_table_name}/import_year={import_date: %Y}/import_month={import_date: %m}/import_day={import_date: %d}/import_date={import_date: %Y%m%d}/import{file_basename}"
+    if import_date and include_file_name:
+        s3_key = f"{s3_prefix}{file_table_name}/import_year={import_date:%Y}/import_month={import_date:%m}/import_day={import_date:%d}/import_date={import_date:%Y%m%d}/{file_basename}"
+    elif import_date:
+        s3_key = f"{s3_prefix}{file_table_name}/import_year={import_date:%Y}/import_month={import_date:%m}/import_day={import_date:%d}/import_date={import_date:%Y%m%d}/"
     else:
         s3_key = f"{s3_prefix}{file_table_name}/"
 

--- a/scripts/tests/env_services/test_create_s3_key.py
+++ b/scripts/tests/env_services/test_create_s3_key.py
@@ -4,25 +4,28 @@ from freezegun import freeze_time
 
 from scripts.jobs.env_services.alloy_api_export import create_s3_key
 
+test_prefix = "my/s3/prefix/"
+test_file = "I_Hate_horses.csv"
+
 
 @freeze_time("2022-11-07")
 class TestCreateS3Key:
     def test_no_prefix_no_import_date(self):
-        output = create_s3_key(s3_prefix="my/s3/prefix/", file="I_Hate_horses.csv")
+        output = create_s3_key(s3_prefix=test_prefix, file=test_file)
         assert output == "my/s3/prefix/i_hate_horses/"
 
     def test_no_import_date(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             prefix_to_remove="I_Hate_",
         )
         assert output == "my/s3/prefix/horses/"
 
     def test_no_prefix(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             import_date=date.today(),
         )
         assert (
@@ -32,8 +35,8 @@ class TestCreateS3Key:
 
     def test_import_date_and_prefix(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             prefix_to_remove="I_Hate_",
             import_date=date.today(),
         )
@@ -44,8 +47,8 @@ class TestCreateS3Key:
 
     def test_prefix_arg_not_in_filename(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             prefix_to_remove="I_Love_",
             import_date=date.today(),
         )
@@ -56,8 +59,8 @@ class TestCreateS3Key:
 
     def test_prefix_case_insensitive(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             prefix_to_remove="i_HaTe_",
             import_date=date.today(),
         )
@@ -68,8 +71,8 @@ class TestCreateS3Key:
 
     def test_include_file_name_in_key(self):
         output = create_s3_key(
-            s3_prefix="my/s3/prefix/",
-            file="I_Hate_horses.csv",
+            s3_prefix=test_prefix,
+            file=test_file,
             prefix_to_remove="i_HaTe_",
             import_date=date.today(),
             include_file_name=True,

--- a/scripts/tests/env_services/test_create_s3_key.py
+++ b/scripts/tests/env_services/test_create_s3_key.py
@@ -1,0 +1,80 @@
+from datetime import date
+
+from freezegun import freeze_time
+
+from scripts.jobs.env_services.alloy_api_export import create_s3_key
+
+
+@freeze_time("2022-11-07")
+class TestCreateS3Key:
+    def test_no_prefix_no_import_date(self):
+        output = create_s3_key(s3_prefix="my/s3/prefix/", file="I_Hate_horses.csv")
+        assert output == "my/s3/prefix/i_hate_horses/"
+
+    def test_no_import_date(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            prefix_to_remove="I_Hate_",
+        )
+        assert output == "my/s3/prefix/horses/"
+
+    def test_no_prefix(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            import_date=date.today(),
+        )
+        assert (
+            output
+            == "my/s3/prefix/i_hate_horses/import_year=2022/import_month=11/import_day=07/import_date=20221107/"
+        )
+
+    def test_import_date_and_prefix(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            prefix_to_remove="I_Hate_",
+            import_date=date.today(),
+        )
+        assert (
+            output
+            == "my/s3/prefix/horses/import_year=2022/import_month=11/import_day=07/import_date=20221107/"
+        )
+
+    def test_prefix_arg_not_in_filename(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            prefix_to_remove="I_Love_",
+            import_date=date.today(),
+        )
+        assert (
+            output
+            == "my/s3/prefix/i_hate_horses/import_year=2022/import_month=11/import_day=07/import_date=20221107/"
+        )
+
+    def test_prefix_case_insensitive(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            prefix_to_remove="i_HaTe_",
+            import_date=date.today(),
+        )
+        assert (
+            output
+            == "my/s3/prefix/horses/import_year=2022/import_month=11/import_day=07/import_date=20221107/"
+        )
+
+    def test_include_file_name_in_key(self):
+        output = create_s3_key(
+            s3_prefix="my/s3/prefix/",
+            file="I_Hate_horses.csv",
+            prefix_to_remove="i_HaTe_",
+            import_date=date.today(),
+            include_file_name=True,
+        )
+        assert (
+            output
+            == "my/s3/prefix/horses/import_year=2022/import_month=11/import_day=07/import_date=20221107/I_Hate_horses.csv"
+        )

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -41,6 +41,7 @@ module "alloy_api_export_raw_env_services" {
     "--aqs"                     = file("${path.module}/../../scripts/jobs/env_services/aqs/${tolist(local.alloy_queries)[count.index]}")
     "--s3_raw_zone_bucket"      = module.raw_zone_data_source.bucket_id
     "--s3_downloads_prefix"     = "env-services/alloy/alloy_api_downloads/${local.alloy_query_names_alphanumeric[count.index]}/"
+    "--s3_parquet_prefix"       = "env-services/alloy/parquet_files/${local.alloy_query_names_alphanumeric[count.index]}/"
     "--prefix_to_remove"        = "joineddesign_"
   }
 }

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -76,7 +76,7 @@ resource "aws_glue_crawler" "alloy_export_crawler" {
   role          = module.department_environmental_services_data_source.glue_role_arn
 
   s3_target {
-    path = "s3://${module.raw_zone_data_source.bucket_id}/env-services/alloy/alloy_api_downloads/${local.alloy_query_names_alphanumeric[count.index]}/"
+    path = "s3://${module.raw_zone_data_source.bucket_id}/env-services/alloy/parquet_files/${local.alloy_query_names_alphanumeric[count.index]}/"
   }
   table_prefix = "${lower(local.alloy_query_names_alphanumeric[count.index])}_"
 

--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -8,7 +8,7 @@ locals {
 resource "aws_glue_trigger" "alloy_daily_export" {
   count   = local.is_live_environment ? length(local.alloy_queries) : 0
   tags    = module.tags.values
-  enabled = local.is_live_environment
+  enabled = local.is_production_environment
 
   name     = "${local.short_identifier_prefix} Alloy API Export Job Trigger ${local.alloy_query_names_alphanumeric[count.index]}"
   type     = "SCHEDULED"


### PR DESCRIPTION
In order to handle non-UTF-8 characters present in some of the exported csv files the `alloy_api_export.py` script now
- Reads imported csv into a spark dataframe
- writes the dataframe as parquet to the raw zone, in UTF-8 encoding

Updated the `alloy_export_crawler` to crawl the parquet files created above.

Updated [alloy_raw_to_refined.py](https://github.com/LBHackney-IT/Data-Platform/compare/dpp-315-alloy?expand=1#diff-2ffa8a3301f6316127f0863742697cdb6fb9d4e5e487f6246421c95f8b83890f) so that it now creates partitions for the date the files are processed

Disables an unnecessary trigger in pre-production.

Add tests for create_s3_key()
Tested full pipeline on affected files in pre. 