### PR TITLE
DPP-507 Update install-node to v3

### DIFF
--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -94,7 +94,7 @@ jobs:
           chmod 400 ~/.ssh/id_rsa ~/.ssh/known_hosts
 
       - name: Setup Node.js 14
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: "14"
 


### PR DESCRIPTION
`actions/setup-node@v2` is using deprecated Node 12. This updates the action to v3 to switch to Node 16 action. Node version installed during the setup has not been changed and is still 14.