### PR TITLE
DPP-376 Add revoke role grants support

### DIFF
--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -17,7 +17,8 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "get_role_names: mark tests for get role names function")
     config.addinivalue_line("markers", "get_roles: mark tests for get roles function")
     config.addinivalue_line("markers", "configure_role_inheritance: mark tests for configure role inheritance function")
-
+    config.addinivalue_line("markers", "revoke_role_grants: mark tests for revoke role grants function")
+    
 @pytest.fixture(scope='session')
 def terraform_output():
   return """{

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
@@ -39,6 +39,10 @@ class TestConfigureRoleInheritance():
     @pytest.fixture(scope="session")
     def terraform_output_with_one_role_config_json(self, terraform_output_with_one_role):
         return json.loads(terraform_output_with_one_role)['redshift_roles']['value'] 
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def revoke_role_grants(self, mocker):
+        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
 
     @pytest.mark.main
     def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
@@ -39,6 +39,10 @@ class TestConfigureRolePermissions():
     @pytest.fixture(scope="session")
     def terraform_output_json(self, terraform_output):
         return json.loads(terraform_output)['redshift_roles']['value'] 
+    
+    @pytest.fixture(scope="function", autouse=True)
+    def revoke_role_grants(self, mocker):
+        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
 
     #main
     @pytest.mark.main

--- a/scripts/tests/redshift_configuration/test_create_redshift_roles.py
+++ b/scripts/tests/redshift_configuration/test_create_redshift_roles.py
@@ -45,6 +45,10 @@ class TestCreateRedshiftRoles():
     def grant_permissions_to_users(self, mocker):
         return mocker.patch('scripts.configure_redshift.configure_users')
 
+    @pytest.fixture(scope="function", autouse=True)
+    def revoke_role_grants(self, mocker):
+        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
+
     #main
     @pytest.mark.main
     def test_main_skips_create_roles_if_role_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, create_roles_mock):

--- a/scripts/tests/redshift_configuration/test_revoke_role_grants.py
+++ b/scripts/tests/redshift_configuration/test_revoke_role_grants.py
@@ -1,4 +1,5 @@
-import pytest, json
+import pytest
+import json
 from scripts.configure_redshift import Redshift, revoke_role_grants
 from unittest import mock
 

--- a/scripts/tests/redshift_configuration/test_revoke_role_grants.py
+++ b/scripts/tests/redshift_configuration/test_revoke_role_grants.py
@@ -1,0 +1,65 @@
+import pytest, json
+from scripts.configure_redshift import Redshift, revoke_role_grants
+from unittest import mock
+
+class TestRevokeRoleGrants():
+
+    @pytest.fixture(scope="function", autouse=True)
+    def boto_3_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.boto3')
+    
+    @pytest.fixture(scope="function")
+    def terraform_output_json(self, terraform_output):
+        return json.loads(terraform_output)['redshift_roles']['value']
+
+    @pytest.fixture(scope="function")
+    def query_id(self):
+        return "aaa111bb-1234-1234-1234-123456789abc" 
+    
+    @pytest.fixture(scope="function")
+    def redshift_mock(self, query_id):
+        redshift_mock = mock.create_autospec(Redshift)
+        redshift_mock.execute_query.return_value = query_id
+        redshift_mock.get_results.return_value = [[{'stringValue': 'role_ten'}]]  
+        return redshift_mock
+
+    @pytest.mark.revoke_role_grants
+    def test_revoke_role_grants_calls_execute_query_on_redshift_to_get_query_id_for_fetching_the_role_grant_results(self, redshift_mock, terraform_output_json):
+        exptected_get_role_grants_query = "select granted_role_name from svv_role_grants where role_name = 'role_two';"
+
+        revoke_role_grants(redshift_mock, terraform_output_json)
+
+        redshift_mock.execute_query.assert_called_once_with(exptected_get_role_grants_query)
+
+    @pytest.mark.revoke_role_grants
+    def test_revoke_role_grants_calls_get_results_on_redshift_with_correct_query_id_to_get_the_current_role_grants_for_a_given_role(self, redshift_mock, terraform_output_json, query_id):
+        revoke_role_grants(redshift_mock, terraform_output_json)
+
+        redshift_mock.get_results.assert_called_once_with(query_id)
+    
+    @pytest.mark.revoke_role_grants
+    def test_revoke_role_grants_calls_execute_batch_query_on_redshift_to_revoke_single_role_grant(self, terraform_output_json, redshift_mock):
+        expected_query = ['revoke role role_ten from role role_two;']
+
+        revoke_role_grants(redshift_mock, terraform_output_json)
+
+        redshift_mock.execute_batch_queries.assert_called_once_with(expected_query)
+
+    @pytest.mark.revoke_role_grants
+    def test_revoke_role_grants_calls_execute_batch_query_on_redshift_to_revoke_multiple_role_grants(self, terraform_output_json, redshift_mock):
+        redshift_mock.get_results.return_value = [[{'stringValue': 'role_ten'}], [{'stringValue': 'role_eleven'}]]       
+        expected_query = ['revoke role role_ten from role role_two;', 'revoke role role_eleven from role role_two;']
+
+        revoke_role_grants(redshift_mock, terraform_output_json)
+
+        redshift_mock.execute_batch_queries.assert_called_once_with(expected_query)
+
+    @pytest.mark.revoke_role_grants
+    def test_revoke_role_grants_outputs_correct_message_when_role_grants_are_revoke(self, redshift_mock, terraform_output_json, capfd):
+        redshift_mock.get_results.return_value = [[{'stringValue': 'role_ten'}], [{'stringValue': 'role_eleven'}]]      
+        
+        revoke_role_grants(redshift_mock, terraform_output_json)
+
+        redout = capfd.readouterr()
+
+        assert redout.out == "Revoked role grants: ['revoke role role_ten from role role_two;', 'revoke role role_eleven from role role_two;']\n"


### PR DESCRIPTION
This update will enable revoking Redshift role grants using Terraform configuration.

If role is removed from the `roles_to_inherit_permissions_from` configuration block the role grant will be removed automatically from Redshift the next time the pipeline runs. 