### PR TITLE
DPP-463 Remove obsolete tasks

### DIFF
--- a/terraform/core/35-sync-production-to-pre-production.tf
+++ b/terraform/core/35-sync-production-to-pre-production.tf
@@ -108,53 +108,6 @@ data "aws_iam_policy_document" "task_role" {
   }
 }
 
-module "sync_production_to_pre_production" {
-  source = "../modules/aws-ecs-fargate-task"
-  count  = local.is_production_environment ? 1 : 0
-
-  tags                          = module.tags.values
-  operation_name                = "${local.short_identifier_prefix}sync-production-to-pre-production"
-  ecs_task_role_policy_document = data.aws_iam_policy_document.task_role.json
-  aws_subnet_ids                = data.aws_subnet_ids.network.ids
-  ecs_cluster_arn               = aws_ecs_cluster.workers.arn
-  tasks = [
-    {
-      task_prefix = "raw-zone-"
-      task_cpu    = 2048
-      task_memory = 4096
-      environment_variables = [
-        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
-        { name = "S3_SYNC_SOURCE", value = module.raw_zone.bucket_id },
-        { name = "S3_SYNC_TARGET", value = "dataplatform-stg-raw-zone" }
-      ]
-      cloudwatch_rule_schedule_expression = "cron(0 0 1 1 ? 2050)"
-    },
-    {
-      task_prefix = "refined-zone-"
-      task_cpu    = 256
-      task_memory = 512
-      environment_variables = [
-        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
-        { name = "S3_SYNC_SOURCE", value = module.refined_zone.bucket_id },
-        { name = "S3_SYNC_TARGET", value = "dataplatform-stg-refined-zone" }
-      ]
-      cloudwatch_rule_schedule_expression = "cron(0 0 1 1 ? 2050)"
-    },
-    {
-      task_prefix = "trusted-zone-"
-      task_cpu    = 256
-      task_memory = 512
-      environment_variables = [
-        { name = "NUMBER_OF_DAYS_TO_RETAIN", value = "90" },
-        { name = "S3_SYNC_SOURCE", value = module.trusted_zone.bucket_id },
-        { name = "S3_SYNC_TARGET", value = "dataplatform-stg-trusted-zone" }
-      ]
-      cloudwatch_rule_schedule_expression = "cron(0 0 1 1 ? 2050)"
-    }
-  ]
-  security_groups = [aws_security_group.pre_production_clean_up[0].id]
-}
-
 resource "aws_s3_bucket_replication_configuration" "raw_zone" {
   count  = local.is_production_environment ? 1 : 0
   role   = aws_iam_role.prod_to_pre_prod_s3_sync_role[0].arn

--- a/terraform/core/99-outputs.tf
+++ b/terraform/core/99-outputs.tf
@@ -17,10 +17,6 @@ output "liberator_dump_to_rds_snapshot_ecr_repository_worker_endpoint" {
   value = try(module.liberator_dump_to_rds_snapshot[0].ecr_repository_worker_endpoint, null)
 }
 
-output "prod_to_pre_prod_ecr_repository_endpoint" {
-  value = try(module.sync_production_to_pre_production[0].ecr_repository_worker_endpoint, null)
-}
-
 output "pre_prod_data_cleanup_ecr_repository_endpoint" {
   value = try(module.pre_production_data_cleanup[0].ecr_repository_worker_endpoint, null)
 }
@@ -36,8 +32,3 @@ output "identity_store_id" {
 output "arn" {
   value = local.sso_instance_arn
 }
-
-output "sync_production_to_pre_production_task_role_arn" {
-  value = try(module.sync_production_to_pre_production[0].task_role, null)
-}
-


### PR DESCRIPTION
Remove obsolete tasks from prod. Both data sync and data clean up tasks have been deployed using new setups, so these tasks are no longer needed. We can tidy up the resources (old role and references to it in workflows etc.) further once these have been removed. 