### PR TITLE
DPP-97 Add glue catalog database for alb logs

### DIFF
--- a/terraform/modules/qlik-sense-server/14-aws-glue-catalog-database.tf
+++ b/terraform/modules/qlik-sense-server/14-aws-glue-catalog-database.tf
@@ -1,0 +1,8 @@
+resource "aws_glue_catalog_database" "qlik_alb_logs" {
+  count = var.is_live_environment ? 1 : 0
+  name  = "${var.identifier_prefix}-qlik-alb-logs"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
Adds glue catalog database to be used for Qlik ALB logs.