### PR TITLE
DPP-96 Share backup ami for test instance

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -98,4 +98,3 @@ data "aws_secretsmanager_secret_version" "subnet_value_for_qlik_sense_pre_prod_i
   count     = !var.is_production_environment && var.is_live_environment ? 1 : 0
   secret_id = data.aws_secretsmanager_secret.subnet_value_for_qlik_sense_pre_prod_instance[0].id
 }
-

--- a/terraform/modules/qlik-sense-server/14-aws-ec2-prod-win-test.tf
+++ b/terraform/modules/qlik-sense-server/14-aws-ec2-prod-win-test.tf
@@ -36,13 +36,7 @@ resource "aws_instance" "test_windows_prod_instance" {
   root_block_device {
     encrypted               = true
     delete_on_termination   = true
-    kms_key_id              = aws_kms_key.key.id
+    kms_key_id              = aws_kms_key.key.arn
     tags                    = merge(var.tags, local.win_prod_test_ec2_tags)
-  }
-
-  lifecycle {
-      ignore_changes = [
-        root_block_device[0].kms_key_id,
-      ]
   }
 }

--- a/terraform/modules/qlik-sense-server/14-aws-ec2-prod-win-test.tf
+++ b/terraform/modules/qlik-sense-server/14-aws-ec2-prod-win-test.tf
@@ -39,4 +39,10 @@ resource "aws_instance" "test_windows_prod_instance" {
     kms_key_id              = aws_kms_key.key.id
     tags                    = merge(var.tags, local.win_prod_test_ec2_tags)
   }
+
+  lifecycle {
+      ignore_changes = [
+        root_block_device[0].kms_key_id,
+      ]
+  }
 }

--- a/terraform/modules/qlik-sense-server/15-aws-ec2-pre-prod-test-restore.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-pre-prod-test-restore.tf
@@ -1,0 +1,39 @@
+locals {
+    test_instance_backup_ami_id = "ami-0513e39717f73ef78"
+    win_pre_prod_test_restore_ec2_tags = {
+        Name = "${var.identifier_prefix}-manual-windows-test-restore-from-prod"
+    }
+}
+
+#share the backup AMI from prod
+resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod_for_test_instance" {
+  count         = var.is_production_environment ? 1 : 0
+  image_id      = local.test_instance_backup_ami_id
+  account_id    = data.aws_secretsmanager_secret_version.pre_production_account_id[0].secret_string
+}
+
+#enable once above permissions have been deployed to prod
+# resource "aws_instance" "test_windows_restore_from_prod_to_pre_prod" {
+#   count                     = !var.is_production_environment && var.is_live_environment ? 1 : 0
+#   ami                       = local.test_instance_backup_ami_id
+#   instance_type             = "t2.micro"
+#   subnet_id                 = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
+#   vpc_security_group_ids    = [aws_security_group.qlik_sense.id]
+
+#   private_dns_name_options {
+#     enable_resource_name_dns_a_record = true
+#   }
+
+#   iam_instance_profile        = aws_iam_instance_profile.qlik_sense.id
+#   disable_api_termination     = false
+#   key_name                    = aws_key_pair.qlik_sense_server_key.key_name
+#   tags                        = merge(var.tags, local.win_pre_prod_test_restore_ec2_tags)
+#   associate_public_ip_address = false
+
+#   root_block_device {
+#     encrypted               = true
+#     delete_on_termination   = true
+#     kms_key_id              = aws_kms_key.key.id
+#     tags                    = merge(var.tags, local.win_pre_prod_test_restore_ec2_tags)
+#   }
+# }


### PR DESCRIPTION
Share backup AMI created from test instance on prod, so we can try to restore it in a follow up PR.

Also update the key handling, so the instance won't get re-created unnecessarily. Value should use arn rather than id to stop terraform detecting it as a change