### PR TITLE
Pushdown predicate helper based on timestamp

### DIFF
--- a/scripts/jobs/copy_json_data_landing_to_raw.py
+++ b/scripts/jobs/copy_json_data_landing_to_raw.py
@@ -11,7 +11,7 @@ import boto3
 import pyspark.sql.functions as F
 
 from scripts.helpers.helpers import get_glue_env_var, add_import_time_columns, get_s3_subfolders, PARTITION_KEYS, \
-    clean_column_names, get_latest_partition_date_from_s3
+    clean_column_names, get_max_date_partition_value_from_glue_catalogue
 
 s3_client = boto3.client('s3')
 sc = SparkContext.getOrCreate()
@@ -27,7 +27,7 @@ def data_source_landing_to_raw(bucket_source, bucket_target, s3_prefix):
     data_source = spark.read.option("multiline", "true").json(bucket_source + "/" + s3_prefix)
     logger.info(f"Retrieved data source from s3 path {bucket_source}/{s3_prefix}")
     
-    latest_import = get_latest_partition_date_from_s3('data-and-insight-raw-zone','icaseworks','import_date')
+    latest_import = get_max_date_partition_value_from_glue_catalogue('data-and-insight-raw-zone', 'icaseworks', 'import_date')
     logger.info(f"latest_data on raw: {latest_import}")
     
     latest_data = data_source.filter(F.col("import_date")>latest_import)

--- a/scripts/jobs/parking/parking_defect_met_fail.py
+++ b/scripts/jobs/parking/parking_defect_met_fail.py
@@ -5,7 +5,7 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_latest_available_partition
+from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -28,7 +28,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_db_defects_mgt",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate_for_latest_available_partition("parking-raw-zone", "parking_parking_ops_db_defects_mgt", "import_date")
+    push_down_predicate=create_pushdown_predicate_for_max_date_partition_value("parking-raw-zone", "parking_parking_ops_db_defects_mgt", "import_date")
     )
 
 # Script generated for node SQL

--- a/scripts/jobs/unrestricted/spatial_enrichment.py
+++ b/scripts/jobs/unrestricted/spatial_enrichment.py
@@ -6,7 +6,7 @@ from awsglue.job import Job
 from awsglue.dynamicframe import DynamicFrame
 
 from pyspark.sql.types import DoubleType
-from scripts.helpers.helpers import table_exists_in_catalog, create_pushdown_predicate_for_latest_available_partition
+from scripts.helpers.helpers import table_exists_in_catalog, create_pushdown_predicate_for_max_date_partition_value
 
 import sys
 
@@ -175,7 +175,7 @@ if __name__ == "__main__":
         geography_data_source = glueContext.create_dynamic_frame.from_catalog(
             name_space=geography_table["database_name"],
             table_name=geography_table["table_name"],
-            push_down_predicate = create_pushdown_predicate_for_latest_available_partition(geography_table["database_name"],geography_table["table_name"],'import_date')
+            push_down_predicate = create_pushdown_predicate_for_max_date_partition_value(geography_table["database_name"], geography_table["table_name"], 'import_date')
         )
         geography_df = geography_data_source.toDF()
 
@@ -212,7 +212,7 @@ if __name__ == "__main__":
         table_to_enrich_source = glueContext.create_dynamic_frame.from_catalog(
             name_space=database_name,
             table_name=table_name,
-            push_down_predicate = create_pushdown_predicate_for_latest_available_partition(enrich_table["database_name"],enrich_table["table_name"],enrich_table["date_partition_name"]),
+            push_down_predicate = create_pushdown_predicate_for_max_date_partition_value(enrich_table["database_name"], enrich_table["table_name"], enrich_table["date_partition_name"]),
             transformation_ctx = f"datasource_{table_name}"
         )
         table_to_enrich_df = table_to_enrich_source.toDF()


### PR DESCRIPTION
Introduces a new helper to create a pushdown predicate when you don't have a date partition in the format yyyymmdd, or when you don't know your partition keys. Also renames the old pushdown predicate helper to make the difference clearer.