### PR TITLE
DPP-96 update key policy to allow deployment role access

### DIFF
--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -112,6 +112,16 @@ data "aws_secretsmanager_secret_version" "central_backup_role_arn" {
   secret_id = data.aws_secretsmanager_secret.central_backup_role_arn[0].id
 }
 
+data "aws_secretsmanager_secret" "pre_prod_deployment_role_arn" {
+  count = var.is_production_environment ? 1 : 0
+  name  = "${var.identifier_prefix}-manually-managed-value-pre-prod-deployment-role-arn"
+}
+
+data "aws_secretsmanager_secret_version" "pre_prod_deployment_role_arn" {
+  count     = var.is_production_environment ? 1 : 0
+  secret_id = data.aws_secretsmanager_secret.pre_prod_deployment_role_arn[0].id
+}
+
 data "aws_iam_policy_document" "key_policy" {
   statement {
     effect = "Allow"
@@ -173,6 +183,32 @@ data "aws_iam_policy_document" "key_policy" {
         "kms:Decrypt",
         "kms:RetireGrant",
         "kms:CreateGrant"
+      ]
+
+      resources = [
+        "*"
+      ]
+    }
+  }
+
+  dynamic statement {
+    for_each = var.is_production_environment ? [1] : [] 
+    
+    content {
+      sid =  "AllowPreProdDeploymentRoleAccessToThisKey"
+      effect = "Allow"
+      
+      principals {
+        type = "AWS"
+        identifiers = [data.aws_secretsmanager_secret_version.pre_prod_deployment_role_arn[0].secret_string]
+      }
+
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
       ]
 
       resources = [

--- a/terraform/modules/qlik-sense-server/15-aws-ec2-pre-prod-test-restore.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-pre-prod-test-restore.tf
@@ -1,16 +1,16 @@
 locals {
-    #test_instance_backup_ami_id = "ami-0513e39717f73ef78"
+    test_instance_backup_ami_id = "ami-05d61c0ddcbe01eb9"
     win_pre_prod_test_restore_ec2_tags = {
         Name = "${var.identifier_prefix}-manual-windows-test-restore-from-prod"
     }
 }
 
 #share the backup AMI from prod
-# resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod_for_test_instance" {
-#   count         = var.is_production_environment ? 1 : 0
-#   image_id      = local.test_instance_backup_ami_id
-#   account_id    = data.aws_secretsmanager_secret_version.pre_production_account_id[0].secret_string
-# }
+resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod_for_test_instance" {
+  count         = var.is_production_environment ? 1 : 0
+  image_id      = local.test_instance_backup_ami_id
+  account_id    = data.aws_secretsmanager_secret_version.pre_production_account_id[0].secret_string
+}
 
 # resource "aws_instance" "test_windows_restore_from_prod_to_pre_prod" {
 #   count                     = !var.is_production_environment && var.is_live_environment ? 1 : 0


### PR DESCRIPTION
Update prod key policy to allow pre-prod deployment role access it. Also share the latest test backup AMI with pre-prod account.