### PR TITLE
Glue trigger timeouts

### DIFF
--- a/terraform/etl/25-alloy-etl-env-services.tf
+++ b/terraform/etl/25-alloy-etl-env-services.tf
@@ -17,6 +17,10 @@ resource "aws_glue_trigger" "alloy_daily_export" {
   actions {
     job_name = module.alloy_api_export_raw_env_services[count.index].job_name
   }
+
+  timeouts {
+    delete = "15m"
+  }
 }
 
 module "alloy_api_export_raw_env_services" {
@@ -64,6 +68,10 @@ resource "aws_glue_trigger" "alloy_export_crawler" {
       job_name = module.alloy_api_export_raw_env_services[count.index].job_name
       state    = "SUCCEEDED"
     }
+  }
+
+  timeouts {
+    delete = "15m"
   }
 }
 
@@ -138,6 +146,10 @@ resource "aws_glue_trigger" "alloy_refined_crawler" {
       job_name = module.alloy_raw_to_refined_env_services[count.index].job_name
       state    = "SUCCEEDED"
     }
+  }
+
+  timeouts {
+    delete = "15m"
   }
 }
 

--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1090,7 +1090,7 @@ module "parking_defect_met_fail" {
   script_name                    = "parking_defect_met_fail"
   glue_version                   = "3.0"
   #triggered_by_job              = "${local.short_identifier_prefix}parking_correspondence_performance_records_with_pcn"
-  triggered_by_crawler           = module.parking_spreadsheet_parking_ops_db_defects_mgt[0].crawler_name.value
+  triggered_by_crawler           = module.parking_spreadsheet_parking_ops_db_defects_mgt[0].crawler_name
   job_description                = "To collect and format the Ops Defect Data."
   trigger_enabled                = local.is_production_environment
   glue_job_timeout               = 10

--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1090,7 +1090,7 @@ module "parking_defect_met_fail" {
   script_name                    = "parking_defect_met_fail"
   glue_version                   = "3.0"
   #triggered_by_job              = "${local.short_identifier_prefix}parking_correspondence_performance_records_with_pcn"
-  triggered_by_crawler           = module.parking_spreadsheet_parking_ops_db_defects_mgt.crawler_name.value
+  triggered_by_crawler           = module.parking_spreadsheet_parking_ops_db_defects_mgt[0].crawler_name.value
   job_description                = "To collect and format the Ops Defect Data."
   trigger_enabled                = local.is_production_environment
   glue_job_timeout               = 10

--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1090,7 +1090,7 @@ module "parking_defect_met_fail" {
   script_name                    = "parking_defect_met_fail"
   glue_version                   = "3.0"
   #triggered_by_job              = "${local.short_identifier_prefix}parking_correspondence_performance_records_with_pcn"
-  triggered_by_crawler           = "google-sheets-import-job-parking-parking-ops-db-defects-mgt"
+  triggered_by_crawler           = module.parking_spreadsheet_parking_ops_db_defects_mgt.crawler_name.value
   job_description                = "To collect and format the Ops Defect Data."
   trigger_enabled                = local.is_production_environment
   glue_job_timeout               = 10


### PR DESCRIPTION
Adds delete timeout parameters to aws_glue_trigger resources because apply was failing to complete with the default 5 mins. 