### PR TITLE
DPP-444 Add new pre-prod data cleanup tasks

### DIFF
--- a/docker/pre-production-data-cleanup/Dockerfile
+++ b/docker/pre-production-data-cleanup/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+
+RUN apk add --update --no-cache \
+    bash \
+    aws-cli \
+    coreutils \
+    && rm -rf /var/cache/apk/*
+
+COPY ./cleanup-past-x-days.sh .
+
+CMD ./cleanup-past-x-days.sh

--- a/docker/pre-production-data-cleanup/cleanup-past-x-days.sh
+++ b/docker/pre-production-data-cleanup/cleanup-past-x-days.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eu -o pipefail
+
+date=`date +"%Y%m%d"`
+
+s3_cleanup_target="s3://${S3_CLEANUP_TARGET}"
+days_to_retain=${NUMBER_OF_DAYS_TO_RETAIN}
+
+echo "S3 bucket target: $s3_cleanup_target"
+
+for i in $(seq 0 $((10))); do
+
+  # This process runs weekly, delete the 10 days just before the retention period
+  # Example. Retain 2 days, current date is 2022-08-04 so delete 2202-8-02 -> 2022-07-26
+  date_to_retain=$(date +"%Y%m%d" -d "${date} -${days_to_retain} day -${i} day")
+  date_to_retain_hyphen_separated=$(date +"%Y-%m-%d" -d "${date} -${days_to_retain} day -${i} day")
+  # Include for deletion on target: *date=20220726/*
+  rm_include_opts+=( --include="*date=$date_to_retain/*" )
+  # Include for deletion on target: 20220726/*
+  rm_include_opts+=( --include="$date_to_retain/*" )
+  # Include for deletion on target: *date=2022-07-26/*
+  rm_include_opts+=( --include="*date=$date_to_retain_hyphen_separated/*" )
+  # Include for deletion on target: *import_year=2022/import_month=7/import_day=26/*
+  rm_include_opts+=( --include="*import_year=$(date -d "$date_to_retain" "+%Y")/import_month=$(date -d "$date_to_retain" "+%-m")/import_day=$(date -d "$date_to_retain" "+%-d")/*" )
+  # Include for deletion on target: *import_year=2022/import_month=07/import_day=26/*
+  rm_include_opts+=( --include="*import_year=$(date -d "$date_to_retain" "+%Y")/import_month=$(date -d "$date_to_retain" "+%m")/import_day=$(date -d "$date_to_retain" "+%d")/*" )
+done
+
+echo "Include flags to be used with s3 rm cmd: ${rm_include_opts[*]}"
+
+echo "Removing old records..."
+aws s3 rm $s3_cleanup_target --recursive --exclude "*" "${rm_include_opts[@]}"
+echo "Clean up job complete for $s3_cleanup_target"

--- a/docker/pre-production-data-cleanup/deploy.sh
+++ b/docker/pre-production-data-cleanup/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu -o pipefail
+
+if [[ $ENVIRONMENT != "stg" ]]
+then
+    echo "Exiting as not in pre-production environment"
+    exit 0;
+fi
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+terraform_dir="${script_dir}/../../terraform/core"
+ecr_url=$(AWS_PROFILE="" terraform -chdir=${terraform_dir} output -raw pre_prod_data_cleanup_ecr_repository_endpoint)
+
+docker build -f ${script_dir}/Dockerfile -t ${ecr_url} ${script_dir}
+
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ecr_url
+
+docker push $ecr_url

--- a/docker/pre-production-data-cleanup/docker-compose.yml
+++ b/docker/pre-production-data-cleanup/docker-compose.yml
@@ -1,0 +1,5 @@
+version: "3.9"
+services:
+  cmd:
+    container_name: cmd-runner
+    build: .

--- a/terraform/core/84-pre-prod-data-cleanup-tasks.tf
+++ b/terraform/core/84-pre-prod-data-cleanup-tasks.tf
@@ -1,0 +1,96 @@
+data "aws_iam_policy_document" "pre_production_data_cleanup_task_role" {
+  count  = !local.is_production_environment && local.is_live_environment ? 1 : 0
+  
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = [
+      module.raw_zone.kms_key_arn,
+      module.refined_zone.kms_key_arn,
+      module.trusted_zone.kms_key_arn
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:DeleteObject*"
+    ]
+    #hard coded to prevent data loss in case of misconfiguration
+    resources = [
+      "arn:aws:s3:::dataplatform-stg-raw-zone*",
+      "arn:aws:s3:::dataplatform-stg-refined-zone*",
+      "arn:aws:s3:::dataplatform-stg-trusted-zone*",
+      "arn:aws:s3:::dataplatform-stg-raw-zone/*",
+      "arn:aws:s3:::dataplatform-stg-refined-zone/*",
+      "arn:aws:s3:::dataplatform-stg-trusted-zone/*"
+    ]
+  }
+}
+
+module "pre_production_data_cleanup" {
+  source = "../modules/aws-ecs-fargate-task"
+  count  = !local.is_production_environment && local.is_live_environment ? 1 : 0
+
+  tags                          = module.tags.values
+  operation_name                = "${local.short_identifier_prefix}pre-production-data-cleanup"
+  ecs_task_role_policy_document = data.aws_iam_policy_document.pre_production_data_cleanup_task_role[0].json
+  aws_subnet_ids                = data.aws_subnet_ids.network.ids
+  ecs_cluster_arn               = aws_ecs_cluster.workers.arn
+  tasks = [
+    {
+      task_prefix = "raw-zone-"
+      task_cpu    = 256
+      task_memory = 512
+      environment_variables = [
+        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
+        { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-raw-zone" }
+      ]
+      cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+    },
+    {
+      task_prefix = "refined-zone-"
+      task_cpu    = 256
+      task_memory = 512
+      environment_variables = [
+        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
+        { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-refined-zone" }
+      ]
+      cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+    },
+    {
+      task_prefix = "trusted-zone-"
+      task_cpu    = 256
+      task_memory = 512
+      environment_variables = [
+        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
+        { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-trusted-zone" }
+      ]
+      cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+    }
+  ]
+  security_groups = [aws_security_group.pre_production_data_cleanup[0].id]
+}
+
+resource "aws_security_group" "pre_production_data_cleanup" {
+  count       = !local.is_production_environment && local.is_live_environment ? 1 : 0
+  name        = "${local.short_identifier_prefix}pre-production-data-cleanup"
+  description = "Restrict access for the cleanup task"
+  vpc_id      = data.aws_vpc.network.id
+  tags        = module.tags.values
+}
+
+resource "aws_security_group_rule" "outbound_traffic_to_s3" {
+  count             = !local.is_production_environment && local.is_live_environment ? 1 : 0
+  description       = "Allow outbound traffic to S3"
+  security_group_id = aws_security_group.pre_production_data_cleanup[0].id
+  protocol          = "TCP"
+  from_port         = 443
+  to_port           = 443
+  type              = "egress"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}

--- a/terraform/core/99-outputs.tf
+++ b/terraform/core/99-outputs.tf
@@ -21,6 +21,10 @@ output "prod_to_pre_prod_ecr_repository_endpoint" {
   value = try(module.sync_production_to_pre_production[0].ecr_repository_worker_endpoint, null)
 }
 
+output "pre_prod_data_cleanup_ecr_repository_endpoint" {
+  value = try(module.pre_production_data_cleanup[0].ecr_repository_worker_endpoint, null)
+}
+
 output "ssl_connection_resources_bucket_id" {
   value = try(aws_s3_bucket.ssl_connection_resources[0].id, "")
 }


### PR DESCRIPTION
Create new data clean up tasks setup for pre-production. This is based on the current clean up job running on production.

There's no need to have this on prod anymore, so this update creates a new standalone setup for pre-prod only. Once deployed the current jobs running on production can be torn down.