### PR TITLE
DPP-510 Add output file mode

### DIFF
--- a/lambdas/icaseworks_api_ingestion/main.py
+++ b/lambdas/icaseworks_api_ingestion/main.py
@@ -18,7 +18,6 @@ import logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-
 def remove_illegal_characters(string):
     """Removes illegal characters from string"""
     regex_list = [['=', ""], ['\/', "_"], ['+', "-"]]

--- a/lambdas/sftp_to_s3/index.js
+++ b/lambdas/sftp_to_s3/index.js
@@ -179,3 +179,4 @@ exports.handler = async (event) => {
     await sftp.end();
   }
 }
+

--- a/lambdas/vonage_api_ingestion/main.py
+++ b/lambdas/vonage_api_ingestion/main.py
@@ -400,3 +400,4 @@ def lambda_handler(event, lambda_context):
 def start_glue_trigger(glue_client, trigger_name):
     trigger_details = glue_client.start_trigger(Name=trigger_name)
     logger.info(f"Started trigger: {trigger_details}")
+

--- a/terraform/modules/api-ingestion-lambda/10-lambda.tf
+++ b/terraform/modules/api-ingestion-lambda/10-lambda.tf
@@ -114,9 +114,10 @@ resource "null_resource" "run_install_requirements" {
 }
 
 data "archive_file" "lambda" {
-  type        = "zip"
-  source_dir  = local.source_dir
-  output_path = "../../lambdas/${local.lambda_name_underscore}.zip"
+  type             = "zip"
+  source_dir       = local.source_dir
+  output_path      = "../../lambdas/${local.lambda_name_underscore}.zip"
+  output_file_mode = "0666"
 }
 
 resource "aws_s3_bucket_object" "lambda" {


### PR DESCRIPTION
Add `output_file_mode` to the archive file config and update the source of all affected lambdas to trigger re-deployment. This will get the source file hash for the lambdas in sync with AWS.