### PR TITLE
add additional states to cloudwatch event

### DIFF
--- a/terraform/core/28-glue-gchat-failure-notification.tf
+++ b/terraform/core/28-glue-gchat-failure-notification.tf
@@ -8,7 +8,9 @@ locals {
     ],
     "detail" : {
       "state" : [
-        "FAILED"
+        "FAILED",
+        "TIMEOUT",
+        "ERROR"
       ]
     }
   }


### PR DESCRIPTION
Updates the Cloudwatch event pattern to also send alerts when jobs timeout or error. 