### PR TITLE
formatting for chat message

### DIFF
--- a/lambdas/glue_failure_gchat_notifications/main.py
+++ b/lambdas/glue_failure_gchat_notifications/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from os import getenv
+from urllib.parse import quote
 
 import boto3
 import urllib3
@@ -12,12 +13,15 @@ logger.setLevel(logging.INFO)
 def format_message(event) -> dict:
     timestamp = event["time"]
     job_name = event["detail"]["jobName"]
+    job_name_parsed = quote(job_name)
     job_run_id = event["detail"]["jobRunId"]
     error_message = event["detail"]["message"]
+    region = event["region"]
     return {
         "text": (
-            f"{timestamp} Glue failure detected for job: {job_name} run id:"
-            f" {job_run_id} Error message: {error_message}"
+            f"{timestamp} \nGlue failure detected for job: *{job_name}* \nrun:"
+            f" https://{region}.console.aws.amazon.com/gluestudio/home?region={region}#/job/{job_name_parsed}/run/{job_run_id} \nError"
+            f" message: {error_message}"
         )
     }
 

--- a/lambdas/glue_failure_gchat_notifications/test.py
+++ b/lambdas/glue_failure_gchat_notifications/test.py
@@ -43,7 +43,7 @@ class TestGlueAlarmsHandler(TestCase):
             "region": "test-region-2",
             "resources": [],
             "detail": {
-                "jobName": "test_job_name",
+                "jobName": "test job name",
                 "severity": "ERROR",
                 "state": "FAILED",
                 "jobRunId": "test_run_id123",
@@ -73,9 +73,10 @@ class TestGlueAlarmsHandler(TestCase):
     def test_format_message_returns_correct_message(self):
         expected_message = {
             "text": (
-                "2023-01-11T13:51:06Z Glue failure detected for job: test_job_name run"
-                " id: test_run_id123 Error message: An error occurred while running the"
-                " job."
+                "2023-01-11T13:51:06Z \nGlue failure detected for job: *test_job_name*"
+                " \nrun:"
+                " https://test-region-2.console.aws.amazon.com/gluestudio/home?region=test-region-2#/job/test%20job%20name/run/test_run_id123"
+                " \nError message: An error occurred while running the job."
             )
         }
         actual_message = format_message(self.cloudwatch_event)


### PR DESCRIPTION
Changes the formatting for Glue failure alert messages in Google Chat making the job name bold and providing a link for the run failure. 