### PR TITLE
DPP-436 force metadata service version 2 on Qlik prod

### DIFF
--- a/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
@@ -50,4 +50,9 @@ resource "aws_instance" "qlik_sense_prod_instance" {
   lifecycle {
     ignore_changes = [ami, subnet_id]
   }
+  
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
 }


### PR DESCRIPTION
Resolve EC2.8 EC2 instances should use Instance Metadata Service Version 2 (IMDSv2) issue for Qlik prod instance