### PR TITLE
Spatial enrichment job fixes

### DIFF
--- a/scripts/jobs/unrestricted/spatial_enrichment.py
+++ b/scripts/jobs/unrestricted/spatial_enrichment.py
@@ -148,7 +148,7 @@ def convert_coordinate_columns_to_double(spark_point_df, x_column, y_column):
 if __name__ == "__main__":
 
     args = getResolvedOptions(sys.argv,
-                              ['TempDir', 'JOB_NAME', 'tables_to_enrich_dict_path', 'geography_tables_dict_path'])
+                              ['TempDir', 'JOB_NAME', 'tables_to_enrich_dict_path', 'geography_tables_dict_path', 'target_location'])
 
     sc = SparkContext()
     glueContext = GlueContext(sc)
@@ -278,12 +278,12 @@ if __name__ == "__main__":
         dynamic_frame = DynamicFrame.fromDF(spark_point_df, glueContext, "target_data_to_write")
 
         # Write the data to S3
-        logger.info(f'Now writing  {table_name} enriched records inside {enrich_table["target_location"] + table_name}')
+        logger.info(f'Now writing  {table_name} enriched records inside {args["target_location"] + table_name}')
         parquet_data = glueContext.write_dynamic_frame.from_options(
             frame=dynamic_frame,
             connection_type="s3",
             format="parquet",
-            connection_options={"path": enrich_table["target_location"] + table_name, "partitionKeys": PARTITION_KEYS},
+            connection_options={"path": args["target_location"] + table_name, "partitionKeys": PARTITION_KEYS},
             transformation_ctx=f'target_data_to_write_{table_name}')
 
     job.commit()

--- a/terraform/etl/24-aws-glue-spatial.tf
+++ b/terraform/etl/24-aws-glue-spatial.tf
@@ -67,6 +67,7 @@ module "env_services_geospatial_enrichment" {
   spark_ui_output_storage_id = module.spark_ui_output_storage_data_source.bucket_id
   job_parameters = {
     "--job-bookmark-option"        = "job-bookmark-enable"
+    "--enable-glue-datacatalog"    = "true"
     "--additional-python-modules"  = "rtree,geopandas"
     "--geography_tables_dict_path" = "s3://${module.glue_scripts_data_source.bucket_id}/${aws_s3_bucket_object.geography_tables_dictionary.key}"
     "--tables_to_enrich_dict_path" = "s3://${module.glue_scripts_data_source.bucket_id}/${aws_s3_bucket_object.env_services_spatial_enrichment_dictionary.key}"


### PR DESCRIPTION
- Add missing 'enable glue catalog' option to enrichment job tf module
- Read target bucket from the job parameters instead of from the json dict