### PR TITLE
DPP-494 Update subnet ids handling

### DIFF
--- a/terraform/core/06-network.tf
+++ b/terraform/core/06-network.tf
@@ -2,12 +2,15 @@ data "aws_vpc" "network" {
   id = data.aws_ssm_parameter.aws_vpc_id.value
 }
 
-data "aws_subnet_ids" "network" {
-  vpc_id = data.aws_ssm_parameter.aws_vpc_id.value
+data "aws_subnets" "network" {
+  filter {
+    name    = "vpc-id"
+    values  = [data.aws_ssm_parameter.aws_vpc_id.value]
+  }
 }
 
 data "aws_subnet" "network" {
-  for_each = data.aws_subnet_ids.network.ids
+  for_each = toset(data.aws_subnets.network.ids)
   id       = each.value
 }
 
@@ -17,8 +20,8 @@ resource "random_id" "index" {
 
 # This show a method of randomly selecting a subnet from the VPC to deploy into.
 locals {
-  subnet_ids_list         = tolist(data.aws_subnet_ids.network.ids)
-  subnet_ids_random_index = random_id.index.dec % length(data.aws_subnet_ids.network.ids)
+  subnet_ids_list         = tolist(data.aws_subnets.network.ids)
+  subnet_ids_random_index = random_id.index.dec % length(data.aws_subnets.network.ids)
   instance_subnet_id      = local.subnet_ids_list[local.subnet_ids_random_index]
 }
 

--- a/terraform/core/32-kafka-event-streaming.tf
+++ b/terraform/core/32-kafka-event-streaming.tf
@@ -16,7 +16,7 @@ module "kafka_event_streaming" {
   identifier_prefix                      = local.identifier_prefix
   short_identifier_prefix                = local.short_identifier_prefix
   vpc_id                                 = data.aws_vpc.network.id
-  subnet_ids                             = data.aws_subnet_ids.network.ids
+  subnet_ids                             = data.aws_subnets.network.ids
   s3_bucket_to_write_to                  = module.raw_zone
   bastion_private_key_ssm_parameter_name = aws_ssm_parameter.bastion_key.name
   bastion_instance_id                    = aws_instance.bastion.id
@@ -40,7 +40,7 @@ module "kafka_test_lambda" {
   lambda_name                    = "kafka-test"
   tags                           = module.tags.values
   vpc_id                         = data.aws_vpc.network.id
-  subnet_ids                     = data.aws_subnet_ids.network.ids
+  subnet_ids                     = data.aws_subnets.network.ids
   identifier_prefix              = local.short_identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
   kafka_cluster_arn              = module.kafka_event_streaming[0].cluster_config.cluster_arn

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -21,7 +21,7 @@ module "liberator_dump_to_rds_snapshot" {
   instance_name              = "${local.short_identifier_prefix}liberator-to-rds-snapshot"
   watched_bucket_name        = module.liberator_data_storage.bucket_id
   watched_bucket_kms_key_arn = module.liberator_data_storage.kms_key_arn
-  aws_subnet_ids             = data.aws_subnet_ids.network.ids
+  aws_subnet_ids             = data.aws_subnets.network.ids
   ecs_cluster_arn            = aws_ecs_cluster.workers.arn
   vpc_id                     = data.aws_vpc.network.id
 }

--- a/terraform/core/84-pre-prod-data-cleanup-tasks.tf
+++ b/terraform/core/84-pre-prod-data-cleanup-tasks.tf
@@ -38,7 +38,7 @@ module "pre_production_data_cleanup" {
   tags                          = module.tags.values
   operation_name                = "${local.short_identifier_prefix}pre-production-data-cleanup"
   ecs_task_role_policy_document = data.aws_iam_policy_document.pre_production_data_cleanup_task_role[0].json
-  aws_subnet_ids                = data.aws_subnet_ids.network.ids
+  aws_subnet_ids                = data.aws_subnets.network.ids
   ecs_cluster_arn               = aws_ecs_cluster.workers.arn
   tasks = [
     {

--- a/terraform/core/99-outputs.tf
+++ b/terraform/core/99-outputs.tf
@@ -6,7 +6,7 @@ output "network_vpc_arn" {
 
 output "network_vpc_subnets" {
   description = "A list of AWS Subnet IDs"
-  value       = data.aws_subnets.network.ids
+  value       = toset(data.aws_subnets.network.ids)
 }
 
 output "network_vpc_subnet_cider_blocks" {

--- a/terraform/core/99-outputs.tf
+++ b/terraform/core/99-outputs.tf
@@ -6,7 +6,7 @@ output "network_vpc_arn" {
 
 output "network_vpc_subnets" {
   description = "A list of AWS Subnet IDs"
-  value       = data.aws_subnet_ids.network.ids
+  value       = data.aws_subnets.network.ids
 }
 
 output "network_vpc_subnet_cider_blocks" {


### PR DESCRIPTION
Update to the new `aws_subnets` from the deprecated `aws_subnet_ids` resource. This does not trigger other changes.