### PR TITLE
DPP-506 Add configuration alias for department data sources

### DIFF
--- a/terraform/modules/data-sources/department/00-init.tf
+++ b/terraform/modules/data-sources/department/00-init.tf
@@ -9,6 +9,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 4.0"
+      configuration_aliases = [
+        aws.aws_hackit_account
+      ]
     }
   }
 }


### PR DESCRIPTION
Add configuration alias to the provider, so the source is set explicitly to "hashicorp/aws" for `aws.aws_hackit_account`

This does not affect the current configuration, but will silence the warning about the provider source.