### PR TITLE
Remove failing glue jobs

### DIFF
--- a/terraform/etl/09-spreadsheet-imports-from-g-drive.tf
+++ b/terraform/etl/09-spreadsheet-imports-from-g-drive.tf
@@ -159,41 +159,6 @@ module "env_enforcement_fix_my_street_noise" {
   }
 }
 
-module "env_enforcement_cc_tv" {
-  count = local.is_live_environment ? 1 : 0
-
-  source                         = "../modules/import-spreadsheet-file-from-g-drive"
-  is_production_environment      = local.is_production_environment
-  is_live_environment            = local.is_live_environment
-  department                     = module.department_env_enforcement_data_source
-  glue_scripts_bucket_id         = module.glue_scripts_data_source.bucket_id
-  glue_catalog_database_name     = module.department_env_enforcement_data_source.raw_zone_catalog_database_name
-  glue_temp_storage_bucket_id    = module.glue_temp_storage_data_source.bucket_url
-  spark_ui_output_storage_id     = module.spark_ui_output_storage_data_source.bucket_id
-  secrets_manager_kms_key        = data.aws_kms_key.secrets_manager_key
-  glue_role_arn                  = data.aws_iam_role.glue_role.arn
-  helper_module_key              = data.aws_s3_bucket_object.helpers.key
-  pydeequ_zip_key                = data.aws_s3_bucket_object.pydeequ.key
-  jars_key                       = data.aws_s3_bucket_object.jars.key
-  spreadsheet_import_script_key  = aws_s3_bucket_object.spreadsheet_import_script.key
-  identifier_prefix              = local.short_identifier_prefix
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage_data_source.bucket_id
-  landing_zone_bucket_id         = module.landing_zone_data_source.bucket_id
-  landing_zone_kms_key_arn       = module.landing_zone_data_source.kms_key_arn
-  landing_zone_bucket_arn        = module.landing_zone_data_source.bucket_arn
-  google_drive_document_id       = "13uiSwGDj-EPTVTUJtJgqbz2UabyRuFmw"
-  glue_job_name                  = "CCTV"
-  output_folder_name             = "cc-tv"
-  raw_zone_bucket_id             = module.raw_zone_data_source.bucket_id
-  input_file_name                = "cctv.xlsx"
-  worksheets = {
-    sheet1 : {
-      header_row_number = 1
-      worksheet_name    = "Sheet1"
-    }
-  }
-}
-
 module "data_and_insight_hb_combined" {
   count = local.is_live_environment ? 1 : 0
 

--- a/terraform/etl/25-aws-glue-job-revenues.tf
+++ b/terraform/etl/25-aws-glue-job-revenues.tf
@@ -1,4 +1,5 @@
 module "etl_ctax_live_properties" {
+  count                          = local.is_live_environment && !local.is_production_environment ? 1 : 0
   source                         = "../modules/aws-glue-job"
   is_live_environment            = local.is_live_environment
   is_production_environment      = local.is_production_environment


### PR DESCRIPTION
- remove failing glue job 'etl_ctax_live_properties' from production
- remove module for failing glue job  'Spreadsheet Import Job - env-enforcement-CCTV - Sheet1' (no longer needed in prod or pre)