### PR TITLE
DPP-377 stop assuming role when deploying to dev

### DIFF
--- a/terraform/core/00-init.tf
+++ b/terraform/core/00-init.tf
@@ -1,27 +1,42 @@
 # Core Infrastructure
 provider "aws" {
   region = var.aws_deploy_region
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "Terraform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : []
+
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "Terraform"
+    }
   }
 }
 
 provider "aws" {
   alias  = "aws_api_account"
   region = var.aws_deploy_region
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_api_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "Terraform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : []
+
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_api_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "Terraform"
+    }
   }
 }
 
 provider "aws" {
   alias  = "aws_hackit_account"
   region = "eu-west-1"
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_hackit_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "DataPlatform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : []
+    
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_hackit_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "DataPlatform"
+    }
   }
 }
 

--- a/terraform/etl/00-init.tf
+++ b/terraform/etl/00-init.tf
@@ -1,27 +1,42 @@
 # Core Infrastructure
 provider "aws" {
   region = var.aws_deploy_region
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "Terraform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : []
+    
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "Terraform"
+    }
   }
 }
 
 provider "aws" {
   alias  = "aws_api_account"
   region = var.aws_deploy_region
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_api_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "Terraform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : [] 
+    
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_api_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "Terraform"
+    }
   }
 }
 
 provider "aws" {
   alias  = "aws_hackit_account"
   region = "eu-west-1"
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_hackit_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "DataPlatform"
+  
+  dynamic assume_role {
+    for_each = local.is_live_environment ? [1] : [] 
+    
+    content {
+      role_arn     = "arn:aws:iam::${var.aws_hackit_account_id}:role/${var.aws_deploy_iam_role_name}"
+      session_name = "DataPlatform"
+    }
   }
 }
 


### PR DESCRIPTION
Individuals do not have permissions to assume the deployment role anymore, so the configuration has been updated to only assume the role when running in live environments (pre-prod and prod). This allows developers to deploy to dev using their own credentials.

This update only resolves the issue for Core and ETL. Networking has some other dependencies that has to be handled separately.