### PR TITLE
Dpp 409 watermarks

### DIFF
--- a/scripts/helpers/watermarks.py
+++ b/scripts/helpers/watermarks.py
@@ -39,7 +39,9 @@ class Watermarks:
     def add_watermark(self, watermark_item: dict) -> None:
         """Adds a watermark item to the DynamoDB table."""
         try:
-            watermark_item_serialized = self.serializer.serialize(watermark_item)
+            watermark_item_serialized = {
+                k: self.serializer.serialize(v) for k, v in watermark_item.items()
+            }
             self.dynamodb_client.put_item(
                 TableName=self.table_name,
                 Item=watermark_item_serialized,

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -716,7 +716,7 @@ data "aws_iam_policy_document" "glue_access_to_watermarks_table" {
       "dynamodb:Update*",
       "dynamodb:PutItem"
     ]
-    resources = ["arn:aws:dynamodb:*:*:table/${var.identifier_prefix}glue-watermarks"]
+    resources = ["arn:aws:dynamodb:*:*:table/${var.short_identifier_prefix}glue-watermarks"]
   }
 
 }

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -80,3 +80,8 @@ resource "aws_iam_role_policy_attachment" "glue_agent_has_full_s3_access_to_glue
   role       = aws_iam_role.glue_agent.name
   policy_arn = aws_iam_policy.full_s3_access_to_glue_resources.arn
 }
+
+resource "aws_iam_role_policy_attachment" "glue_access_to_watermarks_table" {
+  role       = aws_iam_role.glue_agent.name
+  policy_arn = aws_iam_policy.glue_access_to_watermarks_table.arn
+}


### PR DESCRIPTION
Fixing some things that I must have broken while moving everything around:

- attaches the IAM policy that allows the department Glue role to interact with the dynamodb table...!
- IAM policy now uses the short_identifier_prefix for the dynamodb table, which is helpful because that's now the same as the table itself
- fixed the serialization of the watermarks item when adding it to the table
