### PR TITLE
DPP 332 Glue Failure Notifications in GChat

### DIFF
--- a/lambdas/glue_failure_gchat_notifications/Makefile
+++ b/lambdas/glue_failure_gchat_notifications/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install-requirements
+
+install-requirements:
+	python3 -m venv venv
+	# the requirements are generated so that the packages
+	# could be downloaded and packaged up for the lambda
+
+	. venv/bin/activate && sudo pipenv lock --requirements > requirements.txt
+	. venv/bin/activate && sudo pip install --target ./lib -r requirements.txt
+	rm -rf venv/

--- a/lambdas/glue_failure_gchat_notifications/Pipfile
+++ b/lambdas/glue_failure_gchat_notifications/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+urllib3 = "*"
+python-dotenv = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3"

--- a/lambdas/glue_failure_gchat_notifications/Pipfile.lock
+++ b/lambdas/glue_failure_gchat_notifications/Pipfile.lock
@@ -1,0 +1,37 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ddb45df78ca34b7746d2fb76f5a3670baa36c51af655d2149a2a80e6765dd4c8"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "python-dotenv": {
+            "hashes": [
+                "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5",
+                "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"
+            ],
+            "index": "pypi",
+            "version": "==0.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
+            ],
+            "index": "pypi",
+            "version": "==1.26.13"
+        }
+    },
+    "develop": {}
+}

--- a/lambdas/glue_failure_gchat_notifications/main.py
+++ b/lambdas/glue_failure_gchat_notifications/main.py
@@ -24,7 +24,7 @@ def format_message(event) -> dict:
 
 def lambda_handler(event=None, lambda_context=None, secretsManagerClient=None):
     secret_name = getenv("SECRET_NAME")
-    secrets_manager_client = boto3.client("secretsmanager")
+    secrets_manager_client = secretsManagerClient or boto3.client("secretsmanager")
 
     secret = secrets_manager_client.get_secret_value(SecretId=secret_name)
 

--- a/lambdas/glue_failure_gchat_notifications/main.py
+++ b/lambdas/glue_failure_gchat_notifications/main.py
@@ -1,0 +1,42 @@
+import json
+import logging
+from os import getenv
+
+import boto3
+import urllib3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def format_message(event) -> dict:
+    timestamp = event["time"]
+    job_name = event["detail"]["jobName"]
+    job_run_id = event["detail"]["jobRunId"]
+    error_message = event["detail"]["message"]
+    return {
+        "text": (
+            f"{timestamp} Glue failure detected for job: {job_name} run id:"
+            f" {job_run_id} Error message: {error_message}"
+        )
+    }
+
+
+def lambda_handler(event=None, lambda_context=None, secretsManagerClient=None):
+    secret_name = getenv("SECRET_NAME")
+    secrets_manager_client = boto3.client("secretsmanager")
+
+    secret = secrets_manager_client.get_secret_value(SecretId=secret_name)
+
+    webhook_url = secret["SecretString"]
+    message = format_message(event)
+    message_headers = {"Content-Type": "application/json; charset=UTF-8"}
+    http = urllib3.PoolManager()
+
+    http.request("POST", webhook_url, body=json.dumps(message), headers=message_headers)
+
+    logger.info("Alert sent successfully")
+
+
+if __name__ == "__main__":
+    lambda_handler("event", "lambda_context")

--- a/lambdas/glue_failure_gchat_notifications/test.py
+++ b/lambdas/glue_failure_gchat_notifications/test.py
@@ -1,94 +1,107 @@
-from unittest import TestCase, mock
-from lambda_alarms_handler.main import lambda_handler, format_message
 import os
-import botocore.session
-from botocore.stub import Stubber
 from datetime import datetime
 from json import dumps
+from unittest import TestCase, mock
 
-class TestLambdaAlarmsHandler(TestCase):
-    
+import botocore.session
+from botocore.stub import Stubber
+from glue_alarms_handler.main import format_message, lambda_handler
+
+
+class TestGlueAlarmsHandler(TestCase):
     mock_env_vars = {"SECRET_NAME": "test_secret_name"}
 
     def setUp(self):
         self.boto_session = botocore.session.get_session()
         self.boto_session.set_credentials("", "")
-        self.secretsmanager_client = self.boto_session.create_client('secretsmanager', region_name='test-region-2')
+        self.secretsmanager_client = self.boto_session.create_client(
+            "secretsmanager", region_name="test-region-2"
+        )
         self.secretsmanager_client_stubber = Stubber(self.secretsmanager_client)
 
-        self.secret = 'secret_string_abc'
+        self.secret = "secret_string_abc"
 
         self.response = {
-            'ARN': 'arn:aws:secretsmanager:eu-west-2:111111111:secret:secret-key',
-            'Name': 'string',
-            'VersionId': 'version_one_secret_name_11111111:version_one',
-            'SecretBinary': b'bytes',
-            'SecretString': self.secret,
-            'VersionStages': [
-                'string',
+            "ARN": "arn:aws:secretsmanager:eu-west-2:111111111:secret:secret-key",
+            "Name": "string",
+            "VersionId": "version_one_secret_name_11111111:version_one",
+            "SecretBinary": b"bytes",
+            "SecretString": self.secret,
+            "VersionStages": [
+                "string",
             ],
-            'CreatedDate': datetime(2022, 1, 1)
+            "CreatedDate": datetime(2022, 1, 1),
         }
 
-        self.sns_event = {
-            "Records": [
-                {
-                "EventVersion": "1.0", 
-                "EventSubscriptionArn": "arn:aws:sns:lambda-failure", 
-                "EventSource": "aws:sns", 
-                "Sns": {
-                    "Signature": "EXAMPLE", 
-                    "MessageId": "108e2d6c-34a8-50ef-a9b6-716bd21412d2", 
-                    "Type": "Notification", 
-                    "TopicArn": "arn:aws:sns:laambda-failure-notification", 
-                    "MessageAttributes": {}, 
-                    "SignatureVersion": "1", 
-                    "Timestamp": "2015-06-03T17:43:27.123Z", 
-                    "SigningCertUrl": "EXAMPLE", 
-                    "Message": "Sample alert", 
-                    "UnsubscribeUrl": "EXAMPLE", 
-                    "Subject": "LambdaAlarm"
-                }
-                }
-            ]
+        self.cloudwatch_event = {
+            "version": "0",
+            "id": "test_id",
+            "detail-type": "Glue Job State Change",
+            "source": "aws.glue",
+            "account": "test_account",
+            "time": "2023-01-11T13:51:06Z",
+            "region": "test-region-2",
+            "resources": [],
+            "detail": {
+                "jobName": "test_job_name",
+                "severity": "ERROR",
+                "state": "FAILED",
+                "jobRunId": "test_run_id123",
+                "message": "An error occurred while running the job.",
+            },
         }
 
-        self.secret_name = "test_secret_name"       
+        self.secret_name = "test_secret_name"
 
     @mock.patch.dict(os.environ, mock_env_vars)
-    @mock.patch('urllib3.PoolManager', spec=True)
-    def test_calls_get_secret_value_on_secret_manager_client_with_correct_secret_name(self, mock_urllib_poolmanager):
-        expected_params = {'SecretId': self.secret_name}
-        self.secretsmanager_client_stubber.add_response('get_secret_value', self.response, expected_params)
-        self.secretsmanager_client_stubber.activate()
-       
-        lambda_handler(event=self.sns_event, secretsManagerClient=self.secretsmanager_client)
-        
-        self.secretsmanager_client_stubber.assert_no_pending_responses()
-    
-    def test_format_message_creates_a_message_in_correct_format_based_on_sns_event_content(self):
-        expected_message = {
-            'text': "2015-06-03T17:43:27.123Z Lambda failure detected: LambdaAlarm"
-        }
-
-        formatted_message = format_message(self.sns_event)
-        self.assertEqual(expected_message, formatted_message)
-
-    @mock.patch.dict(os.environ, mock_env_vars)
-    @mock.patch('lambda_alarms_handler.main.urllib3.PoolManager', spec=True)
-    def test_calls_poolmanager_on_urllib3_with_correct_params(self, mock_urllib_poolmanager):
-        expected_headers = {'Content-Type': 'application/json; charset=UTF-8'}
-        mock_pool_manager = mock_urllib_poolmanager.return_value
-
-        self.secretsmanager_client_stubber.add_response('get_secret_value', self.response)
+    @mock.patch("urllib3.PoolManager", spec=True)
+    def test_calls_get_secret_value_on_secret_manager_client_with_correct_secret_name(
+        self, mock_urllib_poolmanager
+    ):
+        expected_params = {"SecretId": self.secret_name}
+        self.secretsmanager_client_stubber.add_response(
+            "get_secret_value", self.response, expected_params
+        )
         self.secretsmanager_client_stubber.activate()
 
-        lambda_handler(event=self.sns_event, secretsManagerClient=self.secretsmanager_client)
-
-        mock_pool_manager.request.assert_called_once_with(
-            'POST', 
-            self.secret, 
-            body=dumps(format_message(self.sns_event)), 
-            headers=expected_headers
+        lambda_handler(
+            self.cloudwatch_event, secretsmanager_client=self.secretsmanager_client
         )
 
+        self.secretsmanager_client_stubber.assert_no_pending_responses()
+
+    def test_format_message_returns_correct_message(self):
+        expected_message = {
+            "text": (
+                "2023-01-11T13:51:06Z Glue failure detected for job: test_job_name run"
+                " id: test_run_id123 Error message: An error occurred while running the"
+                " job."
+            )
+        }
+        actual_message = format_message(self.cloudwatch_event)
+
+        self.assertEqual(expected_message, actual_message)
+
+    @mock.patch.dict(os.environ, mock_env_vars)
+    @mock.patch("lambda_alarms_handler.main.urllib3.PoolManager", spec=True)
+    def test_calls_poolmanager_on_urllib3_with_correct_params(
+        self, mock_urllib_poolmanager
+    ):
+        expected_headers = {"Content-Type": "application/json; charset=UTF-8"}
+        mock_pool_manager = mock_urllib_poolmanager.return_value
+
+        self.secretsmanager_client_stubber.add_response(
+            "get_secret_value", self.response
+        )
+        self.secretsmanager_client_stubber.activate()
+
+        lambda_handler(
+            event=self.sns_event, secretsManagerClient=self.secretsmanager_client
+        )
+
+        mock_pool_manager.request.assert_called_once_with(
+            "POST",
+            self.secret,
+            body=dumps(format_message(self.sns_event)),
+            headers=expected_headers,
+        )

--- a/lambdas/glue_failure_gchat_notifications/test.py
+++ b/lambdas/glue_failure_gchat_notifications/test.py
@@ -5,7 +5,7 @@ from unittest import TestCase, mock
 
 import botocore.session
 from botocore.stub import Stubber
-from glue_alarms_handler.main import format_message, lambda_handler
+from glue_failure_gchat_notifications.main import format_message, lambda_handler
 
 
 class TestGlueAlarmsHandler(TestCase):
@@ -65,7 +65,7 @@ class TestGlueAlarmsHandler(TestCase):
         self.secretsmanager_client_stubber.activate()
 
         lambda_handler(
-            self.cloudwatch_event, secretsmanager_client=self.secretsmanager_client
+            self.cloudwatch_event, secretsManagerClient=self.secretsmanager_client
         )
 
         self.secretsmanager_client_stubber.assert_no_pending_responses()
@@ -96,12 +96,12 @@ class TestGlueAlarmsHandler(TestCase):
         self.secretsmanager_client_stubber.activate()
 
         lambda_handler(
-            event=self.sns_event, secretsManagerClient=self.secretsmanager_client
+            event=self.cloudwatch_event, secretsManagerClient=self.secretsmanager_client
         )
 
         mock_pool_manager.request.assert_called_once_with(
             "POST",
             self.secret,
-            body=dumps(format_message(self.sns_event)),
+            body=dumps(format_message(self.cloudwatch_event)),
             headers=expected_headers,
         )

--- a/lambdas/glue_failure_gchat_notifications/test.py
+++ b/lambdas/glue_failure_gchat_notifications/test.py
@@ -1,0 +1,94 @@
+from unittest import TestCase, mock
+from lambda_alarms_handler.main import lambda_handler, format_message
+import os
+import botocore.session
+from botocore.stub import Stubber
+from datetime import datetime
+from json import dumps
+
+class TestLambdaAlarmsHandler(TestCase):
+    
+    mock_env_vars = {"SECRET_NAME": "test_secret_name"}
+
+    def setUp(self):
+        self.boto_session = botocore.session.get_session()
+        self.boto_session.set_credentials("", "")
+        self.secretsmanager_client = self.boto_session.create_client('secretsmanager', region_name='test-region-2')
+        self.secretsmanager_client_stubber = Stubber(self.secretsmanager_client)
+
+        self.secret = 'secret_string_abc'
+
+        self.response = {
+            'ARN': 'arn:aws:secretsmanager:eu-west-2:111111111:secret:secret-key',
+            'Name': 'string',
+            'VersionId': 'version_one_secret_name_11111111:version_one',
+            'SecretBinary': b'bytes',
+            'SecretString': self.secret,
+            'VersionStages': [
+                'string',
+            ],
+            'CreatedDate': datetime(2022, 1, 1)
+        }
+
+        self.sns_event = {
+            "Records": [
+                {
+                "EventVersion": "1.0", 
+                "EventSubscriptionArn": "arn:aws:sns:lambda-failure", 
+                "EventSource": "aws:sns", 
+                "Sns": {
+                    "Signature": "EXAMPLE", 
+                    "MessageId": "108e2d6c-34a8-50ef-a9b6-716bd21412d2", 
+                    "Type": "Notification", 
+                    "TopicArn": "arn:aws:sns:laambda-failure-notification", 
+                    "MessageAttributes": {}, 
+                    "SignatureVersion": "1", 
+                    "Timestamp": "2015-06-03T17:43:27.123Z", 
+                    "SigningCertUrl": "EXAMPLE", 
+                    "Message": "Sample alert", 
+                    "UnsubscribeUrl": "EXAMPLE", 
+                    "Subject": "LambdaAlarm"
+                }
+                }
+            ]
+        }
+
+        self.secret_name = "test_secret_name"       
+
+    @mock.patch.dict(os.environ, mock_env_vars)
+    @mock.patch('urllib3.PoolManager', spec=True)
+    def test_calls_get_secret_value_on_secret_manager_client_with_correct_secret_name(self, mock_urllib_poolmanager):
+        expected_params = {'SecretId': self.secret_name}
+        self.secretsmanager_client_stubber.add_response('get_secret_value', self.response, expected_params)
+        self.secretsmanager_client_stubber.activate()
+       
+        lambda_handler(event=self.sns_event, secretsManagerClient=self.secretsmanager_client)
+        
+        self.secretsmanager_client_stubber.assert_no_pending_responses()
+    
+    def test_format_message_creates_a_message_in_correct_format_based_on_sns_event_content(self):
+        expected_message = {
+            'text': "2015-06-03T17:43:27.123Z Lambda failure detected: LambdaAlarm"
+        }
+
+        formatted_message = format_message(self.sns_event)
+        self.assertEqual(expected_message, formatted_message)
+
+    @mock.patch.dict(os.environ, mock_env_vars)
+    @mock.patch('lambda_alarms_handler.main.urllib3.PoolManager', spec=True)
+    def test_calls_poolmanager_on_urllib3_with_correct_params(self, mock_urllib_poolmanager):
+        expected_headers = {'Content-Type': 'application/json; charset=UTF-8'}
+        mock_pool_manager = mock_urllib_poolmanager.return_value
+
+        self.secretsmanager_client_stubber.add_response('get_secret_value', self.response)
+        self.secretsmanager_client_stubber.activate()
+
+        lambda_handler(event=self.sns_event, secretsManagerClient=self.secretsmanager_client)
+
+        mock_pool_manager.request.assert_called_once_with(
+            'POST', 
+            self.secret, 
+            body=dumps(format_message(self.sns_event)), 
+            headers=expected_headers
+        )
+


### PR DESCRIPTION
## Link to JIRA ticket

[DPP-332](https://hackney.atlassian.net/browse/DPP-332)

## Describe this PR

### *What is the problem we're trying to solve*

Alerting for Glue job failures currently generates an email notification, the team feels these emails are not the best way of communicating these alerts and a Google Chat group would facilitate better visibility and collaboration addressing failures.  

### *What changes have we introduced*

This branch adds a lambda that is targeted by the existing Cloudwatch event for Glue failures and will publish details of the failure from that event to a Google Chat group. 

Updates include:

- a new lambda for handling the Cloudwatch event and sending notifications to a Google Chat group
- additional target for the Cloudwatch event to trigger the Lambda
- creation of a new IAM role to run the Lambda and permissions for that role to read the webhook address from Secrets Manager

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Give users permissions to Google space, so they can see the alarms

[DPP-332]: https://hackney.atlassian.net/browse/DPP-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ