### PR TITLE
DPP-340 Update Redshift configuration script to support roles

### DIFF
--- a/scripts/configure_redshift.py
+++ b/scripts/configure_redshift.py
@@ -111,7 +111,7 @@ def get_roles_to_be_added(existing_roles: list, roles_in_config: str) -> list:
 
     return list(x.strip('\'') for x in difference)
 
-def create_roles(redshift, roles_in_config: json) -> None:
+def create_roles(redshift: Redshift, roles_in_config: json) -> None:
     roles_list = get_role_names_from_configuration(roles_in_config)
     
     query_id = redshift.execute_query(f"select role_name from svv_roles where role_name in({roles_list});")
@@ -177,7 +177,7 @@ def configure_users(redshift, secrets_manager: BaseClient, users: list) -> None:
     create_users(redshift, new_users_with_password)
 
 
-def grant_permissions_to_users(redshift, users: list) -> None:
+def grant_permissions_to_users(redshift: Redshift, users: list) -> None:
     for user in users:
         username = user["user_name"]
         grant_temp_permissions = f"GRANT temp ON DATABASE {redshift.database_name} TO {username};"
@@ -193,7 +193,7 @@ def grant_permissions_to_users(redshift, users: list) -> None:
         print(f"Add permissions for user {username}")
     return
 
-def grant_permissions_to_roles(redshift: Redshift, roles_configuration) -> None:
+def grant_permissions_to_roles(redshift: Redshift, roles_configuration: list) -> None:
     role_names = []
 
     for role in roles_configuration:

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -8,3 +8,92 @@ def spark():
   s = SparkSession.builder.config("spark.eventLog.dir", event_log_dir).config("spark.eventLog.enabled", True).master("local").getOrCreate()
   yield s
   s.stop()
+
+#redshift configuration test setup
+def pytest_configure(config):
+    config.addinivalue_line("markers", "grant_permissions_to_roles: mark tests for grant_permissions_to_roles function")
+    config.addinivalue_line("markers", "main: mark tests for main function")
+    config.addinivalue_line("markers", "create_roles: mark tests for create roles function")
+    config.addinivalue_line("markers", "get_role_names: mark tests for get role names function")
+    config.addinivalue_line("markers", "get_roles: mark tests for get roles function")
+
+@pytest.fixture(scope='session')
+def terraform_output():
+  return """{
+            "redshift_cluster_id": {
+                "value": "redshift-cluster"
+            },
+            "redshift_iam_role_arn": {
+                "value": "arn:aws:iam::role"
+            },
+            "redshift_schemas": {
+                "value": []
+            },
+            "redshift_users": {
+                "value": []
+            },
+            "redshift_roles": {
+                "value": [
+                    {
+                        "role_name": "role_one",
+                        "schemas_to_grant_access_to": [
+                            "schema_one",
+                            "schema_two",
+                            "schema_three"
+                        ]
+                    },
+                    {
+                        "role_name": "role_two",
+                        "schemas_to_grant_access_to": [
+                            "schema_four",
+                            "schema_five",
+                            "schema_six"
+                        ]
+                    }
+                ]
+            }
+    }"""
+
+@pytest.fixture(scope="session")
+def terraform_output_with_one_role():
+  return """{
+            "redshift_cluster_id": {
+                "value": "redshift-cluster"
+            },
+            "redshift_iam_role_arn": {
+                "value": "arn:aws:iam::role"
+            },
+            "redshift_schemas": {
+                "value": []
+            },
+            "redshift_users": {
+                "value": []
+            },
+            "redshift_roles": {
+                "value": [
+                    {
+                        "role_name": "role_one",
+                        "schemas_to_grant_access_to": [
+                            "schema_one"
+                        ]
+                    }
+                ]
+            }
+    }"""
+
+@pytest.fixture(scope='session')
+def terraform_output_without_roles_config():
+  return """{
+          "redshift_cluster_id": {
+              "value": "redshift-cluster"
+          },
+          "redshift_iam_role_arn": {
+              "value": "arn:aws:iam::role"
+          },
+          "redshift_schemas": {
+              "value": []
+          },
+          "redshift_users": {
+              "value": []
+          }
+  }"""

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
@@ -1,0 +1,120 @@
+import pytest
+from scripts.configure_redshift import Redshift, main
+from unittest.mock import call
+
+class TestConfigureRolePermissions():
+
+    @pytest.fixture(scope="function")
+    def grant_permissions_to_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_roles')
+
+    @pytest.fixture(scope="function")
+    def redshift_mock(self, mocker):
+        return mocker.Mock(autospec=Redshift)
+
+    @pytest.fixture(scope="function", autouse=True)
+    def boto3_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.boto3')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def create_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_roles')
+
+    @pytest.fixture(scope="function")
+    def grant_permissions_to_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def create_schemas_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_schemas')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_users')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.grant_permissions_to_users')
+
+    #main
+    @pytest.mark.main
+    def test_main_calls_grant_permissions_to_roles_when_roles_config_is_present(self, terraform_output, redshift_mock, grant_permissions_to_roles_mock):
+        main(terraform_output, redshift_mock)
+
+        assert grant_permissions_to_roles_mock.call_count == 1
+    
+    @pytest.mark.main
+    def test_main_skips_grant_permissions_to_roles_when_roles_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, grant_permissions_to_roles_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+
+        assert grant_permissions_to_roles_mock.call_count == 0
+
+    #grant_permissions_to_roles
+    @pytest.mark.grant_permissions_to_roles
+    def test_grant_permissions_to_roles_calls_execute_query_on_redshift_to_grant_temp_permissions_to_database_when_config_is_present(self, mocker, redshift_mock, terraform_output):
+        role_name_one = "role_one"
+        role_name_two = "role_two"
+        spy = mocker.spy(redshift_mock, "execute_query")
+        expected_query_one = f"grant temp on database {redshift_mock.database_name} to role {role_name_one};"
+        expected_query_two = f"grant temp on database {redshift_mock.database_name} to role {role_name_two};"
+        
+        main(terraform_output, redshift_mock)
+
+        spy.assert_any_call(expected_query_one) 
+        spy.assert_any_call(expected_query_two) 
+
+    @pytest.mark.grant_permissions_to_roles
+    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_schema_permissions_when_config_is_present(self, mocker, redshift_mock, terraform_output):
+        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+
+        expected_queries_for_role_one = ['grant usage on schema schema_one to role role_one;',
+                                         'grant usage on schema schema_two to role role_one;',
+                                         'grant usage on schema schema_three to role role_one;']
+        
+        expected_queries_for_role_two = ['grant usage on schema schema_four to role role_two;',
+                                         'grant usage on schema schema_five to role role_two;',
+                                         'grant usage on schema schema_six to role role_two;']
+
+        main(terraform_output, redshift_mock)
+
+        spy.assert_any_call(expected_queries_for_role_one)
+        spy.assert_any_call(expected_queries_for_role_two)
+
+    @pytest.mark.grant_permissions_to_roles
+    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_table_permissions_on_allowed_schemas(self, mocker, redshift_mock, terraform_output):
+        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+
+        expected_queries_for_role_one = ['grant select on all tables in schema schema_one to role role_one;',
+                                         'grant select on all tables in schema schema_two to role role_one;',
+                                         'grant select on all tables in schema schema_three to role role_one;']
+
+        expected_queries_for_role_two = ['grant select on all tables in schema schema_four to role role_two;', 'grant select on all tables in schema schema_five to role role_two;', 'grant select on all tables in schema schema_six to role role_two;']
+
+        main(terraform_output, redshift_mock)
+
+        spy.assert_any_call(expected_queries_for_role_one)
+        spy.assert_any_call(expected_queries_for_role_two)
+    
+    @pytest.mark.grant_permissions_to_roles
+    def test_grant_permissions_roles_calls_redshift_with_queries_in_the_correct_order(self, redshift_mock, terraform_output_with_one_role):
+        expected_temp_database_access_query = f"grant temp on database {redshift_mock.database_name} to role role_one;"
+        expected_schema_usage_query         = ['grant usage on schema schema_one to role role_one;']
+        expected_table_access_query         = ['grant select on all tables in schema schema_one to role role_one;']
+
+        main(terraform_output_with_one_role, redshift_mock)
+
+        expected_calls = [
+            call.execute_query(expected_temp_database_access_query),
+            call.execute_batch_queries(expected_schema_usage_query),
+            call.execute_batch_queries(expected_table_access_query)
+            ]
+
+        redshift_mock.assert_has_calls(expected_calls, any_order=False)
+
+    @pytest.mark.grant_permissions_to_roles
+    def test_graant_permissions_to_roles_outputs_message_when_roles_were_created(self, redshift_mock, terraform_output, capfd):
+        main(terraform_output, redshift_mock)
+
+        readout = capfd.readouterr()
+
+        assert readout.out == "Granted permissions for roles: role_one, role_two\n"

--- a/scripts/tests/redshift_configuration/test_create_redshift_roles.py
+++ b/scripts/tests/redshift_configuration/test_create_redshift_roles.py
@@ -1,0 +1,160 @@
+import pytest
+from scripts.configure_redshift import create_roles, get_role_names_from_configuration, get_roles_to_be_added, main, Redshift
+import json
+
+class TestCreateRedshiftRoles():
+
+    @pytest.fixture(scope='function')
+    def redshift_mock(self, mocker):
+        return mocker.Mock(spec=Redshift)
+
+    #boto3 is not relevant here, so patch it automatically for every test
+    @pytest.fixture(scope='function', autouse=True)
+    def boto3_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.boto3')
+
+    @pytest.fixture(scope='function')
+    def create_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_roles')
+
+    @pytest.fixture(scope='function', autouse=True)
+    def get_roles_to_be_added_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.get_roles_to_be_added')
+
+    @pytest.fixture(scope='function')
+    def get_role_names_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.get_role_names_from_configuration')     
+
+    @pytest.fixture(scope='session')
+    def terraform_output_json(self, terraform_output):
+        return json.loads(terraform_output)['redshift_roles']['value']   
+
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def create_schemas_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_schemas')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_users')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_users')
+
+    #main
+    @pytest.mark.main
+    def test_main_skips_create_roles_if_role_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, create_roles_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        
+        assert create_roles_mock.call_count == 0
+
+    @pytest.mark.main
+    def test_main_outputs_a_message_when_roles_configuration_not_present(self, terraform_output_without_roles_config, capfd, redshift_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+
+        readout = capfd.readouterr()
+        assert readout.out == "No role configuration found\n"    
+
+    @pytest.mark.main
+    def test_main_calls_create_roles_with_role_configuration(self, terraform_output, redshift_mock, create_roles_mock, terraform_output_json):
+        main(terraform_output, redshift_mock)    
+        
+        create_roles_mock.assert_called_once_with(redshift_mock, terraform_output_json)
+
+    #get_role_names
+    @pytest.mark.get_role_names
+    def test_get_role_names_returns_comma_separated_string(self, terraform_output_json):
+        assert get_role_names_from_configuration(terraform_output_json) ==  "'role_one','role_two'"
+
+    @pytest.mark.get_role_names
+    def test_get_role_names_returns_empty_string_when_input_list_is_empty(self):
+        assert get_role_names_from_configuration([]) == ""
+
+    #ceate_roles
+    @pytest.mark.create_roles
+    def test_create_roles_calls_get_role_names_when_roles_list_is_not_empty(self, redshift_mock, get_role_names_mock, terraform_output_json):
+        create_roles(redshift_mock, terraform_output_json)
+
+        assert get_role_names_mock.call_count == 1
+
+    @pytest.mark.create_roles
+    def test_create_roles_calls_execute_query_on_redshift_with_correct_params_when_provided_roles_list_is_valid(self, mocker, redshift_mock, terraform_output_json):
+        spy = mocker.spy(redshift_mock, "execute_query")
+        expected_query = "select role_name from svv_roles where role_name in('role_one','role_two');"
+        
+        create_roles(redshift_mock, terraform_output_json)
+
+        spy.assert_called_once_with(expected_query)
+    
+    @pytest.mark.create_roles
+    def test_create_roles_calls_get_results_on_redshift_with_correct_query_id(self, mocker, redshift_mock, terraform_output_json):
+        spy = mocker.spy(redshift_mock, "get_results")
+        redshift_mock.execute_query.side_effect = "1"
+
+        create_roles(redshift_mock, terraform_output_json)
+
+        spy.assert_called_once_with("1")
+
+    @pytest.mark.create_roles
+    def test_create_roles_calls_get_roles_to_be_added(self, redshift_mock, get_roles_to_be_added_mock, terraform_output_json):
+        create_roles(redshift_mock, terraform_output_json)
+
+        assert get_roles_to_be_added_mock.call_count == 1
+
+    @pytest.mark.create_roles
+    def test_create_roles_calls_execute_batch_queries_on_redshift_when_there_are_new_roles_to_be_added(self, mocker, capfd, redshift_mock, terraform_output_json):
+        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+        mocker.patch('scripts.configure_redshift.get_roles_to_be_added', return_value=['role_three'])
+        expected_query = ['CREATE ROLE role_three']
+        
+        create_roles(redshift_mock, terraform_output_json)
+    
+        spy.assert_called_once_with(expected_query)
+        readout = capfd.readouterr()
+
+        assert readout.out == "Added following roles: ['role_three']\n"
+    
+    @pytest.mark.create_roles
+    def test_create_roles_outputs_newly_added_roles(self, mocker, capfd, redshift_mock, terraform_output_json):
+        mocker.patch('scripts.configure_redshift.get_roles_to_be_added', return_value=['role_one','role_two'])
+        
+        create_roles(redshift_mock, terraform_output_json)
+
+        readout = capfd.readouterr()
+        assert readout.out == "Added following roles: ['role_one', 'role_two']\n"
+    
+    @pytest.mark.create_roles
+    def test_create_roles_outputs_notification_when_no_roles_to_be_added(self, mocker, capfd, redshift_mock, terraform_output_json):
+        mocker.patch('scripts.configure_redshift.get_roles_to_be_added', return_value=[])
+        
+        create_roles(redshift_mock, terraform_output_json)
+
+        readout = capfd.readouterr()
+        assert readout.out == "No roles to be added\n"
+
+    #get_roles
+    @pytest.mark.get_roles
+    def test_get_roles_to_be_added_returns_list_of_new_roles(self):
+        new_roles_to_be_added = ['role_four', 'role_five']
+        roles_config = """'role_one','role_two','role_three','role_four','role_five'"""
+        
+        #based on a return value from existing function
+        existing_roles_in_redshift = [
+                [
+                    {'stringValue': 'role_one'}
+                ], 
+                [
+                    {'stringValue': 'role_two'}
+                ],
+                [
+                    {'stringValue': 'role_three'}
+                ]
+            ]
+
+        #order doesn't matter, so just check that lists have the same items
+        assert sorted(get_roles_to_be_added(existing_roles_in_redshift, roles_config)) == sorted(new_roles_to_be_added)
+   


### PR DESCRIPTION
## Link to JIRA ticket

[DPP-340](https://hackney.atlassian.net/browse/DPP-340)

## Describe this PR

### *What is the problem we're trying to solve*

We don't currently have any automated way of adding new roles and managing roles' permissions to external schemas in Redshift. This feature is required in order to move forward with the planned role based access control change in Redshift.

### *What changes have we introduced*

This update enhances the existing Redshift configuration script by adding support for adding new roles and granting them access to external schemas.

This is the first iteration of wider piece of work, so this update only supports adding new roles and granting access to them. The script will check whether new roles have been added to Terraform configuration and if so, adds them to Redshift and also grants the roles access to external schemas as per the configuration. If no new roles are found the roles configuration step is skipped.

If the roles configuration is missing altogether the configuration step will be skipped in that case too. This allows us to deploy this change without having the configuration in place. 

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update Terraform config with roles configuration for a department used for POC for RBAC setup. The correct format for roles configuration is:

 ```
redshift_roles = [ 
    {
      role_name = "${module.department_data_and_insight_data_source.identifier_snake_case}_ro",
      schemas_to_grant_access_to = concat([
        replace(module.department_housing_repairs_data_source.raw_zone_catalog_database_name, "-", "_"),
        replace(module.department_housing_repairs_data_source.trusted_zone_catalog_database_name, "-", "_"),
      ], local.unrestricted_schemas)
    },
    {
      role_name = "${module.department_parking_data_source.identifier_snake_case}_ro",
      schemas_to_grant_access_to = concat([
        replace(module.department_parking_data_source.raw_zone_catalog_database_name, "-", "_"),
        "parking_raw_zone_liberator",
        replace(module.department_parking_data_source.trusted_zone_catalog_database_name, "-", "_"),
      ], local.unrestricted_schemas)
    }
  ]
```
The configuration must be added to `terraform/etl/42-redshift.tf` file.

The roles configuration format is identical to the one currently used for users, so the permissions can simply be copied over from user configuration as and when needed.


[DPP-340]: https://hackney.atlassian.net/browse/DPP-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ