### PR TITLE
DPP-942 update module to latest version

### DIFF
--- a/terraform/networking/21-vpc-peering-connection.tf
+++ b/terraform/networking/21-vpc-peering-connection.tf
@@ -9,7 +9,7 @@ module "api_vpc_peering_cross_account" {
   tags    = module.tags.values
   enabled = true
 
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.16.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.19.1"
   name   = "${local.identifier_prefix}-api-vpc-peering-connection"
 
   requester_aws_assume_role_arn             = local.requester_assume_role_arn
@@ -27,7 +27,7 @@ module "mosaic_vpc_peering_cross_account" {
   tags    = module.tags.values
   enabled = true
 
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.16.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.19.1"
   name   = "${local.identifier_prefix}-mosaic-vpc-peering-connection"
 
   requester_aws_assume_role_arn             = local.requester_assume_role_arn
@@ -45,7 +45,7 @@ module "dp_stg_prod_vpc_peering_cross_account" {
   tags    = module.tags.values
   enabled = false
 
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.16.0"
+  source = "git::https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account.git?ref=tags/0.19.1"
   name   = "${local.identifier_prefix}-vpc-peering-connection"
 
   requester_aws_assume_role_arn             = local.requester_assume_role_arn


### PR DESCRIPTION
Update VPC peering module to the latest version. 

This will resolve the deprecated `aws_subnet_ids` data resource warning in the plans.

This has no effect on the current configuration and does not trigger a change.