### PR TITLE
DPP-490 Add variable to supress warnings

### DIFF
--- a/terraform/networking/04-input-redundant.tf
+++ b/terraform/networking/04-input-redundant.tf
@@ -33,3 +33,7 @@ variable "copy_liberator_to_pre_prod_lambda_execution_role" {
 variable "pre_production_liberator_data_storage_kms_key_arn" {
   default = false
 }
+
+variable "emails_to_notify_with_budget_alerts" {
+  default = false
+}

--- a/terraform/networking/04-input-redundant.tf
+++ b/terraform/networking/04-input-redundant.tf
@@ -45,3 +45,7 @@ variable "qlik_ssl_certificate_domain" {
 variable "rentsense_target_path" {
   default = false
 }
+
+variable "datahub_url" {
+  default = false
+}

--- a/terraform/networking/04-input-redundant.tf
+++ b/terraform/networking/04-input-redundant.tf
@@ -37,3 +37,11 @@ variable "pre_production_liberator_data_storage_kms_key_arn" {
 variable "emails_to_notify_with_budget_alerts" {
   default = false
 }
+
+variable "qlik_ssl_certificate_domain" {
+  default = false
+}
+
+variable "rentsense_target_path" {
+  default = false
+}


### PR DESCRIPTION
Add variable for `emails_to_notify_with_budget_alerts`, `qlik_ssl_certificate_domain`, `rentsense_target_path` and `datahub_url` to supress warnings in plans. This is follows the same approach used for other unused env vars in the project. 