### PR TITLE
DPP-444 Change trusted zone sync to use new role

### DIFF
--- a/terraform/core/35-sync-production-to-pre-production.tf
+++ b/terraform/core/35-sync-production-to-pre-production.tf
@@ -211,7 +211,7 @@ resource "aws_s3_bucket_replication_configuration" "refined_zone" {
 }
 resource "aws_s3_bucket_replication_configuration" "trusted_zone" {
   count  = local.is_production_environment ? 1 : 0
-  role   = var.sync_production_to_pre_production_task_role
+  role   = aws_iam_role.prod_to_pre_prod_s3_sync_role.arn
   bucket = module.trusted_zone.bucket_id
 
   rule {

--- a/terraform/core/35-sync-production-to-pre-production.tf
+++ b/terraform/core/35-sync-production-to-pre-production.tf
@@ -211,7 +211,7 @@ resource "aws_s3_bucket_replication_configuration" "refined_zone" {
 }
 resource "aws_s3_bucket_replication_configuration" "trusted_zone" {
   count  = local.is_production_environment ? 1 : 0
-  role   = aws_iam_role.prod_to_pre_prod_s3_sync_role.arn
+  role   = aws_iam_role.prod_to_pre_prod_s3_sync_role[0].arn
   bucket = module.trusted_zone.bucket_id
 
   rule {


### PR DESCRIPTION
Update the trusted zone sync process to use more restricted role and de-couple it from the old sync & cleanup setup.