### PR TITLE
DPP-489 Remove deprecated argument

### DIFF
--- a/terraform/backend-setup/10-aws-s3-buckets.tf
+++ b/terraform/backend-setup/10-aws-s3-buckets.tf
@@ -19,10 +19,6 @@ resource "aws_s3_bucket" "terraform_state_storage" {
       }
     }
   }
-
-  versioning {
-    enabled = true
-  }
 }
 
 resource "aws_s3_bucket_public_access_block" "block_public_access" {


### PR DESCRIPTION
Remove deprecated argument from the bucket config.

This argument has no effect and the bucket has no versioning enabled at the moment. 

This bucket is used for the dev backend setup only and has no workflow. Resource has only been deployed once from a local machine, so this update will not trigger a change.