### PR TITLE
DPP-463 update trusted zone policies for data sync role

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -185,8 +185,8 @@ module "trusted_zone" {
     var.sync_production_to_pre_production_task_role
   ]
 
-  bucket_policy_statements     = local.is_live_environment && !local.is_production_environment ? [] : [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod]
-  bucket_key_policy_statements = local.is_live_environment && !local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod]
+  bucket_policy_statements     = local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod]
+  bucket_key_policy_statements = local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod]
 }
 
 module "glue_scripts" {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -1,3 +1,11 @@
+data "aws_secretsmanager_secret" "production_account_id" {
+  name = "manually-managed-value-prod-account-id"
+}
+
+data "aws_secretsmanager_secret_version" "production_account_id" {
+  secret_id = data.aws_secretsmanager_secret.production_account_id.id
+}
+
 locals {
   rentsense_refined_zone_access_statement = {
     sid    = "AllowRentsenseReadOnlyAccessToExportLocationOnRefinedZone"
@@ -79,6 +87,53 @@ locals {
     }
   }
 
+  prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod = {
+    sid    = "ProdToPreProdTrustedZoneDataSyncAccess"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject*",
+      "s3:DeleteObject*",
+      "s3:ReplicateObject",
+      "s3:ReplicateTags",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateDelete"
+    ]
+
+    resources = [
+      "arn:aws:s3:::dataplatform-stg-trusted-zone",
+      "arn:aws:s3:::dataplatform-stg-trusted-zone/*"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_secretsmanager_secret_version.production_account_id.secret_string}:role/production-to-pre-production-s3-sync-role"
+      ]
+    }
+  }
+
+  prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod = {
+    sid    = "ProdToPreProdTrustedZoneDataSyncKeyAccess"
+    effect = "Allow"
+    actions = [
+      "kms:RetireGrant",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:CreateGrant"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_secretsmanager_secret_version.production_account_id.secret_string}:role/production-to-pre-production-s3-sync-role"
+      ]
+    }
+  }
+
 }
 
 module "landing_zone" {
@@ -129,6 +184,9 @@ module "trusted_zone" {
   role_arns_to_share_access_with = [
     var.sync_production_to_pre_production_task_role
   ]
+
+  bucket_policy_statements     = local.is_live_environment && !local.is_production_environment ? [] : [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod]
+  bucket_key_policy_statements = local.is_live_environment && !local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod]
 }
 
 module "glue_scripts" {


### PR DESCRIPTION
Update bucket and bucket key policies for trusted zone to give access to the new prod to pre-prod data sync role. Bucket locations hard coded to pre-prod for safety and to prevent accidental data deletion on prod due to misconfiguration.