### PR TITLE
DPP-96 Update key policy to allow access from pre-prod

### DIFF
--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -115,6 +115,32 @@ data "aws_iam_policy_document" "key_policy" {
       identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
   }
+
+  dynamic statement {
+    for_each = var.is_production_environment ? [1] : [] 
+    
+    content {
+      sid =  "AllowPreProdEC2RoleAccessToThisKey"
+      effect = "Allow"
+      
+      principals {
+        type = "AWS"
+        identifiers = [data.aws_secretsmanager_secret_version.qlik_sense_ec2_role_arn_on_pre_prod_account[0].secret_string]
+      }
+
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
+  }
 }
 
 resource "aws_kms_key" "key" {

--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -73,3 +73,13 @@ resource "aws_iam_role_policy_attachment" "qlik_sense_prod_key_policy" {
   role          = aws_iam_role.qlik_sense.id
   policy_arn    = aws_iam_policy.qlik_sense_preprod_can_access_shared_prod_key[0].arn
 }
+
+data "aws_secretsmanager_secret" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
+  count = var.is_production_environment ? 1 : 0
+  name  = "${var.identifier_prefix}-manually-managed-value-qlik-sense-ec2-role-arn-on-pre-prod-account"
+}
+
+data "aws_secretsmanager_secret_version" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
+  count     = var.is_production_environment ? 1 : 0
+  secret_id = data.aws_secretsmanager_secret.qlik_sense_ec2_role_arn_on_pre_prod_account[0].id
+}


### PR DESCRIPTION
Give pre-prod EC2 role access to the EBS key on prod.