### PR TITLE
DPP-335 lock runner version down to ubuntu 20.04

### DIFF
--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -74,7 +74,7 @@ on:
 jobs:
   deploy:
     name: Terraform Apply
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout Source

--- a/.github/workflows/deploy_terraform_networking.yml
+++ b/.github/workflows/deploy_terraform_networking.yml
@@ -69,7 +69,7 @@ on:
 jobs:
   deploy:
     name: Terraform Apply
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout Source

--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -64,7 +64,7 @@ on:
 jobs:
   lint:
     name: Terraform Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -64,7 +64,7 @@ on:
 jobs:
   plan:
     name: Terraform Plan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: terraform-compliance/github_action@main
 

--- a/.github/workflows/test-python-and-lambda.yml
+++ b/.github/workflows/test-python-and-lambda.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   tests:
     name: Test Python Jobs & Lambda Functions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unlock_terraform_state.yml
+++ b/.github/workflows/unlock_terraform_state.yml
@@ -77,7 +77,7 @@ on:
 jobs:
   deploy:
     name: Terraform State Unlock
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2

--- a/.github/workflows/validate-and-lint-terraform.yml
+++ b/.github/workflows/validate-and-lint-terraform.yml
@@ -64,7 +64,7 @@ on:
 jobs:
   validate:
     name: Terraform Validate
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +102,7 @@ jobs:
 
   lint:
     name: Terraform Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
`ubuntu-latest` runner image was upgraded to Ubuntu 22.04 recently which meant the default python version was also upgraded from 3.8 to 3.10. This caused some failures with our venv setups, so we need to revert back to Ubuntu version 20.04 until we are ready to upgrade everything to use Python 3.10  