### PR TITLE
DPP-332 Glue failure notifications module

### DIFF
--- a/lambdas/glue_failure_gchat_notifications/Makefile
+++ b/lambdas/glue_failure_gchat_notifications/Makefile
@@ -1,0 +1,10 @@
+.PHONY: install-requirements
+
+install-requirements:
+	python3 -m venv venv
+	# the requirements are generated so that the packages
+	# could be downloaded and packaged up for the lambda
+
+	. venv/bin/activate && sudo pipenv lock --requirements > requirements.txt
+	. venv/bin/activate && sudo pip install --target ./lib -r requirements.txt
+	rm -rf venv/

--- a/lambdas/glue_failure_gchat_notifications/Pipfile
+++ b/lambdas/glue_failure_gchat_notifications/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+urllib3 = "*"
+python-dotenv = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3"

--- a/lambdas/glue_failure_gchat_notifications/Pipfile.lock
+++ b/lambdas/glue_failure_gchat_notifications/Pipfile.lock
@@ -1,0 +1,37 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "ddb45df78ca34b7746d2fb76f5a3670baa36c51af655d2149a2a80e6765dd4c8"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "python-dotenv": {
+            "hashes": [
+                "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5",
+                "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"
+            ],
+            "index": "pypi",
+            "version": "==0.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
+                "sha256:c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8"
+            ],
+            "index": "pypi",
+            "version": "==1.26.13"
+        }
+    },
+    "develop": {}
+}

--- a/lambdas/glue_failure_gchat_notifications/main.py
+++ b/lambdas/glue_failure_gchat_notifications/main.py
@@ -1,0 +1,42 @@
+import json
+import logging
+from os import getenv
+
+import boto3
+import urllib3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def format_message(event) -> dict:
+    timestamp = event["time"]
+    job_name = event["detail"]["jobName"]
+    job_run_id = event["detail"]["jobRunId"]
+    error_message = event["detail"]["message"]
+    return {
+        "text": (
+            f"{timestamp} Glue failure detected for job: {job_name} run id:"
+            f" {job_run_id} Error message: {error_message}"
+        )
+    }
+
+
+def lambda_handler(event=None, lambda_context=None, secretsManagerClient=None):
+    secret_name = getenv("SECRET_NAME")
+    secrets_manager_client = secretsManagerClient or boto3.client("secretsmanager")
+
+    secret = secrets_manager_client.get_secret_value(SecretId=secret_name)
+
+    webhook_url = secret["SecretString"]
+    message = format_message(event)
+    message_headers = {"Content-Type": "application/json; charset=UTF-8"}
+    http = urllib3.PoolManager()
+
+    http.request("POST", webhook_url, body=json.dumps(message), headers=message_headers)
+
+    logger.info("Alert sent successfully")
+
+
+if __name__ == "__main__":
+    lambda_handler("event", "lambda_context")

--- a/lambdas/glue_failure_gchat_notifications/test.py
+++ b/lambdas/glue_failure_gchat_notifications/test.py
@@ -1,0 +1,107 @@
+import os
+from datetime import datetime
+from json import dumps
+from unittest import TestCase, mock
+
+import botocore.session
+from botocore.stub import Stubber
+from glue_failure_gchat_notifications.main import format_message, lambda_handler
+
+
+class TestGlueAlarmsHandler(TestCase):
+    mock_env_vars = {"SECRET_NAME": "test_secret_name"}
+
+    def setUp(self):
+        self.boto_session = botocore.session.get_session()
+        self.boto_session.set_credentials("", "")
+        self.secretsmanager_client = self.boto_session.create_client(
+            "secretsmanager", region_name="test-region-2"
+        )
+        self.secretsmanager_client_stubber = Stubber(self.secretsmanager_client)
+
+        self.secret = "secret_string_abc"
+
+        self.response = {
+            "ARN": "arn:aws:secretsmanager:eu-west-2:111111111:secret:secret-key",
+            "Name": "string",
+            "VersionId": "version_one_secret_name_11111111:version_one",
+            "SecretBinary": b"bytes",
+            "SecretString": self.secret,
+            "VersionStages": [
+                "string",
+            ],
+            "CreatedDate": datetime(2022, 1, 1),
+        }
+
+        self.cloudwatch_event = {
+            "version": "0",
+            "id": "test_id",
+            "detail-type": "Glue Job State Change",
+            "source": "aws.glue",
+            "account": "test_account",
+            "time": "2023-01-11T13:51:06Z",
+            "region": "test-region-2",
+            "resources": [],
+            "detail": {
+                "jobName": "test_job_name",
+                "severity": "ERROR",
+                "state": "FAILED",
+                "jobRunId": "test_run_id123",
+                "message": "An error occurred while running the job.",
+            },
+        }
+
+        self.secret_name = "test_secret_name"
+
+    @mock.patch.dict(os.environ, mock_env_vars)
+    @mock.patch("urllib3.PoolManager", spec=True)
+    def test_calls_get_secret_value_on_secret_manager_client_with_correct_secret_name(
+        self, mock_urllib_poolmanager
+    ):
+        expected_params = {"SecretId": self.secret_name}
+        self.secretsmanager_client_stubber.add_response(
+            "get_secret_value", self.response, expected_params
+        )
+        self.secretsmanager_client_stubber.activate()
+
+        lambda_handler(
+            self.cloudwatch_event, secretsManagerClient=self.secretsmanager_client
+        )
+
+        self.secretsmanager_client_stubber.assert_no_pending_responses()
+
+    def test_format_message_returns_correct_message(self):
+        expected_message = {
+            "text": (
+                "2023-01-11T13:51:06Z Glue failure detected for job: test_job_name run"
+                " id: test_run_id123 Error message: An error occurred while running the"
+                " job."
+            )
+        }
+        actual_message = format_message(self.cloudwatch_event)
+
+        self.assertEqual(expected_message, actual_message)
+
+    @mock.patch.dict(os.environ, mock_env_vars)
+    @mock.patch("lambda_alarms_handler.main.urllib3.PoolManager", spec=True)
+    def test_calls_poolmanager_on_urllib3_with_correct_params(
+        self, mock_urllib_poolmanager
+    ):
+        expected_headers = {"Content-Type": "application/json; charset=UTF-8"}
+        mock_pool_manager = mock_urllib_poolmanager.return_value
+
+        self.secretsmanager_client_stubber.add_response(
+            "get_secret_value", self.response
+        )
+        self.secretsmanager_client_stubber.activate()
+
+        lambda_handler(
+            event=self.cloudwatch_event, secretsManagerClient=self.secretsmanager_client
+        )
+
+        mock_pool_manager.request.assert_called_once_with(
+            "POST",
+            self.secret,
+            body=dumps(format_message(self.cloudwatch_event)),
+            headers=expected_headers,
+        )

--- a/terraform/core/28-glue-gchat-failure-notification.tf
+++ b/terraform/core/28-glue-gchat-failure-notification.tf
@@ -1,0 +1,32 @@
+locals {
+  glue_failure_cloudwatch_event_pattern = {
+    "source" : [
+      "aws.glue"
+    ],
+    "detail-type" : [
+      "Glue Job State Change"
+    ],
+    "detail" : {
+      "state" : [
+        "FAILED"
+      ]
+    }
+  }
+}
+
+module "glue-failure-alert-notifications" {
+  count                          = !local.is_live_environment ? 1 : 0
+  source                         = "../modules/glue-failure-alert-notifications"
+  tags                           = module.tags.values
+  identifier_prefix              = local.short_identifier_prefix
+  lambda_name                    = "glue-failure-gchat-notifications"
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+  cloudwatch_event_pattern       = jsonencode(local.glue_failure_cloudwatch_event_pattern)
+
+  secret_name             = "${local.short_identifier_prefix}glue-failure-gchat-webhook-url"
+  secrets_manager_kms_key = aws_kms_key.secrets_manager_key
+
+  lambda_environment_variables = {
+    "SECRET_NAME" = "${local.short_identifier_prefix}glue-failure-gchat-webhook-url"
+  }
+}

--- a/terraform/core/28-glue-gchat-failure-notification.tf
+++ b/terraform/core/28-glue-gchat-failure-notification.tf
@@ -15,7 +15,7 @@ locals {
 }
 
 module "glue-failure-alert-notifications" {
-  count                          = !local.is_live_environment ? 1 : 0
+  count                          = local.is_production_environment ? 1 : 0
   source                         = "../modules/glue-failure-alert-notifications"
   tags                           = module.tags.values
   identifier_prefix              = local.short_identifier_prefix

--- a/terraform/modules/glue-failure-alert-notifications/00-init.tf
+++ b/terraform/modules/glue-failure-alert-notifications/00-init.tf
@@ -1,0 +1,14 @@
+/* This defines the configuration of Terraform and AWS required Terraform Providers.
+   As this is a module, we don't have any explicity Provider blocks declared, as these
+   will be inherited from the parent Terraform.
+*/
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/modules/glue-failure-alert-notifications/01-inputs-required.tf
+++ b/terraform/modules/glue-failure-alert-notifications/01-inputs-required.tf
@@ -1,0 +1,38 @@
+variable "tags" {
+  description = "AWS tags"
+  type        = map(string)
+}
+
+variable "identifier_prefix" {
+  description = "Project wide resource identifier prefix"
+  type        = string
+}
+
+variable "lambda_name" {
+  description = "Name of the lambda"
+  type        = string
+}
+
+variable "lambda_artefact_storage_bucket" {
+  description = "The name of the S3 bucket where the lambda artefact will be stored"
+  type        = string
+}
+
+variable "secrets_manager_kms_key" {
+  description = "The KMS Key Id to be used to encrypt the secret which stores the web hook url"
+  type = object({
+    key_id = string
+    arn    = string
+  })
+}
+
+variable "cloudwatch_event_pattern" {
+  description = "A Cloudwatch event pattern to trigger the lambda"
+  type        = string
+}
+
+variable "secret_name" {
+  description = "The name of the secret which stores the web hook url"
+  type        = string
+}
+

--- a/terraform/modules/glue-failure-alert-notifications/02-inputs-optional.tf
+++ b/terraform/modules/glue-failure-alert-notifications/02-inputs-optional.tf
@@ -1,0 +1,4 @@
+variable "lambda_environment_variables" {
+  description = "An object containing environment variables to be used in the Lambda"
+  type        = map(string)
+}

--- a/terraform/modules/glue-failure-alert-notifications/03-inputs-derived.tf
+++ b/terraform/modules/glue-failure-alert-notifications/03-inputs-derived.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -79,7 +79,7 @@ resource "aws_s3_bucket_object" "lambda" {
 resource "aws_lambda_function" "lambda" {
   function_name     = lower("${var.identifier_prefix}${var.lambda_name}")
   role              = aws_iam_role.lambda.arn
-  handler           = "main.handler"
+  handler           = "main.lambda_handler"
   runtime           = "python3.8"
   source_code_hash  = filebase64sha256(data.archive_file.lambda.output_path)
   s3_bucket         = var.lambda_artefact_storage_bucket

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -113,9 +113,3 @@ resource "aws_cloudwatch_event_target" "lambda" {
   target_id = "Invoke${var.lambda_name}Lambda"
   arn       = aws_lambda_function.lambda.arn
 }
-
-resource "aws_kms_key" "name" {
-  description = "KMS key for ${var.secret_name}"
-  tags        = var.tags
-}
-

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -1,0 +1,122 @@
+locals {
+  lambda_name_underscore = replace(lower(var.lambda_name), "/[^a-zA-Z0-9]+/", "_")
+}
+
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = lower("${var.identifier_prefix}${var.lambda_name}")
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey",
+    ]
+    effect    = "Allow"
+    resources = [var.secrets_manager_kms_key.arn]
+  }
+
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:${var.secret_name}*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda" {
+  name   = lower("${var.identifier_prefix}${var.lambda_name}")
+  policy = data.aws_iam_policy_document.lambda.json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = aws_iam_policy.lambda.arn
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_dir  = "../../lambdas/${local.lambda_name_underscore}"
+  output_path = "../../lambdas/${local.lambda_name_underscore}.zip"
+}
+
+resource "aws_s3_bucket_object" "lambda" {
+  bucket = var.lambda_artefact_storage_bucket
+  key    = "${local.lambda_name_underscore}.zip"
+  source = data.archive_file.lambda.output_path
+  etag   = filemd5(data.archive_file.lambda.output_path)
+  acl    = "private"
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name = lower("${var.identifier_prefix}${var.lambda_name}")
+  role          = aws_iam_role.lambda.arn
+  handler       = "main.handler"
+  runtime       = "python3.8"
+  #filename          = data.archive_file.lambda.output_path
+  source_code_hash  = filebase64sha256(data.archive_file.lambda.output_path)
+  s3_bucket         = var.lambda_artefact_storage_bucket
+  s3_key            = "${local.lambda_name_underscore}.zip"
+  s3_object_version = aws_s3_bucket_object.lambda.version_id
+  environment {
+    variables = var.lambda_environment_variables
+  }
+  tags = var.tags
+}
+
+resource "aws_lambda_permission" "lambda" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.lambda.arn
+}
+
+resource "aws_cloudwatch_event_rule" "lambda" {
+  name          = lower("${var.identifier_prefix}${var.lambda_name}")
+  description   = "Event rule for triggering lambda ${var.lambda_name}"
+  event_pattern = var.cloudwatch_event_pattern
+  is_enabled    = true
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "lambda" {
+  rule      = aws_cloudwatch_event_rule.lambda.name
+  target_id = "Invoke${var.lambda_name}Lambda"
+  arn       = aws_lambda_function.lambda.arn
+}
+
+resource "aws_kms_key" "name" {
+  description = "KMS key for ${var.secret_name}"
+  tags        = var.tags
+}
+

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -77,11 +77,10 @@ resource "aws_s3_bucket_object" "lambda" {
 }
 
 resource "aws_lambda_function" "lambda" {
-  function_name = lower("${var.identifier_prefix}${var.lambda_name}")
-  role          = aws_iam_role.lambda.arn
-  handler       = "main.handler"
-  runtime       = "python3.8"
-  #filename          = data.archive_file.lambda.output_path
+  function_name     = lower("${var.identifier_prefix}${var.lambda_name}")
+  role              = aws_iam_role.lambda.arn
+  handler           = "main.handler"
+  runtime           = "python3.8"
   source_code_hash  = filebase64sha256(data.archive_file.lambda.output_path)
   s3_bucket         = var.lambda_artefact_storage_bucket
   s3_key            = "${local.lambda_name_underscore}.zip"

--- a/terraform/modules/glue-failure-alert-notifications/99-outputs.tf
+++ b/terraform/modules/glue-failure-alert-notifications/99-outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_name" {
+  description = "Name of the lamda"
+  value       = aws_lambda_function.lambda.function_name
+}
+
+output "lambda_arn" {
+  description = "ARN of the lambda"
+  value       = aws_lambda_function.lambda.arn
+}
+
+output "cloudwatch_event_rule_arn" {
+  description = "ARN of the CloudWatch Event Rule"
+  value       = aws_cloudwatch_event_rule.lambda.arn
+}
+
+output "cloudwatch_event_rule_name" {
+  description = "Name of the CloudWatch Event Rule"
+  value       = aws_cloudwatch_event_rule.lambda.name
+}


### PR DESCRIPTION
## Link to JIRA ticket

[DPP-332](https://hackney.atlassian.net/browse/DPP-332)

## Describe this PR

### *What is the problem we're trying to solve*

Alerting for Glue job failures currently generates an email notification, the team feels these emails are not the best way of communicating these alerts and a Google Chat group would facilitate better visibility and collaboration addressing failures.  

### *What changes have we introduced*

This PR creates a new Terraform module for deploying a Lambda that will provide notifications of Glue job failures to a Google Chat.

Updates include:

- a new lambda for handling the Cloudwatch event and sending notifications to a Google Chat group
- a terraform module to create the Cloudwatch event, Lambda and required permissions

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Give users permissions to Google space, so they can see the alarms
- Create webhook secret in Secrets Manager

[DPP-332]: https://hackney.atlassian.net/browse/DPP-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ