### PR TITLE
DPP-510 Update how lambda is packaged

### DIFF
--- a/terraform/modules/g-drive-to-s3/10-lambda.tf
+++ b/terraform/modules/g-drive-to-s3/10-lambda.tf
@@ -97,21 +97,36 @@ resource "aws_iam_role_policy_attachment" "g_drive_to_s3_copier_lambda" {
   policy_arn = aws_iam_policy.g_drive_to_s3_copier_lambda.arn
 }
 
-data "archive_file" "g_drive_to_s3_copier_lambda" {
-  type        = "zip"
-  source_dir  = "../../lambdas/g_drive_to_s3"
-  output_path = "../../lambdas/g_drive_to_s3.zip"
+locals {
+  lambda_name_underscore = "g_drive_to_s3"
+  lambda_exporter_id     = null_resource.run_install_requirements.id
+  source_dir             = "../../lambdas/${local.lambda_name_underscore}"
 }
 
-resource "aws_s3_bucket_object" "g_drive_to_s3_copier_lambda" {
+resource "null_resource" "run_install_requirements" {
+  triggers = {
+    dir_sha1 = sha1(join("", [for f in fileset(path.module, "../../../lambdas/${local.lambda_name_underscore}/*") : filesha1("${path.module}/${f}")]))
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["bash", "-c"]
+    command     = "make install-requirements"
+    working_dir = "${path.module}/../../../lambdas/${local.lambda_name_underscore}/"
+  }
+}
+
+data "archive_file" "g_drive_to_s3_copier_lambda" {
+  type        = "zip"
+  source_dir  = local.source_dir
+  output_path = "../../lambdas/${local.lambda_name_underscore}.zip"
+}
+
+resource "aws_s3_object" "g_drive_to_s3_copier_lambda" {
   bucket      = var.lambda_artefact_storage_bucket
-  key         = "g_drive_to_s3.zip"
+  key         = "${local.lambda_name_underscore}.zip"
   source      = data.archive_file.g_drive_to_s3_copier_lambda.output_path
   acl         = "private"
-  source_hash = data.archive_file.g_drive_to_s3_copier_lambda.output_md5
-  depends_on = [
-    data.archive_file.g_drive_to_s3_copier_lambda
-  ]
+  source_hash = null_resource.run_install_requirements.triggers["dir_sha1"]
 }
 
 resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
@@ -122,7 +137,7 @@ resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
   runtime          = "python3.8"
   function_name    = lower("${var.identifier_prefix}g-drive-${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
-  s3_key           = aws_s3_bucket_object.g_drive_to_s3_copier_lambda.key
+  s3_key           = aws_s3_object.g_drive_to_s3_copier_lambda.key
   source_code_hash = data.archive_file.g_drive_to_s3_copier_lambda.output_base64sha256
   timeout          = local.lambda_timeout
   memory_size      = local.lambda_memory_size
@@ -136,10 +151,6 @@ resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
       GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_SECRET_ARN = var.google_service_account_credentials_secret
     }
   }
-
-  depends_on = [
-    aws_s3_bucket_object.g_drive_to_s3_copier_lambda,
-  ]
 }
 
 resource "aws_lambda_function_event_invoke_config" "g_drive_to_s3_copier_lambda" {


### PR DESCRIPTION
With the current config the g-drive-to-s3-copier lambdas get deployed every time even though the source hasn't changed. This updates the packaging to follow the approach used elsewhere in the project where the changes are correctly detected.

This will re-create the bucker objects, but it's necessary for updating some of the deprecated resources at the same time.