### PR TITLE
set legacy time parser for glue job

### DIFF
--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -88,6 +88,7 @@ module "ingest_academy_revenues_and_benefits_housing_needs_to_landing_zone" {
     "--s3_ingestion_bucket_target"  = "s3://${module.landing_zone.bucket_id}/academy/"
     "--s3_ingestion_details_target" = "s3://${module.landing_zone.bucket_id}/academy/ingestion-details/"
     "--table_filter_expression"     = each.value
+    "--conf"                        = "spark.sql.legacy.timeParserPolicy=LEGACY --conf spark.sql.legacy.parquet.int96RebaseModeInRead=LEGACY --conf spark.sql.legacy.parquet.int96RebaseModeInWrite=LEGACY --conf spark.sql.legacy.parquet.datetimeRebaseModeInRead=LEGACY --conf spark.sql.legacy.parquet.datetimeRebaseModeInWrite=LEGACY"
   }
 }
 


### PR DESCRIPTION
More of the same, I think this is causing some of the tables not to write at all, and possibly partial writes for others.

Addressing this error:

Caused by: org.apache.spark.SparkUpgradeException: You may get a different result due to the upgrading to Spark >= 3.0: 
writing dates before 1582-10-15 or timestamps before 1900-01-01T00:00:00Z
into Parquet INT96 files can be dangerous, as the files may be read by Spark 2.x
or legacy versions of Hive later, which uses a legacy hybrid calendar that
is different from Spark 3.0+'s Proleptic Gregorian calendar. See more
details in SPARK-31404. You can set "spark.sql.parquet.int96RebaseModeInWrite" to "LEGACY" to rebase the
datetime values w.r.t. the calendar difference during writing, to get maximum
interoperability. Or set "spark.sql.parquet.int96RebaseModeInWrite" to "CORRECTED" to write the datetime
values as it is, if you are 100% sure that the written files will only be read by
Spark 3.0+ or other systems that use Proleptic Gregorian calendar.
