### PR TITLE
DPP-444 Restrict access to refined zone

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -10,7 +10,7 @@ locals {
   
     resources = [
         module.refined_zone.bucket_arn,
-        "${module.refined_zone.bucket_arn}/housings/rentsense/export/*"
+        "${module.refined_zone.bucket_arn}/housing/rentsense/export/*"
     ]
 
     principals = {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -9,7 +9,7 @@ locals {
     ]
   
     resources = [
-        "${module.refined_zone.bucket_arn}",
+        module.refined_zone.bucket_arn,
         "${module.refined_zone.bucket_arn}/housings/rentsense/export/*"
     ]
 

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -1,3 +1,44 @@
+locals {
+  rentsense_refined_zone_access_statement = {
+    sid = "AllowRentsenseReadOnlyAccessToExportLocationOnRefinedZone"
+    effect = "Allow"
+    actions = [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:GetObjectTagging"
+    ]
+  
+    resources = [
+        "${module.refined_zone.bucket_arn}",
+        "${module.refined_zone.bucket_arn}/housings/rentsense/export/*"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::971933469343:root",
+        "arn:aws:iam::971933469343:role/customer-midas-roles-pluto-HackneyMidasRole-1M6PTJ5VS8104"
+      ]
+    }
+  }
+    
+  rentsense_refined_zone_key_statement = {
+    sid = "RentSenseAccesToRefinedZoneKey"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::971933469343:root",
+        "arn:aws:iam::971933469343:role/customer-midas-roles-pluto-HackneyMidasRole-1M6PTJ5VS8104"
+      ]
+    }
+  }
+}
+
 module "landing_zone" {
   source            = "../modules/s3-bucket"
   tags              = module.tags.values
@@ -30,11 +71,9 @@ module "refined_zone" {
   identifier_prefix = local.identifier_prefix
   bucket_name       = "Refined Zone"
   bucket_identifier = "refined-zone"
-  role_arns_to_share_access_with = [
-    var.sync_production_to_pre_production_task_role,
-    "arn:aws:iam::971933469343:root",
-    "arn:aws:iam::971933469343:role/customer-midas-roles-pluto-HackneyMidasRole-1M6PTJ5VS8104"
-  ]
+  role_arns_to_share_access_with  = [var.sync_production_to_pre_production_task_role]
+  bucket_policy_statements        = [local.rentsense_refined_zone_access_statement]
+  bucket_key_policy_statements    = [local.rentsense_refined_zone_key_statement]
 }
 
 module "trusted_zone" {

--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -3,3 +3,124 @@ variable "role_arns_to_share_access_with" {
   type        = list(string)
   default     = []
 }
+
+variable "bucket_policy_statements" {
+  description = "A list of statements to be added to the bucket policy"
+  type = list(object({
+    sid       = string
+    effect    = string
+    actions   = list(string)
+    resources = list(string)
+    principals = object({
+      type        = string
+      identifiers = list(string)
+    })
+  }))
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if o.sid != null && o.sid != ""
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Sid is required"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if contains(["Allow", "Deny"], o.effect)
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Effect must be either Allow or Deny"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.actions) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Actions list cannot be empty"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.resources) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Resources cannot be empty"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+      if length(o.principals.identifiers) > 0
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Principal identifiers must be provided"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_policy_statements : true
+       if o.principals.type != null && o.principals.type != ""
+    ]) == length(var.bucket_policy_statements)
+    error_message = "Principal type must be provided"
+  }
+  #other principals object related checks are covered by default Terraform behaviour
+
+  default = []
+}
+
+variable "bucket_key_policy_statements" {
+  description = "A list of statements to be added to the bucket policy"
+  type = list(object({
+    sid       = string
+    effect    = string
+    actions   = list(string)
+    principals = object({
+      type        = string
+      identifiers = list(string)
+    })
+  }))
+
+  validation {
+    condition = length([
+      for o in var.bucket_key_policy_statements : true
+      if o.sid != null && o.sid != ""
+    ]) == length(var.bucket_key_policy_statements)
+    error_message = "Sid is required"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_key_policy_statements : true
+      if contains(["Allow", "Deny"], o.effect)
+    ]) == length(var.bucket_key_policy_statements)
+    error_message = "Effect must be either Allow or Deny"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_key_policy_statements : true
+      if length(o.actions) > 0
+    ]) == length(var.bucket_key_policy_statements)
+    error_message = "Actions list cannot be empty"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_key_policy_statements : true
+      if length(o.principals.identifiers) > 0
+    ]) == length(var.bucket_key_policy_statements)
+    error_message = "Principal identifiers must be provided"
+  }
+
+  validation {
+    condition = length([
+      for o in var.bucket_key_policy_statements : true
+       if o.principals.type != null && o.principals.type != ""
+    ]) == length(var.bucket_key_policy_statements)
+    error_message = "Principal type must be provided"
+  }
+  #other principals object related checks are covered by default Terraform behaviour
+
+  default = []
+}

--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -33,6 +33,22 @@ data "aws_iam_policy_document" "key_policy" {
       identifiers = local.role_arns_to_share_access_with
     }
   }
+
+  dynamic statement {
+    for_each = var.bucket_key_policy_statements
+    
+    content { 
+      sid       = lookup(statement.value, "sid", "")
+      effect    = lookup(statement.value, "effect", "")
+      actions   = lookup(statement.value, "actions", [])
+      resources = ["*"]
+      
+      principals {
+        type        = lookup(statement.value.principals, "type", "")
+        identifiers = lookup(statement.value.principals, "identifiers", [])
+      }
+    }
+  }
 }
 
 resource "aws_kms_key" "key" {
@@ -64,6 +80,22 @@ data "aws_iam_policy_document" "bucket_policy_document" {
     principals {
       type        = "AWS"
       identifiers = local.role_arns_to_share_access_with
+    }
+  }
+
+  dynamic statement {
+    for_each = var.bucket_policy_statements
+    
+    content { 
+      sid       = lookup(statement.value, "sid", "")
+      effect    = lookup(statement.value, "effect", "")
+      actions   = lookup(statement.value, "actions", [])
+      resources = lookup(statement.value, "resources", [])
+      
+      principals {
+        type        = lookup(statement.value.principals, "type", "")
+        identifiers = lookup(statement.value.principals, "identifiers", [])
+      }
     }
   }
 }


### PR DESCRIPTION
This update will limit external RentSense role's access to refined zone bucket.

The S3 bucket module has been updated to accept custom bucket and bucket key policy statements to allow more refined control over the permissions.