### PR TITLE
DPP-497 Remove experimental optional variables

### DIFF
--- a/terraform/core/12-housing-income-collection-db-ingestion.tf
+++ b/terraform/core/12-housing-income-collection-db-ingestion.tf
@@ -74,6 +74,7 @@ module "ingest_housing_income_collection_database_to_housing_raw_zone" {
       Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
       }
     })
+    table_prefix      = null
   }
 }
    

--- a/terraform/core/14-parking-geolive-database-ingestion.tf
+++ b/terraform/core/14-parking-geolive-database-ingestion.tf
@@ -43,5 +43,6 @@ module "parking_geolive_ingestion_job" {
         TableLevelConfiguration = 4
       }
     })
+    table_prefix      = null
   }
 }

--- a/terraform/core/15-unrestricted-geolive-database-ingestion.tf
+++ b/terraform/core/15-unrestricted-geolive-database-ingestion.tf
@@ -43,6 +43,7 @@ module "boundaries_geolive_ingestion_job" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }
     
@@ -91,6 +92,7 @@ module "recycling_boundaries_geolive_ingestion_job" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }  
   
@@ -139,6 +141,7 @@ module "health_boundaries_geolive_ingestion_job" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }  
 
@@ -187,6 +190,7 @@ module "education_boundaries_geolive_ingestion_job" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }  
 
@@ -235,5 +239,6 @@ module "housing_boundaries_geolive_ingestion_job" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }  

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -116,6 +116,7 @@ module "copy_mtfh_rentsense_dynamo_db_tables_to_raw_zone" {
         Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
       }
     })
+    table_prefix      = null
   }
 }
 

--- a/terraform/core/38-api-ingestion.tf
+++ b/terraform/core/38-api-ingestion.tf
@@ -98,6 +98,7 @@ module "copy_icaseworks_data_landing_to_raw" {
         TableLevelConfiguration = 3
       }
     })
+    table_prefix      = null
   }
 }
 
@@ -138,6 +139,6 @@ module "copy_vonage_data_landing_to_raw" {
         TableLevelConfiguration = 3
       }
     })
+    table_prefix      = null
   }
 }
-#

--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -75,6 +75,7 @@ module "ingest_housing_interim_finance_database_to_housing_raw_zone" {
       Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
       }
     })
+    table_prefix      = null
   }
 }
     

--- a/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
+++ b/terraform/core/40-ringgo-sftp-to-s3-ingestion.tf
@@ -93,5 +93,6 @@ module "ringgo_sftp_data_to_raw" {
         TableLevelConfiguration = 4
       }
     })
+    table_prefix      = null
   }
 }

--- a/terraform/core/84-pre-prod-data-cleanup-tasks.tf
+++ b/terraform/core/84-pre-prod-data-cleanup-tasks.tf
@@ -50,6 +50,7 @@ module "pre_production_data_cleanup" {
         { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-raw-zone" }
       ]
       cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+      cloudwatch_rule_event_pattern       = null
     },
     {
       task_prefix = "refined-zone-"
@@ -60,6 +61,7 @@ module "pre_production_data_cleanup" {
         { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-refined-zone" }
       ]
       cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+      cloudwatch_rule_event_pattern       = null
     },
     {
       task_prefix = "trusted-zone-"
@@ -70,6 +72,7 @@ module "pre_production_data_cleanup" {
         { name = "S3_CLEANUP_TARGET", value = "dataplatform-stg-trusted-zone" }
       ]
       cloudwatch_rule_schedule_expression = "cron(0 0 ? * 1 *)"
+      cloudwatch_rule_event_pattern       = null
     }
   ]
   security_groups = [aws_security_group.pre_production_data_cleanup[0].id]

--- a/terraform/etl/12-aws-glue-crawler-parking-spreadsheets.tf
+++ b/terraform/etl/12-aws-glue-crawler-parking-spreadsheets.tf
@@ -16,6 +16,7 @@ resource "aws_glue_crawler" "raw_zone_parking_g_drive_crawler" {
       TableLevelConfiguration = 4
     }
   })
+  table_prefix = null
 }
 
 resource "aws_glue_trigger" "raw_zone_parking_spreadsheets_crawler" {

--- a/terraform/etl/12-aws-glue-parking-manual-upload.tf
+++ b/terraform/etl/12-aws-glue-parking-manual-upload.tf
@@ -36,6 +36,7 @@ module "manually_uploaded_parking_data_to_raw" {
         TableLevelConfiguration = 4
       }
     })
+    table_prefix       = null 
   }
 }
 

--- a/terraform/etl/20-noiseworks-import-s3.tf
+++ b/terraform/etl/20-noiseworks-import-s3.tf
@@ -22,5 +22,6 @@ module "noiseworks_to_raw_zone" {
     database_name      = module.department_env_enforcement_data_source.raw_zone_catalog_database_name
     s3_target_location = "s3://${module.raw_zone_data_source.bucket_id}/env-enforcement/noiseworks/"
     table_prefix       = "noiseworks_"
+    configuration      = null 
   }
 }

--- a/terraform/etl/24-aws-glue-housing.tf
+++ b/terraform/etl/24-aws-glue-housing.tf
@@ -25,6 +25,8 @@ module "mtfh_reshape_to_refined" {
   crawler_details = {
     database_name      = module.department_housing_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/housing/mtfh"
+    configuration      = null
+    table_prefix       = null 
   }
 
 }

--- a/terraform/etl/24-aws-glue-spatial.tf
+++ b/terraform/etl/24-aws-glue-spatial.tf
@@ -23,6 +23,8 @@ module "llpg_raw_to_trusted" {
   crawler_details = {
     database_name      = module.department_unrestricted_data_source.trusted_zone_catalog_database_name
     s3_target_location = "s3://${module.trusted_zone_data_source.bucket_id}/unrestricted/llpg/latest_llpg"
+    configuration      = null
+    table_prefix       = null 
   }
 
 }
@@ -79,5 +81,6 @@ module "env_services_geospatial_enrichment" {
     database_name      = module.department_environmental_services_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/env-services/spatially-enriched"
     table_prefix       = "spatially_enriched_"
+    configuration      = null
   }
 }

--- a/terraform/etl/24-aws-glue-tascomi-data.tf
+++ b/terraform/etl/24-aws-glue-tascomi-data.tf
@@ -199,6 +199,7 @@ module "tascomi_parse_tables_increments" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }
 
@@ -268,6 +269,7 @@ module "tascomi_create_daily_snapshot" {
         TableLevelConfiguration = 5
       }
     })
+    table_prefix      = null
   }
 }
 
@@ -299,9 +301,9 @@ module "tascomi_applications_to_trusted" {
   crawler_details = {
     database_name      = aws_glue_catalog_database.trusted_zone_tascomi.name
     s3_target_location = "s3://${module.trusted_zone_data_source.bucket_id}/planning/tascomi/applications"
-
+    configuration      = null
+    table_prefix       = null
   }
-
 }
 
 module "tascomi_officers_teams_to_trusted" {
@@ -330,6 +332,8 @@ module "tascomi_officers_teams_to_trusted" {
   crawler_details = {
     database_name      = aws_glue_catalog_database.trusted_zone_tascomi.name
     s3_target_location = "s3://${module.trusted_zone_data_source.bucket_id}/planning/tascomi/officers"
+    configuration      = null
+    table_prefix       = null
   }
 
 }
@@ -360,6 +364,8 @@ module "tascomi_locations_to_trusted" {
   crawler_details = {
     database_name      = aws_glue_catalog_database.trusted_zone_tascomi.name
     s3_target_location = "s3://${module.trusted_zone_data_source.bucket_id}/planning/tascomi/locations"
+    configuration      = null
+    table_prefix       = null
   }
 
 }
@@ -388,6 +394,7 @@ module "tascomi_subsidiary_tables_to_trusted" {
   crawler_details = {
     database_name      = aws_glue_catalog_database.trusted_zone_tascomi.name
     s3_target_location = "s3://${module.trusted_zone_data_source.bucket_id}/planning/tascomi/"
+    configuration      = null
+    table_prefix       = null 
   }
-
 }

--- a/terraform/etl/29-aws-glue-job-repairs-dlo.tf
+++ b/terraform/etl/29-aws-glue-job-repairs-dlo.tf
@@ -29,6 +29,7 @@ module "housing_repairs_dlo_cleaning_job" {
     table_prefix       = "housing_repairs_repairs_dlo_"
     database_name      = module.department_housing_repairs_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/housing-repairs/repairs-dlo/cleaned/"
+    configuration      = null
   }
 }
 
@@ -57,6 +58,7 @@ module "housing_repairs_dlo_address_cleaning_job" {
     table_prefix       = "housing_repairs_repairs_dlo_"
     database_name      = module.department_housing_repairs_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/housing-repairs/repairs-dlo/with-cleaned-addresses/"
+    configuration      = null
   }
 }
 
@@ -87,6 +89,7 @@ module "get_uprn_from_uhref_job" {
     table_prefix       = "housing_repairs_repairs_dlo_"
     database_name      = module.department_housing_repairs_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/housing-repairs/repairs-dlo/with_uprn_from_uhref/"
+    configuration      = null
   }
 }
 

--- a/terraform/etl/35-aws-glue-env-enforcement.tf
+++ b/terraform/etl/35-aws-glue-env-enforcement.tf
@@ -28,6 +28,8 @@ module "liberator_fpns_to_refined" {
   crawler_details = {
     database_name      = module.department_env_enforcement_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/env-enforcement"
+    configuration      = null
+    table_prefix       = null 
   }
 
 }
@@ -59,6 +61,8 @@ module "noisework_complaints_to_refined" {
   crawler_details = {
     database_name      = module.department_env_enforcement_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/env-enforcement"
+    configuration      = null
+    table_prefix       = null 
   }
 
 }

--- a/terraform/etl/37-aws-glue-job-housing-repairs.tf
+++ b/terraform/etl/37-aws-glue-job-housing-repairs.tf
@@ -22,6 +22,8 @@ module "address_matching_glue_job" {
   crawler_details = {
     database_name      = aws_glue_catalog_database.landing_zone_data_and_insight_address_matching[count.index].name
     s3_target_location = "s3://${module.landing_zone_data_source.bucket_id}/data-and-insight/address-matching-glue-job-output/"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 

--- a/terraform/etl/40-aws-glue-job-sandbox.tf
+++ b/terraform/etl/40-aws-glue-job-sandbox.tf
@@ -18,6 +18,8 @@ module "load_locations_vaccine_to_refined_sandbox" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/daro-covid-locations-vaccinations-cleaned"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 
@@ -59,6 +61,8 @@ module "load_covid_data_to_refined_marta" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/marta-covid-locations-vaccinations-cleaned"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 
@@ -83,6 +87,8 @@ module "load_covid_data_to_refined_adam" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/covid_adam"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 
@@ -128,6 +134,7 @@ module "steve_covid_locations_and_vaccinations_sandbox" {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/steve-covid-vaccinations-locations"
     table_prefix       = "sandbox_"
+    configuration      = null
   }
 }
 
@@ -152,6 +159,8 @@ module "stg_job_template_huu_do_sandbox" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/covid-data-huu-do/"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 
@@ -175,6 +184,8 @@ module "covid_vaccinations_verlander_sandbox" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/covid_locations_verlander/"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 
@@ -198,6 +209,8 @@ module "covid_vaccinations_arda_sandbox" {
   crawler_details = {
     database_name      = module.department_sandbox_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/sandbox/covid_locations_arda/"
+    configuration      = null
+    table_prefix       = null 
   }
 }
 #

--- a/terraform/etl/43-aws-glue-job-rentsense.tf
+++ b/terraform/etl/43-aws-glue-job-rentsense.tf
@@ -41,8 +41,9 @@ module "rentsense_output_to_landing_S3" {
     Version = 1.0
     Grouping = {
       TableLevelConfiguration = 4
-    }
-  })
+      }
+    })
+    table_prefix = null
   }
 
 }

--- a/terraform/etl/45-aws-glue-job-active-persons-records.tf
+++ b/terraform/etl/45-aws-glue-job-active-persons-records.tf
@@ -50,6 +50,8 @@ module "active_persons_records_refined" {
   crawler_details = {
     database_name      = module.department_data_and_insight_data_source.refined_zone_catalog_database_name
     s3_target_location = "s3://${module.refined_zone_data_source.bucket_id}/data-and-insight/active-person-records"
+    configuration      = null
+    table_prefix       = null
   }
 
 }

--- a/terraform/modules/aws-ecs-fargate-task/00-init.tf
+++ b/terraform/modules/aws-ecs-fargate-task/00-init.tf
@@ -4,7 +4,6 @@
 */
 terraform {
   required_version = "~> 1.0"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/aws-ecs-fargate-task/01-inputs-required.tf
+++ b/terraform/modules/aws-ecs-fargate-task/01-inputs-required.tf
@@ -26,11 +26,11 @@ variable "aws_subnet_ids" {
 variable "tasks" {
   description = "An array of objects containing tasks to be created"
   type = list(object({
-    task_prefix                         = optional(string)
-    cloudwatch_rule_schedule_expression = optional(string)
-    cloudwatch_rule_event_pattern       = optional(string)
-    task_cpu                            = optional(number)
-    task_memory                         = optional(number)
+    task_prefix                         = string
+    cloudwatch_rule_schedule_expression = string
+    cloudwatch_rule_event_pattern       = string
+    task_cpu                            = number
+    task_memory                         = number
     environment_variables = list(object({
       name  = string
       value = string

--- a/terraform/modules/aws-glue-job/00-init.tf
+++ b/terraform/modules/aws-glue-job/00-init.tf
@@ -4,7 +4,6 @@
 */
 terraform {
   required_version = "~> 1.0"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/aws-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/aws-glue-job/02-inputs-optional.tf
@@ -98,12 +98,14 @@ variable "crawler_details" {
   type = object({
     database_name      = string
     s3_target_location = string
-    table_prefix       = optional(string)
-    configuration      = optional(string)
+    table_prefix       = string
+    configuration      = string
   })
   default = {
     database_name      = null
     s3_target_location = null
+    table_prefix       = null
+    configuration      = null
   }
 }
 

--- a/terraform/modules/aws-glue-job/03-inputs-derived.tf
+++ b/terraform/modules/aws-glue-job/03-inputs-derived.tf
@@ -1,12 +1,3 @@
 locals {
   job_name_identifier = replace(lower(var.job_name), "/[^a-zA-Z0-9]+/", "-")
-  default_crawler_configuration = jsonencode({
-    Version = 1.0
-    CrawlerOutput = {
-      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
-    }
-  })
-  crawler_details = defaults(var.crawler_details, {
-    configuration = local.default_crawler_configuration
-  })
 }

--- a/terraform/modules/data-sources/aws-glue-job/00-init.tf
+++ b/terraform/modules/data-sources/aws-glue-job/00-init.tf
@@ -4,7 +4,6 @@
 */
 terraform {
   required_version = "~> 1.0"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/database-ingestion-via-jdbc-connection/00-init.tf
+++ b/terraform/modules/database-ingestion-via-jdbc-connection/00-init.tf
@@ -4,7 +4,6 @@
 */
 terraform {
   required_version = "~> 1.0"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/dynamodb/00-init.tf
+++ b/terraform/modules/dynamodb/00-init.tf
@@ -4,7 +4,6 @@
 */
 terraform {
   required_version = "~> 1.0"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-data-cleaning.tf
+++ b/terraform/modules/electrical-mechnical-fire-safety-cleaning-job/10-aws-glue-data-cleaning.tf
@@ -35,5 +35,6 @@ module "housing_repairs_elec_mech_fire_cleaning" {
     database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/repairs-electrical-mechanical-fire/${var.dataset_name}/cleaned/"
     table_prefix       = "housing_repairs_elec_mech_fire_${replace(var.dataset_name, "-", "_")}_"
+    configuration      = null
   }
 }

--- a/terraform/modules/electrical-mechnical-fire-safety-cleaning-job/11-aws-glue-address-cleaning.tf
+++ b/terraform/modules/electrical-mechnical-fire-safety-cleaning-job/11-aws-glue-address-cleaning.tf
@@ -22,6 +22,7 @@ module "housing_repairs_elec_mech_fire_address_cleaning" {
     database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/repairs-electrical-mechanical-fire/${var.dataset_name}/with-cleaned-addresses/"
     table_prefix       = "housing_repairs_elec_mech_fire_${replace(var.dataset_name, "-", "_")}_"
+    configuration      = null
   }
 }
 

--- a/terraform/modules/housing-repairs-google-sheets-cleaning/10-aws-glue-data-cleaning.tf
+++ b/terraform/modules/housing-repairs-google-sheets-cleaning/10-aws-glue-data-cleaning.tf
@@ -33,6 +33,7 @@ module "housing_repairs_google_sheets_cleaning" {
     table_prefix       = "housing_repairs_${replace(var.dataset_name, "-", "_")}_"
     database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/cleaned/"
+    configuration      = null
   }
   trigger_enabled = false
 }

--- a/terraform/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
+++ b/terraform/modules/housing-repairs-google-sheets-cleaning/11-aws-glue-address-cleaning.tf
@@ -22,5 +22,6 @@ module "housing_repairs_google_sheets_address_cleaning" {
     table_prefix       = "housing_repairs_${replace(var.dataset_name, "-", "_")}_"
     database_name      = local.refined_zone_catalog_database_name
     s3_target_location = "s3://${var.refined_zone_bucket_id}/housing-repairs/${var.dataset_name}/with-cleaned-addresses/"
+    configuration      = null
   }
 }

--- a/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
+++ b/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
@@ -29,6 +29,7 @@ module "spreadsheet_import" {
         TableLevelConfiguration = 3
       }
     })
+    table_prefix      = null
   }
   trigger_enabled = false
 }

--- a/terraform/modules/sql-to-rds-snapshot/10-ecs.tf
+++ b/terraform/modules/sql-to-rds-snapshot/10-ecs.tf
@@ -62,9 +62,11 @@ module "sql_to_parquet" {
   ecs_cluster_arn               = var.ecs_cluster_arn
   tasks = [
     {
-      cloudwatch_rule_event_pattern = local.event_pattern
-      task_cpu                      = 256
-      task_memory                   = 512
+      cloudwatch_rule_event_pattern       = local.event_pattern
+      cloudwatch_rule_schedule_expression = null
+      task_prefix                         = null
+      task_cpu                            = 256
+      task_memory                         = 512
       environment_variables = [
         { name : "MYSQL_HOST", value : aws_db_instance.ingestion_db.address },
         { name : "MYSQL_USER", value : aws_db_instance.ingestion_db.username },


### PR DESCRIPTION
Remove support for experimental 'module_variable_optional_attrs` in modules.

Optional variables are great feature, but they are not officially supported by our version of Terraform. To ensure this experimental feature won't break anything in the future this update removes it from the project.

Impact of this is that all input variables must be provided with a value from now on. If variable doesn't need to be set to a specific value it needs to be set to null.

This only affect ecs task definitions and glue crawler details.

I have also removed redundant `default_crawler_configuration` and `crawler_details` locals since they are not being used anywhere.

 