### PR TITLE
DPP-96 Add EC2 Qlik instance for pre-prod - PLEASE DO NOT MERGE WITHOUT APPROVAL FROM DC & TK

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -1,5 +1,9 @@
 locals {
     backup_ami_id = "ami-050960cc7acbe15d9"
+    ec2_tags = {
+        BackupPolicy  = title(var.environment)
+        Name          = "${var.identifier_prefix}-qlik-sense-restore"
+    }
 }
 
 data "aws_secretsmanager_secret" "pre_production_account_id" {
@@ -82,4 +86,46 @@ data "aws_secretsmanager_secret" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
 data "aws_secretsmanager_secret_version" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
   count     = var.is_production_environment ? 1 : 0
   secret_id = data.aws_secretsmanager_secret.qlik_sense_ec2_role_arn_on_pre_prod_account[0].id
+}
+
+#manually added/managed value
+data "aws_secretsmanager_secret" "subnet_value_for_qlik_sense_pre_prod_instance" {
+  count = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  name  = "${var.identifier_prefix}-manually-managed-value-subnet-value-for-qlik-sense-restore-pre-prod-instance"
+}
+
+data "aws_secretsmanager_secret_version" "subnet_value_for_qlik_sense_pre_prod_instance" {
+  count     = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  secret_id = data.aws_secretsmanager_secret.subnet_value_for_qlik_sense_pre_prod_instance[0].id
+}
+
+resource "aws_instance" "qlik_sense_pre_prod_instance" {
+  count                     = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  ami                       = local.backup_ami_id
+  instance_type             = "c5.4xlarge"
+  subnet_id                 = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
+  vpc_security_group_ids    = [aws_security_group.qlik_sense.id]
+  
+  private_dns_name_options {
+    enable_resource_name_dns_a_record = true
+  }
+
+  iam_instance_profile        = aws_iam_instance_profile.qlik_sense.id
+  disable_api_termination     = true
+  key_name                    = aws_key_pair.qlik_sense_server_key.key_name
+  tags                        = merge(var.tags, local.ec2_tags)
+  associate_public_ip_address = false
+
+  root_block_device {
+    encrypted               = true
+    delete_on_termination   = false
+    kms_key_id              = data.aws_secretsmanager_secret_version.production_account_qlik_ec2_ebs_encryption_key_arn[0].secret_string
+    tags                    = merge(var.tags, local.ec2_tags)
+    volume_size             = 1000
+    volume_type             = "gp3"
+  }
+  
+  lifecycle {
+    ignore_changes = [ami, subnet_id]
+  }
 }


### PR DESCRIPTION
This update deploys a new EC2 Qlik instance on pre-prod. The instance is based on the specific backup AMI from prod account. By using the backup AMI we can ensure the software setup is identical in both environments.

This is just one time setup though, so the sofware will be in sync only briefly and both environments can then be managed individually moving forward.