### PR TITLE
DPP-514 make G.1X default worker type for Glue jobs

### DIFF
--- a/terraform/modules/aws-glue-job/02-inputs-optional.tf
+++ b/terraform/modules/aws-glue-job/02-inputs-optional.tf
@@ -123,7 +123,7 @@ variable "number_of_workers_for_glue_job" {
 variable "glue_job_worker_type" {
   description = "Specify the worker type to use for the glue job"
   type        = string
-  default     = "Standard"
+  default     = "G.1X"
 
   validation {
     condition     = contains(["Standard", "G.1X", "G.2X"], var.glue_job_worker_type)


### PR DESCRIPTION
Changes the default worker type from standard to G.1X. Defaulting to standard creates issues where modern versions of Glue would be created with worker types that don't support functionality like flexible execution. The Glue 2.0 jobs are able to run on G.1X workers.

from docs:

Standard – When you choose this type, you also provide a value for Maximum capacity. Maximum capacity is the number of AWS Glue data processing units (DPUs) that can be allocated when this job runs. A DPU is a relative measure of processing power that consists of 4 vCPUs of compute capacity and 16 GB of memory. The Standard worker type has a 50 GB disk and 2 executors.

G.1X – When you choose this type, you also provide a value for Number of workers. Each worker maps to 1 DPU (4 vCPU, 16 GB of memory, 64 GB disk), and provides 1 executor per worker. We recommend this worker type for workloads such as data transforms, joins, and queries, to offers a scalable and cost effective way to run most jobs.

https://docs.aws.amazon.com/glue/latest/dg/add-job.html