### PR TITLE
DPP-493 Remove quotes from reference

### DIFF
--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -57,7 +57,7 @@ resource "aws_glue_workflow" "parking_liberator_backdated_data" {
   tags = module.tags.values
 
   lifecycle {
-    ignore_changes = ["default_run_properties"]
+    ignore_changes = [default_run_properties]
   }
 }
 


### PR DESCRIPTION
Quoted references are now deprecated. Remove the quotes to silence the warnings.