### PR TITLE
Enable Glue Job Metrics

### DIFF
--- a/terraform/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/aws-glue-job/10-aws-glue-job.tf
@@ -58,6 +58,7 @@ resource "aws_glue_job" "job" {
       "--extra-py-files"                   = "s3://${local.scripts_bucket_id}/${var.helper_module_key},s3://${local.scripts_bucket_id}/${var.pydeequ_zip_key}"
       "--extra-jars"                       = local.extra_jars
       "--enable-continuous-cloudwatch-log" = "true"
+      "--enable-metrics"                   = ""
       "--enable-spark-ui"                  = "true"
       "--spark-event-logs-path"            = local.spark_ui_storage
   })


### PR DESCRIPTION
From the console this is on by default. Setting this argument enables Glue Job Metrics to help identify behaviour in the driver and executors. 