### PR TITLE
DPP-429 require metadata v2

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -71,4 +71,9 @@ resource "aws_instance" "qlik_sense_pre_prod_instance" {
   lifecycle {
     ignore_changes = [ami, subnet_id]
   }
+
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
 }


### PR DESCRIPTION
Resolve EC2.8 EC2 instances should use Instance Metadata Service Version 2 (IMDSv2) issue for Qlik pre-prod instance