### PR TITLE
DPP-96 stop key sharing

### DIFF
--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -141,32 +141,6 @@ data "aws_iam_policy_document" "key_policy" {
     for_each = var.is_production_environment ? [1] : [] 
     
     content {
-      sid =  "AllowPreProdEC2RoleAccessToThisKey"
-      effect = "Allow"
-      
-      principals {
-        type = "AWS"
-        identifiers = [data.aws_secretsmanager_secret_version.qlik_sense_ec2_role_arn_on_pre_prod_account[0].secret_string]
-      }
-
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey"
-      ]
-
-      resources = [
-        "*"
-      ]
-    }
-  }
-
-  dynamic statement {
-    for_each = var.is_production_environment ? [1] : [] 
-    
-    content {
       sid =  "AllowCentralBackupVaultAccessToThisKey"
       effect = "Allow"
       
@@ -190,33 +164,6 @@ data "aws_iam_policy_document" "key_policy" {
       ]
     }
   }
-
-  dynamic statement {
-    for_each = var.is_production_environment ? [1] : [] 
-    
-    content {
-      sid =  "AllowPreProdDeploymentRoleAccessToThisKey"
-      effect = "Allow"
-      
-      principals {
-        type = "AWS"
-        identifiers = [data.aws_secretsmanager_secret_version.pre_prod_deployment_role_arn[0].secret_string]
-      }
-
-      actions = [
-        "kms:Encrypt",
-        "kms:Decrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*",
-        "kms:DescribeKey"
-      ]
-
-      resources = [
-        "*"
-      ]
-    }
-  }
-  
 }
 
 resource "aws_kms_key" "key" {

--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -112,16 +112,6 @@ data "aws_secretsmanager_secret_version" "central_backup_role_arn" {
   secret_id = data.aws_secretsmanager_secret.central_backup_role_arn[0].id
 }
 
-data "aws_secretsmanager_secret" "pre_prod_deployment_role_arn" {
-  count = var.is_production_environment ? 1 : 0
-  name  = "${var.identifier_prefix}-manually-managed-value-pre-prod-deployment-role-arn"
-}
-
-data "aws_secretsmanager_secret_version" "pre_prod_deployment_role_arn" {
-  count     = var.is_production_environment ? 1 : 0
-  secret_id = data.aws_secretsmanager_secret.pre_prod_deployment_role_arn[0].id
-}
-
 data "aws_iam_policy_document" "key_policy" {
   statement {
     effect = "Allow"

--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -37,47 +37,6 @@ resource "aws_secretsmanager_secret_version" "production_account_qlik_ec2_ebs_en
   secret_string = "TODO" #value managed manually
 }
 
-data "aws_secretsmanager_secret" "production_account_qlik_ec2_ebs_encryption_key_arn" {
-  count         = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  name          = aws_secretsmanager_secret.production_account_qlik_ec2_ebs_encryption_key_arn[0].arn
-}
-
-data "aws_secretsmanager_secret_version" "production_account_qlik_ec2_ebs_encryption_key_arn" {
-  count         = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  secret_id     = data.aws_secretsmanager_secret.production_account_qlik_ec2_ebs_encryption_key_arn[0].id
-}
-
-resource "aws_iam_policy" "qlik_sense_preprod_can_access_shared_prod_key" {
-  count     = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  tags      = var.tags
-
-  name      = "${var.identifier_prefix}-qlik-sense-preprod-role-can-access-shared-prod-key"
-
-  policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Sid    = "AllowQlikEC2RoleAccessToTheSharedProdKey"
-          Action = [
-            "kms:Encrypt",
-            "kms:Decrypt",
-            "kms:ReEncrypt*",
-            "kms:GenerateDataKey*",
-            "kms:DescribeKey"
-          ]
-          Effect   = "Allow"
-          Resource = [data.aws_secretsmanager_secret_version.production_account_qlik_ec2_ebs_encryption_key_arn[0].secret_string]
-        }
-      ]
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "qlik_sense_prod_key_policy" {
-  count         = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  role          = aws_iam_role.qlik_sense.id
-  policy_arn    = aws_iam_policy.qlik_sense_preprod_can_access_shared_prod_key[0].arn
-}
-
 #manually added/managed value
 data "aws_secretsmanager_secret" "subnet_value_for_qlik_sense_pre_prod_instance" {
   count = !var.is_production_environment && var.is_live_environment ? 1 : 0

--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -78,16 +78,6 @@ resource "aws_iam_role_policy_attachment" "qlik_sense_prod_key_policy" {
   policy_arn    = aws_iam_policy.qlik_sense_preprod_can_access_shared_prod_key[0].arn
 }
 
-data "aws_secretsmanager_secret" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
-  count = var.is_production_environment ? 1 : 0
-  name  = "${var.identifier_prefix}-manually-managed-value-qlik-sense-ec2-role-arn-on-pre-prod-account"
-}
-
-data "aws_secretsmanager_secret_version" "qlik_sense_ec2_role_arn_on_pre_prod_account" {
-  count     = var.is_production_environment ? 1 : 0
-  secret_id = data.aws_secretsmanager_secret.qlik_sense_ec2_role_arn_on_pre_prod_account[0].id
-}
-
 #manually added/managed value
 data "aws_secretsmanager_secret" "subnet_value_for_qlik_sense_pre_prod_instance" {
   count = !var.is_production_environment && var.is_live_environment ? 1 : 0


### PR DESCRIPTION
Stop sharing the prod key with pre-prod account. This is no longer necessary.