### PR TITLE
DPP-370 add role inheritance support

### DIFF
--- a/scripts/configure_redshift.py
+++ b/scripts/configure_redshift.py
@@ -221,6 +221,7 @@ def configure_role_inheritance(redshift: Redshift, roles_configuration: json):
             grant_role_inheritance = [f"grant role {role_to_inherit_from} to role {role_name};" for role_to_inherit_from in
                                         role["roles_to_inherit_permissions_from"]]
             redshift.execute_batch_queries(grant_role_inheritance)
+            print(f"Applied role grants for role {role_name}")
 
 def main(terraform_output = None, redshift_instance = None) -> None:
     secrets_manager: BaseClient = boto3.client('secretsmanager')

--- a/scripts/configure_redshift.py
+++ b/scripts/configure_redshift.py
@@ -213,6 +213,14 @@ def grant_permissions_to_roles(redshift: Redshift, roles_configuration: list) ->
     
     print(f"Granted permissions for roles: {', '.join(role_names)}")
 
+def configure_role_inheritance(redshift: Redshift, roles_configuration: json):
+    for role in roles_configuration:
+        role_name = role["role_name"]
+        
+        if "roles_to_inherit_permissions_from" in role and len(role["roles_to_inherit_permissions_from"]) > 0:
+            grant_role_inheritance = [f"grant role {role_to_inherit_from} to role {role_name};" for role_to_inherit_from in
+                                        role["roles_to_inherit_permissions_from"]]
+            redshift.execute_batch_queries(grant_role_inheritance)
 
 def main(terraform_output = None, redshift_instance = None) -> None:
     secrets_manager: BaseClient = boto3.client('secretsmanager')
@@ -249,6 +257,7 @@ def main(terraform_output = None, redshift_instance = None) -> None:
     if roles_configuration_exists:
         create_roles(redshift, roles_configuration)    
         grant_permissions_to_roles(redshift, roles_configuration)
+        configure_role_inheritance(redshift, roles_configuration)
 
 if __name__ == '__main__':
     main()

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -16,6 +16,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "create_roles: mark tests for create roles function")
     config.addinivalue_line("markers", "get_role_names: mark tests for get role names function")
     config.addinivalue_line("markers", "get_roles: mark tests for get roles function")
+    config.addinivalue_line("markers", "configure_role_inheritance: mark tests for configure role inheritance function")
 
 @pytest.fixture(scope='session')
 def terraform_output():
@@ -44,6 +45,9 @@ def terraform_output():
                     },
                     {
                         "role_name": "role_two",
+                        "roles_to_inherit_permissions_from": [
+                            "role_one"
+                        ],
                         "schemas_to_grant_access_to": [
                             "schema_four",
                             "schema_five",

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
@@ -65,3 +65,11 @@ class TestConfigureRoleInheritance():
         configure_role_inheritance(redshift_mock, terraform_output_with_one_role_config_json)
 
         spy.assert_not_called()
+    
+    @pytest.mark.configure_role_inheritance
+    def test_configure_role_inheritance_outputs_message_when_role_inheritance_is_added(self, redshift_mock, terraform_output_json, capfd):
+        configure_role_inheritance(redshift_mock, terraform_output_json)
+
+        readout = capfd.readouterr()
+
+        assert readout.out == "Applied role grants for role role_two\n"

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
@@ -1,0 +1,67 @@
+import json
+import pytest
+from scripts.configure_redshift import main, Redshift, configure_role_inheritance
+
+class TestConfigureRoleInheritance():
+
+    @pytest.fixture(scope="function", autouse=True)
+    def boto3_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.boto3')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def create_schemas_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_schemas')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_users')
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.grant_permissions_to_users')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_users(self, mocker):
+        return mocker.patch('scripts.configure_redshift.get_roles_to_be_added')
+
+    @pytest.fixture(scope="function")
+    def configure_role_inheritance_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_role_inheritance')
+    
+    @pytest.fixture(scope="function")
+    def redshift_mock(self, mocker):
+        return mocker.Mock(autospec=Redshift)
+
+    @pytest.fixture(scope="session")
+    def terraform_output_json(self, terraform_output):
+        return json.loads(terraform_output)['redshift_roles']['value'] 
+
+    @pytest.fixture(scope="session")
+    def terraform_output_with_one_role_config_json(self, terraform_output_with_one_role):
+        return json.loads(terraform_output_with_one_role)['redshift_roles']['value'] 
+
+    @pytest.mark.main
+    def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):
+        main(terraform_output, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 1
+
+    @pytest.mark.configure_role_inheritance
+    def test_main_does_not_call_configure_role_inhertance_when_role_configuration_is_not_present(self, redshift_mock, terraform_output_without_roles_config, configure_role_inheritance_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 0
+    
+    @pytest.mark.configure_role_inheritance
+    def test_configure_role_inheritance_calls_execute_batch_queries_on_redshift_to_grant_a_role_access_to_other_role(self, mocker, redshift_mock, terraform_output_json):
+        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+        expected_query = ['grant role role_one to role role_two;']
+
+        configure_role_inheritance(redshift_mock, terraform_output_json)
+
+        spy.assert_called_once_with(expected_query)
+
+    @pytest.mark.configure_role_inheritance
+    def test_configure_role_inheritance_ignores_roles_that_are_missing_inheritance_configuration(self, mocker, redshift_mock, terraform_output_with_one_role_config_json):
+        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+        configure_role_inheritance(redshift_mock, terraform_output_with_one_role_config_json)
+
+        spy.assert_not_called()

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
@@ -1,5 +1,5 @@
-import pytest
-from scripts.configure_redshift import Redshift, main
+import pytest, json
+from scripts.configure_redshift import Redshift, main, grant_permissions_to_roles
 from unittest.mock import call
 
 class TestConfigureRolePermissions():
@@ -35,6 +35,10 @@ class TestConfigureRolePermissions():
     @pytest.fixture(scope="function", autouse=True)
     def grant_permissions_to_users(self, mocker):
         return mocker.patch('scripts.configure_redshift.grant_permissions_to_users')
+
+    @pytest.fixture(scope="session")
+    def terraform_output_json(self, terraform_output):
+        return json.loads(terraform_output)['redshift_roles']['value'] 
 
     #main
     @pytest.mark.main
@@ -112,8 +116,8 @@ class TestConfigureRolePermissions():
         redshift_mock.assert_has_calls(expected_calls, any_order=False)
 
     @pytest.mark.grant_permissions_to_roles
-    def test_graant_permissions_to_roles_outputs_message_when_roles_were_created(self, redshift_mock, terraform_output, capfd):
-        main(terraform_output, redshift_mock)
+    def test_graant_permissions_to_roles_outputs_message_when_roles_were_created(self, redshift_mock, terraform_output_json, capfd):
+        grant_permissions_to_roles(redshift_mock, terraform_output_json)
 
         readout = capfd.readouterr()
 


### PR DESCRIPTION
This update adds role inheritance support for Redshift roles configuration. This will be used in the new RBAC setup.

If any of the roles should inherit permissions from another one the following configuration can be added to the role configuration in Terraform:
```
 roles_to_inherit_permissions_from = [
        "${module.department_parking_data_source.identifier_snake_case}_ro"
      ]
```
There's also an update to a test that's not directly related to this function. That's one example test that should be refactored to reduce its scope to be more appropriate for a unit test.
