### PR TITLE
DPP-97 Forward to saml url on http

### DIFF
--- a/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
+++ b/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
@@ -98,6 +98,7 @@ resource "aws_alb_listener" "qlik_sense_http" {
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
+      path        = "/saml/hub"
     }
   }
 }


### PR DESCRIPTION
Forward requests for port 80 to HTPPS SAML url.