### PR TITLE
DPP-341 Enable Redshift role inheritance config

### DIFF
--- a/scripts/configure_redshift.py
+++ b/scripts/configure_redshift.py
@@ -277,8 +277,8 @@ def main(terraform_output = None, redshift_instance = None) -> None:
     if roles_configuration_exists:
         create_roles(redshift, roles_configuration)    
         grant_permissions_to_roles(redshift, roles_configuration)
-        #configure_role_inheritance(redshift, roles_configuration)
-        #revoke_role_grants(redshift, roles_configuration)
+        configure_role_inheritance(redshift, roles_configuration)
+        revoke_role_grants(redshift, roles_configuration)
 
 if __name__ == '__main__':
     main()

--- a/scripts/tests/redshift_configuration/test_configure_redshift.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift.py
@@ -56,22 +56,22 @@ class TestConfigureRedshift():
         main(terraform_output, redshift_mock)
         assert grant_permissions_to_roles_mock.call_count == 1
 
-    # @pytest.mark.main
-    # def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):
-    #     main(terraform_output, redshift_mock)
-    #     assert configure_role_inheritance_mock.call_count == 1
+    @pytest.mark.main
+    def test_main_calls_configure_role_inheritance_when_role_configuration_is_present(self, redshift_mock, terraform_output, configure_role_inheritance_mock):
+        main(terraform_output, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 1
 
-    # @pytest.mark.main
-    # def test_main_skips_call_configure_role_inhertance_when_role_configuration_is_not_present(self, redshift_mock, terraform_output_without_roles_config, configure_role_inheritance_mock):
-    #     main(terraform_output_without_roles_config, redshift_mock)
-    #     assert configure_role_inheritance_mock.call_count == 0
+    @pytest.mark.main
+    def test_main_skips_call_configure_role_inhertance_when_role_configuration_is_not_present(self, redshift_mock, terraform_output_without_roles_config, configure_role_inheritance_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert configure_role_inheritance_mock.call_count == 0
     
-    # @pytest.mark.main
-    # def test_main_skips_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output_without_roles_config, revoke_role_grants_mock):
-    #     main(terraform_output_without_roles_config, redshift_mock)
-    #     assert revoke_role_grants_mock.call_count == 0
+    @pytest.mark.main
+    def test_main_skips_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output_without_roles_config, revoke_role_grants_mock):
+        main(terraform_output_without_roles_config, redshift_mock)
+        assert revoke_role_grants_mock.call_count == 0
 
-    # @pytest.mark.main
-    # def test_main_calls_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output, revoke_role_grants_mock):
-    #     main(terraform_output, redshift_mock)
-    #     assert revoke_role_grants_mock.call_count == 1
+    @pytest.mark.main
+    def test_main_calls_revoke_role_grants_when_role_configuration_is_present(self, redshift_mock, terraform_output, revoke_role_grants_mock):
+        main(terraform_output, redshift_mock)
+        assert revoke_role_grants_mock.call_count == 1

--- a/scripts/tests/redshift_configuration/test_configure_redshift.py
+++ b/scripts/tests/redshift_configuration/test_configure_redshift.py
@@ -28,13 +28,13 @@ class TestConfigureRedshift():
     def grant_permissions_to_roles_mock(self, mocker):
         return mocker.patch('scripts.configure_redshift.grant_permissions_to_roles')   
 
-    # @pytest.fixture(scope="function", autouse=True)
-    # def configure_role_inheritance_mock(self, mocker):
-    #     return mocker.patch('scripts.configure_redshift.configure_role_inheritance')
+    @pytest.fixture(scope="function", autouse=True)
+    def configure_role_inheritance_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.configure_role_inheritance')
 
-    # @pytest.fixture(scope="function", autouse=True)
-    # def revoke_role_grants_mock(self, mocker):
-    #     return mocker.patch('scripts.configure_redshift.revoke_role_grants')
+    @pytest.fixture(scope="function", autouse=True)
+    def revoke_role_grants_mock(self, mocker):
+        return mocker.patch('scripts.configure_redshift.revoke_role_grants')
 
     @pytest.mark.main
     def test_main_skips_create_roles_if_role_configuration_not_present(self, terraform_output_without_roles_config, redshift_mock, create_roles_mock):


### PR DESCRIPTION
Enable previously commented out code for Redshift role inheritance configuration. This will complete the initial RBAC setup.