### PR TITLE
Dpp 463 update refined and raw zones permissions for data sync

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -134,6 +134,53 @@ locals {
     }
   }
 
+  prod_to_pre_prod_refined_zone_data_sync_statement_for_pre_prod = {
+    sid    = "ProdToPreProdRefinedZoneDataSyncAccess"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:PutObject*",
+      "s3:DeleteObject*",
+      "s3:ReplicateObject",
+      "s3:ReplicateTags",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateDelete"
+    ]
+
+    resources = [
+      "arn:aws:s3:::dataplatform-stg-refined-zone",
+      "arn:aws:s3:::dataplatform-stg-refined-zone/*"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_secretsmanager_secret_version.production_account_id.secret_string}:role/production-to-pre-production-s3-sync-role"
+      ]
+    }
+  }
+
+  prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod = {
+    sid    = "ProdToPreProdRefinedZoneDataSyncKeyAccess"
+    effect = "Allow"
+    actions = [
+      "kms:RetireGrant",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Encrypt",
+      "kms:DescribeKey",
+      "kms:Decrypt",
+      "kms:CreateGrant"
+    ]
+
+    principals = {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_secretsmanager_secret_version.production_account_id.secret_string}:role/production-to-pre-production-s3-sync-role"
+      ]
+    }
+  }
+
 }
 
 module "landing_zone" {
@@ -169,8 +216,14 @@ module "refined_zone" {
   bucket_name                    = "Refined Zone"
   bucket_identifier              = "refined-zone"
   role_arns_to_share_access_with = [var.sync_production_to_pre_production_task_role]
-  bucket_policy_statements       = [local.rentsense_refined_zone_access_statement]
-  bucket_key_policy_statements   = [local.rentsense_refined_zone_key_statement]
+
+  bucket_policy_statements = concat(
+    [local.rentsense_refined_zone_access_statement],
+  local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_refined_zone_data_sync_statement_for_pre_prod])
+
+  bucket_key_policy_statements = concat(
+    [local.rentsense_refined_zone_key_statement],
+  local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod])
 }
 
 module "trusted_zone" {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -266,11 +266,11 @@ module "refined_zone" {
 
   bucket_policy_statements = concat(
     [local.rentsense_refined_zone_access_statement],
-  local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_refined_zone_data_sync_statement_for_pre_prod])
+  local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_refined_zone_data_sync_statement_for_pre_prod] : [])
 
   bucket_key_policy_statements = concat(
     [local.rentsense_refined_zone_key_statement],
-  local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod])
+  local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod] : [])
 }
 
 module "trusted_zone" {
@@ -285,8 +285,8 @@ module "trusted_zone" {
     var.sync_production_to_pre_production_task_role
   ]
 
-  bucket_policy_statements     = local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod]
-  bucket_key_policy_statements = local.is_live_environment && local.is_production_environment ? [] : [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod]
+  bucket_policy_statements     = local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod] : []
+  bucket_key_policy_statements = local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod] : []
 }
 
 module "glue_scripts" {


### PR DESCRIPTION
Update raw and refined zones permissions to support the new data sync role. 

Also update trusted zone's logic to match. This does not affetc the current live setup.