### PR TITLE
DPP-444 Revert to full access

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -43,14 +43,12 @@ locals {
     effect = "Allow"
 
     actions = [
-      "s3:ListBucket",
-      "s3:PutObject",
-      "s3:PutObjectAcl"
+      "s3:*"
     ]
 
     resources = [
       module.raw_zone.bucket_arn,
-      "${module.raw_zone.bucket_arn}/unrestricted/addresses_api/*"
+      "${module.raw_zone.bucket_arn}/*"
     ]
 
     principals = {
@@ -66,7 +64,7 @@ locals {
     sid    = "S3ToS3CopierForAddressesAPIAccessToRawZoneKey"
     effect = "Allow"
     actions = [
-      "kms:Encrypt"
+      "kms:*"
     ]
 
     principals = {


### PR DESCRIPTION
Revert addresses api ingestion permissions to full access until we have a proper test setup in place for this. That is required to test the new more strict access policies.