### PR TITLE
Set Autoscaling Value for RDS Instance

### DIFF
--- a/terraform/modules/sql-to-rds-snapshot/30-rds.tf
+++ b/terraform/modules/sql-to-rds-snapshot/30-rds.tf
@@ -5,18 +5,19 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_instance" "ingestion_db" {
-  allocated_storage       = 15
-  engine                  = "mysql"
-  engine_version          = "8.0"
-  instance_class          = "db.t3.micro"
-  identifier              = var.instance_name
-  db_subnet_group_name    = aws_db_subnet_group.default.name
+  allocated_storage     = 15
+  max_allocated_storage = 30
+  engine                = "mysql"
+  engine_version        = "8.0"
+  instance_class        = "db.t3.micro"
+  identifier            = var.instance_name
+  db_subnet_group_name  = aws_db_subnet_group.default.name
 
-  username                = "dataplatform"
-  password                = random_password.rds_password.result
-  skip_final_snapshot     = true
-  vpc_security_group_ids  = [aws_security_group.snapshot_db.id]
-  apply_immediately       = false
+  username               = "dataplatform"
+  password               = random_password.rds_password.result
+  skip_final_snapshot    = true
+  vpc_security_group_ids = [aws_security_group.snapshot_db.id]
+  apply_immediately      = false
 }
 
 resource "random_password" "rds_password" {

--- a/terraform/modules/sql-to-rds-snapshot/30-rds.tf
+++ b/terraform/modules/sql-to-rds-snapshot/30-rds.tf
@@ -5,14 +5,13 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_instance" "ingestion_db" {
-  allocated_storage     = 15
-  max_allocated_storage = 30
-  engine                = "mysql"
-  engine_version        = "8.0"
-  instance_class        = "db.t3.micro"
-  identifier            = var.instance_name
-  db_subnet_group_name  = aws_db_subnet_group.default.name
-
+  allocated_storage      = 15
+  max_allocated_storage  = 30
+  engine                 = "mysql"
+  engine_version         = "8.0"
+  instance_class         = "db.t3.micro"
+  identifier             = var.instance_name
+  db_subnet_group_name   = aws_db_subnet_group.default.name
   username               = "dataplatform"
   password               = random_password.rds_password.result
   skip_final_snapshot    = true


### PR DESCRIPTION
This sets the maximum size the instance can scale to. 

The Liberator backdated ingestion was failing because there was insufficient storage space, this allows for the instance to expand and complete the task. 