### PR TITLE
DPP-382 Add development deploy role

### DIFF
--- a/terraform/core/83-development-deploy-role.tf
+++ b/terraform/core/83-development-deploy-role.tf
@@ -1,0 +1,75 @@
+data "aws_organizations_organization" "org" {
+  count = local.is_live_environment ? 0 : 1
+}
+
+data "aws_secretsmanager_secret" "admin_sso_role" {
+  count = local.is_live_environment ? 0 : 1
+  name = "manual-developer-admin-sso-role-arn"
+}
+
+data "aws_secretsmanager_secret_version" "admin_sso_role" {
+  count = local.is_live_environment ? 0 : 1
+  secret_id = data.aws_secretsmanager_secret.admin_sso_role[0].id
+}
+
+data "aws_iam_policy_document" "development_deploy_assume_role" {
+  count = local.is_live_environment ? 0 : 1
+  
+  statement {
+    sid = "AllowDataPlatformDevelopersDeploymentAdminAccess"
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      identifiers = [
+        "arn:aws:iam::${var.aws_deploy_account_id}:root"
+      ]
+
+      type = "AWS"
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = [data.aws_secretsmanager_secret_version.admin_sso_role[0].secret_string]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:PrincipalOrgID"
+      values   = [data.aws_organizations_organization.org[0].id]
+    }
+  }
+}
+
+resource "aws_iam_role" "development_deploy_role" {
+  count = local.is_live_environment ? 0 : 1
+  name               = "development_deploy"
+  assume_role_policy = data.aws_iam_policy_document.development_deploy_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "development_deploy_policy_document" {
+  count = local.is_live_environment ? 0 : 1
+
+  statement {
+    actions   = ["*"]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "development_deploy_policy" {
+  count = local.is_live_environment ? 0 : 1
+
+  name     = "development_deploy"
+  policy   = data.aws_iam_policy_document.development_deploy_policy_document[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "development_deploy_role_policy_attachment" {
+  count = local.is_live_environment ? 0 : 1
+
+  role       = aws_iam_role.development_deploy_role[0].name
+  policy_arn = aws_iam_policy.development_deploy_policy[0].arn
+}

--- a/terraform/networking/00-init.tf
+++ b/terraform/networking/00-init.tf
@@ -1,9 +1,14 @@
 # Core Infrastructure
 provider "aws" {
   region = var.aws_deploy_region
-  assume_role {
-    role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
-    session_name = "Terraform"
+  
+  dynamic assume_role {
+    for_each = local.environment != "dev" ? [1] : []
+
+      content {
+        role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
+        session_name = "Terraform"
+      }
   }
 }
 


### PR DESCRIPTION
Add development deploy role. Some modules required assumed role to be used during deployments, so this will add support to those features in development environment. This has no impact to live environments.

Previously assumed role can no longer be assumed due to permissions restrictions.