### PR TITLE
DPP-480 update setup terraform to nodejs 16 version

### DIFF
--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
           terraform_version: 1.2.0

--- a/.github/workflows/deploy_terraform_networking.yml
+++ b/.github/workflows/deploy_terraform_networking.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
           terraform_version: 1.2.0

--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.2.0
 

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.2.0
 

--- a/.github/workflows/unlock_terraform_state.yml
+++ b/.github/workflows/unlock_terraform_state.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_wrapper: false
           terraform_version: 1.2.0

--- a/.github/workflows/validate-and-lint-terraform.yml
+++ b/.github/workflows/validate-and-lint-terraform.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.2.0
 

--- a/.github/workflows/validate-and-lint-terraform.yml
+++ b/.github/workflows/validate-and-lint-terraform.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v1.3.2
+        uses: hashicorp/setup-terraform@v2.0.3
         with:
           terraform_version: 1.2.0
 


### PR DESCRIPTION
Update `setup-terraform` action to use the latest version (2.0.3). This will update the Node.js runtime to version 16 from the  now deprecated version 12.

Please note this does not update the Terraform version itself, just the runtime in the workflow.