### PR TITLE
Dpp 437 mtfh ingestion

### DIFF
--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -9,14 +9,13 @@ module "ingest_mtfh_rentsense_tables" {
   environment               = var.environment
   tags                      = module.tags.values
   glue_role_arn             = aws_iam_role.glue_role.arn
-
-  job_name             = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
-  job_description      = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
-  script_s3_object_key = aws_s3_bucket_object.dynamodb_tables_ingest.key
-  helper_module_key    = aws_s3_bucket_object.helpers.key
-  glue_version         = "4.0"
-  glue_job_timeout     = "300"
-  glue_job_worker_type = "G.1X"
+  job_name                  = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
+  job_description           = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
+  script_s3_object_key      = aws_s3_bucket_object.dynamodb_tables_ingest.key
+  helper_module_key         = aws_s3_bucket_object.helpers.key
+  glue_version              = "4.0"
+  glue_job_timeout          = "300"
+  glue_job_worker_type      = "G.1X"
 
   pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
   number_of_workers_for_glue_job = local.number_of_workers_for_mtfh_rentsense_ingestion

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -15,8 +15,9 @@ module "ingest_mtfh_rentsense_tables" {
   script_s3_object_key           = aws_s3_bucket_object.dynamodb_tables_ingest.key
   helper_module_key              = aws_s3_bucket_object.helpers.key
   glue_version                   = "4.0"
-  glue_job_timeout               = "180"
-  glue_job_worker_type           = "G.2X"
+  glue_job_timeout               = "300"
+  glue_job_worker_type           = "G.1X"
+
   pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
   number_of_workers_for_glue_job = local.number_of_workers_for_mtfh_rentsense_ingestion
   glue_scripts_bucket_id         = module.glue_scripts.bucket_id

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -9,14 +9,14 @@ module "ingest_mtfh_rentsense_tables" {
   environment               = var.environment
   tags                      = module.tags.values
   glue_role_arn             = aws_iam_role.glue_role.arn
-  job_name                  = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
-  job_description           = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
-  script_s3_object_key      = aws_s3_bucket_object.dynamodb_tables_ingest.key
-  helper_module_key         = aws_s3_bucket_object.helpers.key
-  glue_version              = "4.0"
-  glue_job_timeout          = "300"
-  glue_job_worker_type      = "G.1X"
 
+  job_name                       = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
+  job_description                = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
+  script_s3_object_key           = aws_s3_bucket_object.dynamodb_tables_ingest.key
+  helper_module_key              = aws_s3_bucket_object.helpers.key
+  glue_version                   = "4.0"
+  glue_job_timeout               = "300"
+  glue_job_worker_type           = "G.1X"
   pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
   number_of_workers_for_glue_job = local.number_of_workers_for_mtfh_rentsense_ingestion
   glue_scripts_bucket_id         = module.glue_scripts.bucket_id

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -10,13 +10,13 @@ module "ingest_mtfh_rentsense_tables" {
   tags                      = module.tags.values
   glue_role_arn             = aws_iam_role.glue_role.arn
 
-  job_name                       = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
-  job_description                = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
-  script_s3_object_key           = aws_s3_bucket_object.dynamodb_tables_ingest.key
-  helper_module_key              = aws_s3_bucket_object.helpers.key
-  glue_version                   = "4.0"
-  glue_job_timeout               = "300"
-  glue_job_worker_type           = "G.1X"
+  job_name             = "${local.short_identifier_prefix}Ingest MTFH Rentsense tables"
+  job_description      = "Ingest all tables from MTFH for Rentsense from the Housing Dynamo DB instances"
+  script_s3_object_key = aws_s3_bucket_object.dynamodb_tables_ingest.key
+  helper_module_key    = aws_s3_bucket_object.helpers.key
+  glue_version         = "4.0"
+  glue_job_timeout     = "300"
+  glue_job_worker_type = "G.1X"
 
   pydeequ_zip_key                = aws_s3_bucket_object.pydeequ.key
   number_of_workers_for_glue_job = local.number_of_workers_for_mtfh_rentsense_ingestion
@@ -25,10 +25,12 @@ module "ingest_mtfh_rentsense_tables" {
   spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
   schedule                       = "cron(30 5 ? * MON-FRI *)"
   job_parameters = {
-    "--table_names"       = "TenureInformation,Persons,ContactDetails,Assets,Accounts,EqualityInformation,HousingRegister,HousingRepairsOnline,PatchesAndAreas,Processes,Notes", # This is a comma delimited list of Dynamo DB table names to be imported
-    "--role_arn"          = data.aws_ssm_parameter.role_arn_to_access_housing_tables.value
-    "--s3_target"         = "s3://${module.landing_zone.bucket_id}/mtfh/"
-    "--number_of_workers" = local.number_of_workers_for_mtfh_ingestion
+    "--table_names"         = "TenureInformation,Persons,ContactDetails,Assets,Accounts,EqualityInformation,HousingRegister,HousingRepairsOnline,PatchesAndAreas,Processes,Notes", # This is a comma delimited list of Dynamo DB table names to be imported
+    "--role_arn"            = data.aws_ssm_parameter.role_arn_to_access_housing_tables.value
+    "--s3_target"           = "s3://${module.landing_zone.bucket_id}/mtfh/"
+    "--number_of_workers"   = local.number_of_workers_for_mtfh_ingestion
+    "--enable-job-insights" = "true"
+    "--enable-auto-scaling" = "true"
   }
 
   crawler_details = {


### PR DESCRIPTION
Changing some parameters to address problems with the MTFH ingestion job

- Increase the timeout period as the job has been failing to complete
- Reduce the worker type as increasing this doesn't appear to have reduced the time taken for job to complete
- Enable auto-scaling of workers, given the time to complete doesn't seem to be dependant on type of worker it's likely alot of the time they're sat idle waiting for data transfer, this will hopefully reduce DPU / costs
- Enable job insights for better monitoring (this should probably be a default in the Glue module) [https://docs.aws.amazon.com/glue/latest/dg/monitor-job-insights.html](url)
