### PR TITLE
DPP-450 update qlik alb egress rules

### DIFF
--- a/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
+++ b/terraform/modules/qlik-sense-server/12-aws-load-balancer.tf
@@ -18,12 +18,11 @@ resource "aws_security_group" "qlik_sense_alb" {
   revoke_rules_on_delete = true
 
   egress {
-    description      = "Allow all outbound traffic"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    description     = "Allow outbound to target group instances security group"
+    from_port       = 443
+    to_port         = 443
+    protocol        = "TCP"
+    security_groups = [aws_security_group.qlik_sense.id]
   }
 
   ingress {


### PR DESCRIPTION
Lock down egress rules for qlik alb security group. Only allow traffic to target group instances security group.