### PR TITLE
DPP-498 Update provider config

### DIFF
--- a/terraform/modules/db-snapshot-to-s3-sandbox-resources/00-init.tf
+++ b/terraform/modules/db-snapshot-to-s3-sandbox-resources/00-init.tf
@@ -9,11 +9,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.0"
+      configuration_aliases = [
+        aws.aws_sandbox_account
+     ]
     }
   }
-}
-
-
-provider "aws" {
-  alias = "aws_sandbox_account"
 }

--- a/terraform/modules/department/00-init.tf
+++ b/terraform/modules/department/00-init.tf
@@ -9,10 +9,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.0"
+      configuration_aliases = [ 
+        aws.aws_hackit_account
+       ]
     }
   }
-}
-
-provider "aws" {
-  alias = "aws_hackit_account"
 }


### PR DESCRIPTION
Move provider alias from deprecated empty provider block to `configuration_aliases` block.