### PR TITLE
DPP-342 Add redshift roles output

### DIFF
--- a/terraform/etl/99-outputs.tf
+++ b/terraform/etl/99-outputs.tf
@@ -15,3 +15,8 @@ output "redshift_users" {
   value     = local.redshift_users
   sensitive = true
 }
+
+output "redshift_roles" {
+  value     = local.redshift_roles
+  sensitive = true
+}


### PR DESCRIPTION
Add output for redshift roles configuration. This is required as input for the redshift configuration script.