### PR TITLE
DPP-444 Add new prod to pre-prod sync role

### DIFF
--- a/terraform/core/35-sync-production-to-pre-production.tf
+++ b/terraform/core/35-sync-production-to-pre-production.tf
@@ -1,3 +1,11 @@
+data "aws_secretsmanager_secret" "pre_production_account_id" {
+  name = "manually-managed-value-pre-prod-account-id"
+}
+
+data "aws_secretsmanager_secret_version" "pre_production_account_id" {
+  secret_id = data.aws_secretsmanager_secret.pre_production_account_id.id
+}
+
 data "aws_iam_policy_document" "ecs_assume_role" {
   statement {
     actions = [
@@ -287,9 +295,9 @@ data "aws_iam_policy_document" "prod_to_pre_prod_s3_sync_policy" {
       module.raw_zone.kms_key_arn,
       module.refined_zone.kms_key_arn,
       module.trusted_zone.kms_key_arn,
-      "arn:aws:kms:eu-west-2:120038763019:key/03a1da8d-955d-422d-ac0f-fd27946260c0",
-      "arn:aws:kms:eu-west-2:120038763019:key/670ec494-c7a3-48d8-ae21-2ef85f2c6d21",
-      "arn:aws:kms:eu-west-2:120038763019:key/49166434-f10b-483c-81e4-91f099e4a8a0"
+      "arn:aws:kms:eu-west-2:${data.aws_secretsmanager_secret_version.pre_production_account_id.secret_string}:key/03a1da8d-955d-422d-ac0f-fd27946260c0",
+      "arn:aws:kms:eu-west-2:${data.aws_secretsmanager_secret_version.pre_production_account_id.secret_string}:key/670ec494-c7a3-48d8-ae21-2ef85f2c6d21",
+      "arn:aws:kms:eu-west-2:${data.aws_secretsmanager_secret_version.pre_production_account_id.secret_string}:key/49166434-f10b-483c-81e4-91f099e4a8a0"
     ]
   }
 

--- a/terraform/core/35-sync-production-to-pre-production.tf
+++ b/terraform/core/35-sync-production-to-pre-production.tf
@@ -248,3 +248,108 @@ resource "aws_security_group_rule" "allow_outbound_traffic_to_s3" {
   cidr_blocks       = ["0.0.0.0/0"]
   ipv6_cidr_blocks  = ["::/0"]
 }
+
+data "aws_iam_policy_document" "prod_to_pre_prod_s3_sync_policy" {
+  count = local.is_production_environment ? 1 : 0
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject*",
+      "s3:GetReplicationConfiguration",
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:ListBucket"
+    ]
+    resources = [
+      module.raw_zone.bucket_arn,
+      "${module.raw_zone.bucket_arn}/*",
+      module.refined_zone.bucket_arn,
+      "${module.refined_zone.bucket_arn}/*",
+      module.trusted_zone.bucket_arn,
+      "${module.trusted_zone.bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:RetireGrant",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:CreateGrant"
+    ]
+    resources = [
+      module.raw_zone.kms_key_arn,
+      module.refined_zone.kms_key_arn,
+      module.trusted_zone.kms_key_arn,
+      "arn:aws:kms:eu-west-2:120038763019:key/03a1da8d-955d-422d-ac0f-fd27946260c0",
+      "arn:aws:kms:eu-west-2:120038763019:key/670ec494-c7a3-48d8-ae21-2ef85f2c6d21",
+      "arn:aws:kms:eu-west-2:120038763019:key/49166434-f10b-483c-81e4-91f099e4a8a0"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject*",
+      "s3:DeleteObject*",
+      "s3:ReplicateObject",
+      "s3:ReplicateTags",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateDelete"
+    ]
+    resources = [
+      "arn:aws:s3:::dataplatform-stg-raw-zone*",
+      "arn:aws:s3:::dataplatform-stg-refined-zone*",
+      "arn:aws:s3:::dataplatform-stg-trusted-zone*",
+      "arn:aws:s3:::dataplatform-stg-raw-zone/*",
+      "arn:aws:s3:::dataplatform-stg-refined-zone/*",
+      "arn:aws:s3:::dataplatform-stg-trusted-zone/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "s3_assume_role" {
+  count = local.is_production_environment ? 1 : 0
+
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+    principals {
+      identifiers = [
+        "s3.amazonaws.com"
+      ]
+      type = "Service"
+    }
+  }
+}
+
+resource "aws_iam_role" "prod_to_pre_prod_s3_sync_role" {
+  count = local.is_production_environment ? 1 : 0
+  tags  = module.tags.values
+
+  name               = "${local.short_identifier_prefix}production-to-pre-production-s3-sync-role"
+  assume_role_policy = data.aws_iam_policy_document.s3_assume_role[0].json
+}
+
+resource "aws_iam_policy" "prod_to_pre_prod_s3_sync_policy" {
+  count  = local.is_production_environment ? 1 : 0
+  tags   = module.tags.values
+  name   = "${local.short_identifier_prefix}production-to-pre-production-s3-sync"
+  policy = data.aws_iam_policy_document.prod_to_pre_prod_s3_sync_policy[0].json
+}
+
+resource "aws_iam_policy_attachment" "prod_to_pre_prod_s3_sync_policy_attachment" {
+  count      = local.is_production_environment ? 1 : 0
+  name       = "${local.short_identifier_prefix}production-to-pre-production-s3-sync"
+  roles      = [aws_iam_role.prod_to_pre_prod_s3_sync_role[0].name]
+  policy_arn = aws_iam_policy.prod_to_pre_prod_s3_sync_policy[0].arn
+}
+


### PR DESCRIPTION
Add new prod to pre-prod sync role with more restricted buckets and keys access.

Once deployed the zone bucket policies can be updated to use this new role and also the S3 replication setups can be switched over to this new more restricted role.

This helps to complete the separation of the original data sync/cleanup jobs setup that were tightly coupled together due to them being in the same script.

Bucket resource ARNs are hard coded for safety against misconfiguration.