### PR TITLE
Add pre-commit-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ dist/
 /scripts/logs/
 /scripts/tests/test_person_matching.py
 /lambdas/vonage_api_ingestion/messbook.py
-.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.14.2
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]


### PR DESCRIPTION
Removes pre-commit-config.yaml from .gitignore so that this can be included in the repo. Adds a pre-commit-config that runs GitGuardian / ggshield checks. 