### PR TITLE
Enable custom schedule for JDBC ingestion jobs

### DIFF
--- a/terraform/modules/database-ingestion-via-jdbc-connection/02-inputs-optional.tf
+++ b/terraform/modules/database-ingestion-via-jdbc-connection/02-inputs-optional.tf
@@ -9,3 +9,9 @@ variable "create_workflow" {
   type        = bool
   default     = true
 }
+
+variable "job_schedule" {
+  description = "Used to set the schedule for the ingestion job"
+  type        = string
+  default     = "cron(15 0 ? * MON,TUE,WED,THU,FRI *)"
+}

--- a/terraform/modules/database-ingestion-via-jdbc-connection/11-aws-glue-connection-crawler.tf
+++ b/terraform/modules/database-ingestion-via-jdbc-connection/11-aws-glue-connection-crawler.tf
@@ -40,7 +40,7 @@ resource "aws_glue_trigger" "ingestion_crawler" {
 
   name          = "${var.identifier_prefix}${var.name}"
   type          = "SCHEDULED"
-  schedule      = "cron(15 0 ? * MON,TUE,WED,THU,FRI *)"
+  schedule      = var.job_schedule
   workflow_name = local.workflow_name
 
   actions {


### PR DESCRIPTION
Currently all JDBC ingestion jobs are scheduled to run at the same time. This update enables each job to set their custom schedule if necessary.

Hard coded cron schedule in the trigger that starts the ingestion job has been replaced with a variable value. Default value for the variable has been set to be the same as the previous hard coded value to ensure existing setups won't be affected.