### PR TITLE
DPP-170 Add correct trigger config

### DIFF
--- a/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
+++ b/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
@@ -1,5 +1,5 @@
 locals {
-  glue_trigger_name     = local.is_live_environment ? module.ringgo_sftp_data_to_raw[0].trigger_name : ""
+  ringgo_copy_glue_job__trigger_name     = local.is_live_environment ? module.ringgo_sftp_data_to_raw[0].trigger_name : ""
 }
 
 module "sftp_to_s3_ingestion" {
@@ -31,7 +31,7 @@ module "sftp_to_s3_ingestion" {
     "S3_TARGET_FOLDER"            = "ringgo/sftp/input"
   }
   lambda_execution_cron_schedule  = "cron(0 21 * * ? *)"
-  trigger_to_run                  = local.glue_trigger_name
+  trigger_to_run                  = local.ringgo_copy_glue_job__trigger_name
 }  
 
 data "aws_secretsmanager_secret" "sftp_server_credentials" {

--- a/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
+++ b/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
@@ -1,3 +1,7 @@
+locals {
+  glue_trigger_name     = local.is_live_environment ? module.ringgo_sftp_data_to_raw[0].trigger_name : ""
+}
+
 module "sftp_to_s3_ingestion" {
   count                     = local.is_live_environment ? 1 : 0
   source                    = "../modules/api-ingestion-lambda"
@@ -27,6 +31,7 @@ module "sftp_to_s3_ingestion" {
     "S3_TARGET_FOLDER"            = "ringgo/sftp/input"
   }
   lambda_execution_cron_schedule  = "cron(0 21 * * ? *)"
+  trigger_to_run                  = local.glue_trigger_name
 }  
 
 data "aws_secretsmanager_secret" "sftp_server_credentials" {


### PR DESCRIPTION
Add missing trigger config for the copy landing to raw job. 

This config is required in order for the lambda to start the correct trigger.