### PR TITLE
DPP-96 update Qlik EC2 role on pre prod

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -33,31 +33,29 @@ resource "aws_secretsmanager_secret_version" "production_account_qlik_ec2_ebs_en
   secret_string = "TODO" #value managed manually
 }
 
-data "aws_iam_policy_document" "qlik_sense_shared_prod_key_policy" {
-    count = !var.is_production_environment && var.is_live_environment ? 1 : 0
-    
-    statement {
-      sid     = "AllowQlikEC2RoleAccessToTheSharedProdKey"
-      effect  = "Allow"
-      
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey"
-      ]
-
-      resources = [aws_secretsmanager_secret_version.production_account_qlik_ec2_ebs_encryption_key_arn[0].secret_string]
-    }
-}
-
 resource "aws_iam_policy" "qlik_sense_preprod_can_access_shared_prod_key" {
   count     = !var.is_production_environment && var.is_live_environment ? 1 : 0
   tags      = var.tags
 
   name      = "${var.identifier_prefix}-qlik-sense-preprod-role-can-access-shared-prod-key"
-  policy    = data.aws_iam_policy_document.qlik_sense_shared_prod_key_policy[0].json
+
+  policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Sid    = "AllowQlikEC2RoleAccessToTheSharedProdKey"
+          Action = [
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+            "kms:DescribeKey"
+          ]
+          Effect   = "Allow"
+          Resource = [aws_secretsmanager_secret_version.production_account_qlik_ec2_ebs_encryption_key_arn[0].secret_string]
+        }
+      ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "qlik_sense_prod_key_policy" {

--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -32,3 +32,36 @@ resource "aws_secretsmanager_secret_version" "production_account_qlik_ec2_ebs_en
   secret_id     = aws_secretsmanager_secret.production_account_qlik_ec2_ebs_encryption_key_arn[0].id
   secret_string = "TODO" #value managed manually
 }
+
+data "aws_iam_policy_document" "qlik_sense_shared_prod_key_policy" {
+    count = !var.is_production_environment && var.is_live_environment ? 1 : 0
+    
+    statement {
+      sid     = "AllowQlikEC2RoleAccessToTheSharedProdKey"
+      effect  = "Allow"
+      
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+
+      resources = [aws_secretsmanager_secret_version.production_account_qlik_ec2_ebs_encryption_key_arn[0].secret_string]
+    }
+}
+
+resource "aws_iam_policy" "qlik_sense_preprod_can_access_shared_prod_key" {
+  count     = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  tags      = var.tags
+
+  name      = "${var.identifier_prefix}-qlik-sense-preprod-role-can-access-shared-prod-key"
+  policy    = data.aws_iam_policy_document.qlik_sense_shared_prod_key_policy[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "qlik_sense_prod_key_policy" {
+  count         = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  role          = aws_iam_role.qlik_sense.id
+  policy_arn    = aws_iam_policy.qlik_sense_preprod_can_access_shared_prod_key[0].arn
+}


### PR DESCRIPTION
Update the role used by the Qlik EC2 instance on pre-prod to have access to the shared EBS encryption key on prod.

This is required for the initial restore of the AMI backup from prod to pre-prod.

This policy will be removed in later PR once the new instance has been fully configured on pre-prod.