### PR TITLE
DPP-500 Update deprecated number to numeric

### DIFF
--- a/terraform/modules/department/40-aws-secretsmanager.tf
+++ b/terraform/modules/department/40-aws-secretsmanager.tf
@@ -18,7 +18,7 @@ resource "aws_ssm_parameter" "redshift_cluster_credentials_arn" {
 resource "random_password" "redshift_password" {
   length      = 24
   special     = false
-  number      = true
+  numeric     = true
   min_numeric = 1
   upper       = true
   min_upper   = 1


### PR DESCRIPTION
`number` argument is deprecated. Update to use `numeric` instead. This has no effect on the current configuration.