### PR TITLE
DPP-95 Enable qlik alb logs

### DIFF
--- a/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
+++ b/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
@@ -85,6 +85,11 @@ resource "aws_alb" "qlik_sense" {
   lifecycle {
     prevent_destroy = true
   }
+
+  access_logs {
+    bucket  = aws_s3_bucket.qlik_alb_logs[0].id
+    enabled = true
+  }
 }
 
 resource "aws_alb_listener" "qlik_sense_http" {


### PR DESCRIPTION
This update enables Qlik ALB logs to be sent to S3 bucket created in [PR#1189](https://github.com/LBHackney-IT/Data-Platform/pull/1189) 