### PR TITLE
DPP-97 Add S3 bucket for Qlik ALB logs

### DIFF
--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -1,10 +1,12 @@
 Feature: S3
 
   @exclude_aws_s3_bucket.ssl_connection_resources\[0\]
+  @exclude_aws_s3_bucket.qlik_alb_logs\[0\]
   Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource
     Given I have aws_s3_bucket defined
     Then it must have server_side_encryption_configuration
 
+  @exclude_aws_s3_bucket.ssl_connection_resources\[0\]
   @exclude_module.athena_storage.aws_s3_bucket.bucket
   @exclude_module.glue_scripts.aws_s3_bucket.bucket
   @exclude_module.glue_temp_storage.aws_s3_bucket.bucket
@@ -17,6 +19,10 @@ Feature: S3
   @exclude_module.refined_zone.aws_s3_bucket.bucket
   @exclude_module.spark_ui_output_storage.aws_s3_bucket.bucket
   @exclude_module.trusted_zone.aws_s3_bucket.bucket
+  @exclude_module.kafka_dependency_storage.aws_s3_bucket.bucket
+  @exclude_module.rds_export_storage.aws_s3_bucket.bucket
+  @exclude_aws_s3_bucket.cloudtrail
+
   Scenario: Data must be encrypted at rest for buckets created using separate server side configuration resource
     Given I have aws_s3_bucket defined
     Then it must have aws_s3_bucket_server_side_encryption_configuration

--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -1,7 +1,7 @@
 Feature: S3
 
   @exclude_aws_s3_bucket.ssl_connection_resources\[0\]
-  @exclude_aws_s3_bucket.qlik_alb_logs\[0\]
+  @exclude_module.qlik_server\[0\].aws_s3_bucket.qlik_alb_logs\[0\]
   Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource
     Given I have aws_s3_bucket defined
     Then it must have server_side_encryption_configuration
@@ -19,10 +19,10 @@ Feature: S3
   @exclude_module.refined_zone.aws_s3_bucket.bucket
   @exclude_module.spark_ui_output_storage.aws_s3_bucket.bucket
   @exclude_module.trusted_zone.aws_s3_bucket.bucket
-  @exclude_module.kafka_dependency_storage.aws_s3_bucket.bucket
-  @exclude_module.rds_export_storage.aws_s3_bucket.bucket
-  @exclude_aws_s3_bucket.cloudtrail
-
+  @exclude_module.kafka_event_streaming\[0\].module.kafka_dependency_storage.aws_s3_bucket.bucket
+  @exclude_module.db_snapshot_to_s3\[0\].module.rds_export_storage.aws_s3_bucket.bucket
+  @exclude_module.liberator_dump_to_rds_snapshot\[0\].aws_s3_bucket.cloudtrail
+  @exclude_module.liberator_db_snapshot_to_s3\[0\].module.rds_export_storage.aws_s3_bucket.bucket 
   Scenario: Data must be encrypted at rest for buckets created using separate server side configuration resource
     Given I have aws_s3_bucket defined
     Then it must have aws_s3_bucket_server_side_encryption_configuration

--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -1,6 +1,22 @@
 Feature: S3
 
   @exclude_aws_s3_bucket.ssl_connection_resources\[0\]
-  Scenario: Data must be encrypted at rest
+  Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource
     Given I have aws_s3_bucket defined
     Then it must have server_side_encryption_configuration
+
+  @exclude_module.athena_storage.aws_s3_bucket.bucket
+  @exclude_module.glue_scripts.aws_s3_bucket.bucket
+  @exclude_module.glue_temp_storage.aws_s3_bucket.bucket
+  @exclude_module.lambda_artefact_storage.aws_s3_bucket.bucket
+  @exclude_module.lambda_artefact_storage_for_api_account.aws_s3_bucket.bucket
+  @exclude_module.landing_zone.aws_s3_bucket.bucket
+  @exclude_module.liberator_data_storage.aws_s3_bucket.bucket
+  @exclude_module.noiseworks_data_storage.aws_s3_bucket.bucket
+  @exclude_module.raw_zone.aws_s3_bucket.bucket
+  @exclude_module.refined_zone.aws_s3_bucket.bucket
+  @exclude_module.spark_ui_output_storage.aws_s3_bucket.bucket
+  @exclude_module.trusted_zone.aws_s3_bucket.bucket
+  Scenario: Data must be encrypted at rest for buckets created using separate server side configuration resource
+    Given I have aws_s3_bucket defined
+    Then it must have aws_s3_bucket_server_side_encryption_configuration

--- a/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
+++ b/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
@@ -11,6 +11,7 @@ resource "aws_s3_bucket_acl" "qlik_alb_logs" {
 }
 
 resource "aws_s3_bucket_public_access_block" "qlik_alb_logs_public_access" {
+  count  = var.is_live_environment ? 1 : 0
   bucket = aws_s3_bucket.qlik_alb_logs[0].id
 
   block_public_acls       = true
@@ -113,7 +114,7 @@ data "aws_iam_policy_document" "write_access_for_aws_loggers" {
   }
 }
 
-resource "aws_s3_bucket_policy" "write_access_aws_for_loggers" {
+resource "aws_s3_bucket_policy" "write_access_for_aws_loggers" {
   count  = var.is_live_environment ? 1 : 0
 
   bucket = aws_s3_bucket.qlik_alb_logs[0].id
@@ -121,6 +122,7 @@ resource "aws_s3_bucket_policy" "write_access_aws_for_loggers" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_lifecycle" {
+  count  = var.is_live_environment ? 1 : 0
   bucket = aws_s3_bucket.qlik_alb_logs[0].id
 
   rule {

--- a/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
+++ b/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
@@ -1,0 +1,147 @@
+resource "aws_s3_bucket" "qlik_alb_logs" {
+  count  = var.is_live_environment ? 1 : 0
+  tags   = var.tags
+  bucket = "${var.identifier_prefix}-qlik-alb-logs"
+}
+
+resource "aws_s3_bucket_acl" "qlik_alb_logs" {
+  count  = var.is_live_environment ? 1 : 0
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "qlik_alb_logs_public_access" {
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "qlik_alb_logs_s3_encryption" {
+  count  = var.is_live_environment ? 1 : 0
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "qlik_alb_logs_versioning" {
+  count  = var.is_live_environment ? 1 : 0
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+}
+
+data "aws_iam_policy_document" "write_access_for_aws_loggers" {
+  count  = var.is_live_environment ? 1 : 0
+  
+  statement {
+    sid    = "AWSLogDeliveryAclCheck"
+    effect = "Allow"
+
+    resources = [aws_s3_bucket.qlik_alb_logs[0].arn]
+    actions   = ["s3:GetBucketAcl"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:*"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "AWSLogDeliveryWrite"
+    effect = "Allow"
+    resources = [aws_s3_bucket.qlik_alb_logs[0].arn,
+    "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"]
+    actions = ["s3:PutObject"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:eu-west-2:${data.aws_caller_identity.current.account_id}:*"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "AllowELBAccountWriteAccess"
+    effect = "Allow"
+    resources = [aws_s3_bucket.qlik_alb_logs[0].arn,
+    "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"]
+    actions = ["s3:PutObject"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::652711504416:root"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "write_access_aws_for_loggers" {
+  count  = var.is_live_environment ? 1 : 0
+
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+  policy = data.aws_iam_policy_document.write_access_aws_for_loggers[0].json
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3_lifecycle" {
+  bucket = aws_s3_bucket.qlik_alb_logs[0].id
+
+  rule {
+    id = "rule-1"
+
+    filter {}
+
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 60
+      storage_class = "GLACIER"
+    }
+
+    expiration {
+      days = 90
+    }
+  }
+}

--- a/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
+++ b/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
@@ -118,7 +118,7 @@ resource "aws_s3_bucket_policy" "write_access_for_aws_loggers" {
   count  = var.is_live_environment ? 1 : 0
 
   bucket = aws_s3_bucket.qlik_alb_logs[0].id
-  policy = data.aws_iam_policy_document.write_access_aws_for_loggers[0].json
+  policy = data.aws_iam_policy_document.write_access_for_aws_loggers[0].json
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "s3_lifecycle" {


### PR DESCRIPTION
This update adds a S3 bucket for Qlik Application Load Balancer logs. Lifecycle configuration based on cloud engineers recommendations.

Also updates the Terraform compliance checks for S3 buckets to support both new and deprecated encryption configuration.

