### PR TITLE
Changes to job trigger in  terraform

### DIFF
--- a/terraform/etl/45-aws-glue-job-active-persons-records.tf
+++ b/terraform/etl/45-aws-glue-job-active-persons-records.tf
@@ -60,7 +60,7 @@ resource "aws_glue_trigger" "active_persons_records_refined_trigger" {
   tags     = module.department_data_and_insight_data_source.tags
   type     = "SCHEDULED"
   schedule = "cron(0 22 * * ? *)"
-  enabled  = local.is_live_environment
+  enabled  = local.is_production_environment
   count    = local.active_persons_environment_count
 
   actions {


### PR DESCRIPTION
* Changes to job trigger local.is_live_environment to local.is_production_environment so job is not scheduled to run on pre-prod but remains in existence.