### PR TITLE
allow flexible execution

### DIFF
--- a/terraform/modules/aws-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/aws-glue-job/02-inputs-optional.tf
@@ -217,3 +217,14 @@ variable "max_retries" {
     error_message = "Maximum number of retries must be between 0 and 3."
   }
 }
+
+variable "execution_class" {
+  description = "Execution class to use for the glue job"
+  type        = string
+  default     = "STANDARD"
+
+  validation {
+    condition     = contains(["STANDARD", "FLEX"], var.execution_class)
+    error_message = "Execution class must be STANDARD or FLEX."
+  }
+}

--- a/terraform/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/aws-glue-job/10-aws-glue-job.tf
@@ -39,6 +39,8 @@ resource "aws_glue_job" "job" {
   role_arn          = local.glue_role_arn
   timeout           = var.glue_job_timeout
   connections       = var.jdbc_connections
+  execution_class   = var.execution_class
+
   command {
     python_version  = "3"
     script_location = "s3://${local.scripts_bucket_id}/${local.object_key}"


### PR DESCRIPTION
adds an optional variable execution_class that allows the user to specify STANDARD or FLEX execution. Defaults to STANDARD which is the current behavior. 