### PR TITLE
DPP-97 Revert back to lb_cookie

### DIFF
--- a/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
+++ b/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
@@ -62,7 +62,7 @@ resource "aws_alb_target_group" "qlik-sense" {
   }
 
   stickiness {
-    type = "app_cookie"
+    type = "lb_cookie"
   }
 }
 


### PR DESCRIPTION
app_cookie requires additional configuration missing from previous change, so this update will revert the change for now.