### PR TITLE
DPP-427 force metadata v2 on bastion

### DIFF
--- a/terraform/core/06-network.tf
+++ b/terraform/core/06-network.tf
@@ -130,4 +130,9 @@ resource "aws_instance" "bastion" {
   lifecycle {
     ignore_changes = [ami, subnet_id]
   }
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
 }


### PR DESCRIPTION
Resolve EC2.8 EC2 instances should use Instance Metadata Service Version 2 (IMDSv2) issue for bastion host.