### PR TITLE
Refactor Redshift configuration script test setups

### DIFF
--- a/scripts/tests/redshift_configuration/test_configure_redshift.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift.py
@@ -1,0 +1,77 @@
+from unittest import mock
+import pytest
+from scripts.configure_redshift import main, Redshift
+
+class TestConfigureRedshift():
+
+    @pytest.fixture(scope="function", autouse=True)
+    def boto3_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.boto3')
+    
+    @pytest.fixture(scope="function")
+    def redshift_mock(self):
+        return mock.create_autospec(Redshift)
+
+    @pytest.fixture(scope="function", autouse=True)
+    def create_schemas_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_schemas')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_users_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_users')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def create_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.create_roles')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def grant_permissions_to_roles_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')   
+
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_role_inheritance_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_role_inheritance')
+
+    @pytest.fixture(scope="function", autouse=True)
+    def revoke_role_grants_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
+
+    @pytest.mark.main
+    def test_main_skips_create_roles_if_role_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, create_roles_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert create_roles_mock.call_count == 0
+    
+    @pytest.mark.main
+    def test_main_calls_create_roles_if_role_configuration_not_present(self, terraform_output, redshift_mock, create_roles_mock):
+        main(terraform_output, redshift_mock)
+        assert create_roles_mock.call_count == 1
+
+    @pytest.mark.main
+    def test_main_skips_grant_permissions_to_roles_when_roles_config_not_present(self, terraform_output_without_roles_config, redshift_mock, grant_permissions_to_roles_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert grant_permissions_to_roles_mock.call_count == 0
+    
+    @pytest.mark.main
+    def test_main_calls_grant_permissions_to_roles_when_roles_config_is_present(self, terraform_output, redshift_mock, grant_permissions_to_roles_mock):
+        main(terraform_output, redshift_mock)
+        assert grant_permissions_to_roles_mock.call_count == 1
+
+    @pytest.mark.main
+    def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):
+        main(terraform_output, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 1
+
+    @pytest.mark.main
+    def test_main_skips_call_configure_role_inhertance_when_role_configuration_is_not_present(self, redshift_mock, terraform_output_without_roles_config, configure_role_inheritance_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 0
+    
+    @pytest.mark.main
+    def test_main_skips_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output_without_roles_config, revoke_role_grants_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert revoke_role_grants_mock.call_count == 0
+
+    @pytest.mark.main
+    def test_main_calls_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output, revoke_role_grants_mock):
+        main(terraform_output, redshift_mock)
+        assert revoke_role_grants_mock.call_count == 1

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_inheritance.py
@@ -1,36 +1,13 @@
 import json
+from unittest import mock
 import pytest
-from scripts.configure_redshift import main, Redshift, configure_role_inheritance
+from scripts.configure_redshift import Redshift, configure_role_inheritance
 
 class TestConfigureRoleInheritance():
 
-    @pytest.fixture(scope="function", autouse=True)
-    def boto3_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.boto3')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def create_schemas_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_schemas')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def configure_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.configure_users')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def grant_permissions_to_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.grant_permissions_to_users')
-
-    @pytest.fixture(scope="function", autouse=True)
-    def grant_permissions_to_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.get_roles_to_be_added')
-
     @pytest.fixture(scope="function")
-    def configure_role_inheritance_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.configure_role_inheritance')
-    
-    @pytest.fixture(scope="function")
-    def redshift_mock(self, mocker):
-        return mocker.Mock(autospec=Redshift)
+    def redshift_mock(self):
+        return mock.create_autospec(Redshift)
 
     @pytest.fixture(scope="session")
     def terraform_output_json(self, terraform_output):
@@ -40,35 +17,19 @@ class TestConfigureRoleInheritance():
     def terraform_output_with_one_role_config_json(self, terraform_output_with_one_role):
         return json.loads(terraform_output_with_one_role)['redshift_roles']['value'] 
     
-    @pytest.fixture(scope="function", autouse=True)
-    def revoke_role_grants(self, mocker):
-        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
-
-    @pytest.mark.main
-    def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):
-        main(terraform_output, redshift_mock)
-        assert configure_role_inheritance_mock.call_count == 1
-
     @pytest.mark.configure_role_inheritance
-    def test_main_does_not_call_configure_role_inhertance_when_role_configuration_is_not_present(self, redshift_mock, terraform_output_without_roles_config, configure_role_inheritance_mock):
-        main(terraform_output_without_roles_config, redshift_mock)
-        assert configure_role_inheritance_mock.call_count == 0
-    
-    @pytest.mark.configure_role_inheritance
-    def test_configure_role_inheritance_calls_execute_batch_queries_on_redshift_to_grant_a_role_access_to_other_role(self, mocker, redshift_mock, terraform_output_json):
-        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+    def test_configure_role_inheritance_calls_execute_batch_queries_on_redshift_to_grant_a_role_access_to_other_role(self, redshift_mock, terraform_output_json):
         expected_query = ['grant role role_one to role role_two;']
 
         configure_role_inheritance(redshift_mock, terraform_output_json)
 
-        spy.assert_called_once_with(expected_query)
+        redshift_mock.execute_batch_queries.assert_called_once_with(expected_query)
 
     @pytest.mark.configure_role_inheritance
-    def test_configure_role_inheritance_ignores_roles_that_are_missing_inheritance_configuration(self, mocker, redshift_mock, terraform_output_with_one_role_config_json):
-        spy = mocker.spy(redshift_mock, "execute_batch_queries")
+    def test_configure_role_inheritance_ignores_roles_that_are_missing_inheritance_configuration(self, redshift_mock, terraform_output_with_one_role_config_json):
         configure_role_inheritance(redshift_mock, terraform_output_with_one_role_config_json)
 
-        spy.assert_not_called()
+        redshift_mock.execute_batch_queries.assert_not_called()
     
     @pytest.mark.configure_role_inheritance
     def test_configure_role_inheritance_outputs_message_when_role_inheritance_is_added(self, redshift_mock, terraform_output_json, capfd):

--- a/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift_role_permissions.py
@@ -1,80 +1,38 @@
+from unittest import mock
 import pytest, json
-from scripts.configure_redshift import Redshift, main, grant_permissions_to_roles
+from scripts.configure_redshift import Redshift, grant_permissions_to_roles
 from unittest.mock import call
 
 class TestConfigureRolePermissions():
 
     @pytest.fixture(scope="function")
-    def grant_permissions_to_roles_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_roles')
-
-    @pytest.fixture(scope="function")
     def redshift_mock(self, mocker):
-        return mocker.Mock(autospec=Redshift)
-
-    @pytest.fixture(scope="function", autouse=True)
-    def boto3_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.boto3')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def create_roles_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_roles')
-
-    @pytest.fixture(scope="function")
-    def grant_permissions_to_roles_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')
-
-    @pytest.fixture(scope="function", autouse=True)
-    def create_schemas_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_schemas')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def configure_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.configure_users')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def grant_permissions_to_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.grant_permissions_to_users')
+        redshift_mock = mocker.Mock(autospec=Redshift)
+        redshift_mock.database_name = mock.PropertyMock(return_value = "db_name")
+        return redshift_mock
 
     @pytest.fixture(scope="session")
     def terraform_output_json(self, terraform_output):
         return json.loads(terraform_output)['redshift_roles']['value'] 
     
-    @pytest.fixture(scope="function", autouse=True)
-    def revoke_role_grants(self, mocker):
-        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
-
-    #main
-    @pytest.mark.main
-    def test_main_calls_grant_permissions_to_roles_when_roles_config_is_present(self, terraform_output, redshift_mock, grant_permissions_to_roles_mock):
-        main(terraform_output, redshift_mock)
-
-        assert grant_permissions_to_roles_mock.call_count == 1
-    
-    @pytest.mark.main
-    def test_main_skips_grant_permissions_to_roles_when_roles_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, grant_permissions_to_roles_mock):
-        main(terraform_output_without_roles_config, redshift_mock)
-
-        assert grant_permissions_to_roles_mock.call_count == 0
-
-    #grant_permissions_to_roles
+    @pytest.fixture(scope="session")
+    def terraform_output_with_one_role_json(self, terraform_output_with_one_role):
+        return json.loads(terraform_output_with_one_role)['redshift_roles']['value'] 
+   
     @pytest.mark.grant_permissions_to_roles
-    def test_grant_permissions_to_roles_calls_execute_query_on_redshift_to_grant_temp_permissions_to_database_when_config_is_present(self, mocker, redshift_mock, terraform_output):
+    def test_grant_permissions_to_roles_calls_execute_query_on_redshift_to_grant_temp_permissions_to_database_when_config_is_present(self, redshift_mock, terraform_output_json):
         role_name_one = "role_one"
         role_name_two = "role_two"
-        spy = mocker.spy(redshift_mock, "execute_query")
         expected_query_one = f"grant temp on database {redshift_mock.database_name} to role {role_name_one};"
         expected_query_two = f"grant temp on database {redshift_mock.database_name} to role {role_name_two};"
         
-        main(terraform_output, redshift_mock)
+        grant_permissions_to_roles(redshift_mock, terraform_output_json)
 
-        spy.assert_any_call(expected_query_one) 
-        spy.assert_any_call(expected_query_two) 
+        redshift_mock.execute_query.assert_any_call(expected_query_one) 
+        redshift_mock.execute_query.assert_any_call(expected_query_two) 
 
     @pytest.mark.grant_permissions_to_roles
-    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_schema_permissions_when_config_is_present(self, mocker, redshift_mock, terraform_output):
-        spy = mocker.spy(redshift_mock, "execute_batch_queries")
-
+    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_schema_permissions_when_config_is_present(self, redshift_mock, terraform_output_json):
         expected_queries_for_role_one = ['grant usage on schema schema_one to role role_one;',
                                          'grant usage on schema schema_two to role role_one;',
                                          'grant usage on schema schema_three to role role_one;']
@@ -83,33 +41,33 @@ class TestConfigureRolePermissions():
                                          'grant usage on schema schema_five to role role_two;',
                                          'grant usage on schema schema_six to role role_two;']
 
-        main(terraform_output, redshift_mock)
+        grant_permissions_to_roles(redshift_mock, terraform_output_json)
 
-        spy.assert_any_call(expected_queries_for_role_one)
-        spy.assert_any_call(expected_queries_for_role_two)
+        redshift_mock.execute_batch_queries.assert_any_call(expected_queries_for_role_one)
+        redshift_mock.execute_batch_queries.assert_any_call(expected_queries_for_role_two)
 
     @pytest.mark.grant_permissions_to_roles
-    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_table_permissions_on_allowed_schemas(self, mocker, redshift_mock, terraform_output):
-        spy = mocker.spy(redshift_mock, "execute_batch_queries")
-
+    def test_grant_permissions_to_roles_calls_execute_batch_queries_on_redshift_to_grant_table_permissions_on_allowed_schemas(self, redshift_mock, terraform_output_json):
         expected_queries_for_role_one = ['grant select on all tables in schema schema_one to role role_one;',
                                          'grant select on all tables in schema schema_two to role role_one;',
                                          'grant select on all tables in schema schema_three to role role_one;']
 
-        expected_queries_for_role_two = ['grant select on all tables in schema schema_four to role role_two;', 'grant select on all tables in schema schema_five to role role_two;', 'grant select on all tables in schema schema_six to role role_two;']
+        expected_queries_for_role_two = ['grant select on all tables in schema schema_four to role role_two;', 
+                                         'grant select on all tables in schema schema_five to role role_two;', 
+                                         'grant select on all tables in schema schema_six to role role_two;']
 
-        main(terraform_output, redshift_mock)
+        grant_permissions_to_roles(redshift_mock, terraform_output_json)
 
-        spy.assert_any_call(expected_queries_for_role_one)
-        spy.assert_any_call(expected_queries_for_role_two)
+        redshift_mock.execute_batch_queries.assert_any_call(expected_queries_for_role_one)
+        redshift_mock.execute_batch_queries.assert_any_call(expected_queries_for_role_two)
     
     @pytest.mark.grant_permissions_to_roles
-    def test_grant_permissions_roles_calls_redshift_with_queries_in_the_correct_order(self, redshift_mock, terraform_output_with_one_role):
+    def test_grant_permissions_roles_calls_redshift_with_queries_in_the_correct_order(self, redshift_mock, terraform_output_with_one_role_json):
         expected_temp_database_access_query = f"grant temp on database {redshift_mock.database_name} to role role_one;"
         expected_schema_usage_query         = ['grant usage on schema schema_one to role role_one;']
         expected_table_access_query         = ['grant select on all tables in schema schema_one to role role_one;']
 
-        main(terraform_output_with_one_role, redshift_mock)
+        grant_permissions_to_roles(redshift_mock, terraform_output_with_one_role_json)
 
         expected_calls = [
             call.execute_query(expected_temp_database_access_query),

--- a/scripts/tests/redshift_configuration/test_create_redshift_roles.py
+++ b/scripts/tests/redshift_configuration/test_create_redshift_roles.py
@@ -1,21 +1,13 @@
+from unittest import mock
 import pytest
-from scripts.configure_redshift import create_roles, get_role_names_from_configuration, get_roles_to_be_added, main, Redshift
+from scripts.configure_redshift import create_roles, get_role_names_from_configuration, get_roles_to_be_added, Redshift
 import json
 
 class TestCreateRedshiftRoles():
 
     @pytest.fixture(scope='function')
     def redshift_mock(self, mocker):
-        return mocker.Mock(spec=Redshift)
-
-    #boto3 is not relevant here, so patch it automatically for every test
-    @pytest.fixture(scope='function', autouse=True)
-    def boto3_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.boto3')
-
-    @pytest.fixture(scope='function')
-    def create_roles_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_roles')
+        return mock.create_autospec(Redshift)
 
     @pytest.fixture(scope='function', autouse=True)
     def get_roles_to_be_added_mock(self, mocker):
@@ -28,46 +20,6 @@ class TestCreateRedshiftRoles():
     @pytest.fixture(scope='session')
     def terraform_output_json(self, terraform_output):
         return json.loads(terraform_output)['redshift_roles']['value']   
-
-    @pytest.fixture(scope="function", autouse=True)
-    def grant_permissions_to_roles_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def create_schemas_mock(self, mocker):
-        return mocker.patch('scripts.configure_redshift.create_schemas')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def configure_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.configure_users')
-    
-    @pytest.fixture(scope="function", autouse=True)
-    def grant_permissions_to_users(self, mocker):
-        return mocker.patch('scripts.configure_redshift.configure_users')
-
-    @pytest.fixture(scope="function", autouse=True)
-    def revoke_role_grants(self, mocker):
-        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
-
-    #main
-    @pytest.mark.main
-    def test_main_skips_create_roles_if_role_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, create_roles_mock):
-        main(terraform_output_without_roles_config, redshift_mock)
-        
-        assert create_roles_mock.call_count == 0
-
-    @pytest.mark.main
-    def test_main_outputs_a_message_when_roles_configuration_not_present(self, terraform_output_without_roles_config, capfd, redshift_mock):
-        main(terraform_output_without_roles_config, redshift_mock)
-
-        readout = capfd.readouterr()
-        assert readout.out == "No role configuration found\n"    
-
-    @pytest.mark.main
-    def test_main_calls_create_roles_with_role_configuration(self, terraform_output, redshift_mock, create_roles_mock, terraform_output_json):
-        main(terraform_output, redshift_mock)    
-        
-        create_roles_mock.assert_called_once_with(redshift_mock, terraform_output_json)
 
     #get_role_names
     @pytest.mark.get_role_names
@@ -87,21 +39,19 @@ class TestCreateRedshiftRoles():
 
     @pytest.mark.create_roles
     def test_create_roles_calls_execute_query_on_redshift_with_correct_params_when_provided_roles_list_is_valid(self, mocker, redshift_mock, terraform_output_json):
-        spy = mocker.spy(redshift_mock, "execute_query")
         expected_query = "select role_name from svv_roles where role_name in('role_one','role_two');"
         
         create_roles(redshift_mock, terraform_output_json)
 
-        spy.assert_called_once_with(expected_query)
+        redshift_mock.execute_query.assert_called_once_with(expected_query)
     
     @pytest.mark.create_roles
     def test_create_roles_calls_get_results_on_redshift_with_correct_query_id(self, mocker, redshift_mock, terraform_output_json):
-        spy = mocker.spy(redshift_mock, "get_results")
         redshift_mock.execute_query.side_effect = "1"
 
         create_roles(redshift_mock, terraform_output_json)
 
-        spy.assert_called_once_with("1")
+        redshift_mock.get_results.assert_called_once_with("1")
 
     @pytest.mark.create_roles
     def test_create_roles_calls_get_roles_to_be_added(self, redshift_mock, get_roles_to_be_added_mock, terraform_output_json):
@@ -111,13 +61,12 @@ class TestCreateRedshiftRoles():
 
     @pytest.mark.create_roles
     def test_create_roles_calls_execute_batch_queries_on_redshift_when_there_are_new_roles_to_be_added(self, mocker, capfd, redshift_mock, terraform_output_json):
-        spy = mocker.spy(redshift_mock, "execute_batch_queries")
         mocker.patch('scripts.configure_redshift.get_roles_to_be_added', return_value=['role_three'])
         expected_query = ['CREATE ROLE role_three']
         
         create_roles(redshift_mock, terraform_output_json)
     
-        spy.assert_called_once_with(expected_query)
+        redshift_mock.execute_batch_queries.assert_called_once_with(expected_query)
         readout = capfd.readouterr()
 
         assert readout.out == "Added following roles: ['role_three']\n"
@@ -161,4 +110,3 @@ class TestCreateRedshiftRoles():
 
         #order doesn't matter, so just check that lists have the same items
         assert sorted(get_roles_to_be_added(existing_roles_in_redshift, roles_config)) == sorted(new_roles_to_be_added)
-   


### PR DESCRIPTION
- More consistent and robust mock setups
- Fix test scopes so we have only unit tests at this point
- Move role related tests for the main function into separate file