### PR TITLE
DPP-317 More restrictive ingress rules for Redshift

### DIFF
--- a/terraform/modules/redshift/10-redshift.tf
+++ b/terraform/modules/redshift/10-redshift.tf
@@ -155,11 +155,27 @@ resource "aws_security_group" "redshift_cluster_security_group" {
   vpc_id      = var.vpc_id
 
   ingress {
-    description = "Allows inbound traffic from BI tools using PostgreSQL protocol"
+    description = "Allows inbound traffic when running queries from the console"
     from_port   = 5439
     to_port     = 5439
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    self        = true
+  }
+
+  ingress {
+    description = "Allows cidr based inbound traffic"
+    from_port = 5439
+    to_port = 5439
+    protocol = "tcp"
+    cidr_blocks = local.redshift_ingress_rules["cidr_blocks"]
+  }
+
+  ingress {
+    description = "Allows security group based inbound traffic"
+    from_port = 5439
+    to_port = 5439
+    protocol = "tcp"
+    security_groups = local.redshift_ingress_rules["security_groups"]
   }
 
   egress {


### PR DESCRIPTION
This updates changes the Redshift ingress rules management so that the configuration can be changed using values in secrets manager.