### PR TITLE
DPP-378 disable startup script

### DIFF
--- a/terraform/modules/sagemaker/11-notebook.tf
+++ b/terraform/modules/sagemaker/11-notebook.tf
@@ -12,12 +12,13 @@ locals {
 
 resource "aws_sagemaker_notebook_instance_lifecycle_configuration" "sagemaker_lifecycle" {
   name = "${var.identifier_prefix}sagemaker-lifecycle-configuration-${var.instance_name}"
-  on_start = base64encode(templatefile("${path.module}/scripts/notebook-start-up.sh",
-    {
-      "glueendpointconfig" : jsonencode(local.glue_dev_endpoint_config),
-      "sparkmagicconfig" : file("${path.module}/spark-magic-config.json")
-    }
-  ))
+  # on_start = base64encode(templatefile("${path.module}/scripts/notebook-start-up.sh",
+  #   {
+  #     "glueendpointconfig" : jsonencode(local.glue_dev_endpoint_config),
+  #     "sparkmagicconfig" : file("${path.module}/spark-magic-config.json")
+  #   }
+  # ))
+  on_start  = base64encode("echo startup_script_temporarily_disabled")
 }
 
 resource "aws_sagemaker_notebook_instance" "nb" {


### PR DESCRIPTION
Our current life cycle configuration script for notebook startup is failing and causing notebook startup failures.

This is update replaces the startup script with simple echo command. This should enable us to start the notebooks in a state that is enough to salvage any code that's not in source control.

This change means development end points won't be created for the notebooks, so the envrionments won't support full development. This update is purely for recovering code.