### PR TITLE
add max_retries variable to glue jobs

### DIFF
--- a/terraform/modules/aws-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/aws-glue-job/02-inputs-optional.tf
@@ -209,4 +209,9 @@ variable "max_retries" {
   description = "Maximum number of times to retry this job if it fails"
   type        = number
   default     = 0
+
+  validation {
+    condition     = var.max_retries >= 0 && var.max_retries <= 3
+    error_message = "Maximum number of retries must be between 0 and 3."
+  }
 }

--- a/terraform/modules/aws-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/aws-glue-job/02-inputs-optional.tf
@@ -204,3 +204,9 @@ variable "glue_version" {
     error_message = "Glue version supplied is not valid, must be \"1.0\", \"2.0\", \"3.0\" or \"4.0\"."
   }
 }
+
+variable "max_retries" {
+  description = "Maximum number of times to retry this job if it fails"
+  type        = number
+  default     = 0
+}

--- a/terraform/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/aws-glue-job/10-aws-glue-job.tf
@@ -35,6 +35,7 @@ resource "aws_glue_job" "job" {
   name              = "${local.job_name_prefix}${var.job_name}"
   number_of_workers = var.number_of_workers_for_glue_job
   worker_type       = var.glue_job_worker_type
+  max_retries       = var.max_retries
   role_arn          = local.glue_role_arn
   timeout           = var.glue_job_timeout
   connections       = var.jdbc_connections

--- a/terraform/modules/google-sheets-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/google-sheets-glue-job/02-inputs-optional.tf
@@ -32,3 +32,9 @@ variable "create_workflow" {
   type        = bool
   default     = false
 }
+
+variable "max_retries" {
+  description = "Maximum number of times to retry this job if it fails"
+  type        = number
+  default     = 2
+}

--- a/terraform/modules/google-sheets-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/google-sheets-glue-job/02-inputs-optional.tf
@@ -37,4 +37,9 @@ variable "max_retries" {
   description = "Maximum number of times to retry this job if it fails"
   type        = number
   default     = 2
+
+  validation {
+    condition     = var.max_retries >= 0 && var.max_retries <= 3
+    error_message = "Maximum number of retries must be between 0 and 3."
+  }
 }

--- a/terraform/modules/google-sheets-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/google-sheets-glue-job/10-aws-glue-job.tf
@@ -22,6 +22,7 @@ module "google_sheet_import" {
   }
   workflow_name   = var.create_workflow ? aws_glue_workflow.workflow[0].name : null
   schedule        = var.google_sheet_import_schedule
+  max_retries     = var.max_retries
   trigger_enabled = (var.is_live_environment && var.enable_glue_trigger)
   crawler_details = {
     database_name      = var.glue_catalog_database_name
@@ -38,5 +39,5 @@ module "google_sheet_import" {
 
 resource "aws_glue_workflow" "workflow" {
   count = var.create_workflow ? 1 : 0
-  name = "${var.identifier_prefix}${local.import_name}"
+  name  = "${var.identifier_prefix}${local.import_name}"
 }


### PR DESCRIPTION
These changes allow for the Glue jobs importing Google Sheets to automatically retry on failure to address recent problems with the API not returning the requested data. 

Will also allow users to specify the number of times a glue job can retry from the base module. 


Changes
- add max_tries variable to glue job module with default 0
- add max_tries variable to google spreadsheet import module with default 2