### PR TITLE
Add support for additional bucket policy statements

### DIFF
--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -3,3 +3,68 @@ variable "role_arns_to_share_access_with" {
   type        = list(string)
   default     = []
 }
+
+variable "bucket_policy_statements" {
+  description = "A list of statements to be added to the bucket policy"
+  type = list(object({
+    sid       = string
+    effect    = string
+    actions   = list(string)
+    resources = list(string)
+    principals = object({
+      type        = string
+      identifiers = list(string)
+    })
+  }))
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if o.sid != null && o.sid != ""
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Sid is required"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if contains(["Allow", "Deny"], o.effect)
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Effect must be either Allow or Deny"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.actions) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Actions list cannot be empty"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.resources) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Resources cannot be empty"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.principals.identifiers) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Principal identifiers must be provided"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if o.principals.type != null && o.principals.type != ""
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Principal type must be provided"
+  }
+  #other principals object related checks are covered by default Terraform behaviour
+
+  default = []
+}

--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -66,6 +66,22 @@ data "aws_iam_policy_document" "bucket_policy_document" {
       identifiers = local.role_arns_to_share_access_with
     }
   }
+
+  dynamic "statement" {
+    for_each = var.bucket_policy_statements
+
+    content {
+      sid       = lookup(statement.value, "sid", "")
+      effect    = lookup(statement.value, "effect", "")
+      actions   = lookup(statement.value, "actions", [])
+      resources = lookup(statement.value, "resources", [])
+
+      principals {
+        type        = lookup(statement.value.principals, "type", "")
+        identifiers = lookup(statement.value.principals, "identifiers", [])
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket" "bucket" {


### PR DESCRIPTION
Update the S3 bucket module so that additional policy statements can be passed to the bucket policy document.

This enables more specific policies to be used for each bucket that are using this module.

