### PR TITLE
Fixes to staff sickness forecasting scripts.

### DIFF
--- a/scripts/jobs/hr_and_od/staff_sickness_forecasting.py
+++ b/scripts/jobs/hr_and_od/staff_sickness_forecasting.py
@@ -66,8 +66,9 @@ def main():
                                                          source_catalog_table_sickness, 'import_date'))
         absence_pdf = absence_df.toPandas()
         absence_pdf = reshape_time_series_data(pdf=absence_pdf,
-                                               date_col='Calculation Date:Absence',
-                                               var_cols=['Days Lost:Absence'])
+                                               date_col='calculation_date:absence',
+                                               var_cols=['days_lost:absence'],
+                                               dateformat='%d/%m/%Y')
 
         # set min and max cutoff dates
         #  TODO a function that trims data to nearest Monday two weeks either end

--- a/terraform/etl/47-aws-glue-job-staff-sickness-forecasting.tf
+++ b/terraform/etl/47-aws-glue-job-staff-sickness-forecasting.tf
@@ -19,7 +19,7 @@ module "staff_sickness_forecast_refined" {
     "--job-bookmark-option"              = "job-bookmark-enable"
     "--enable-glue-datacatalog"          = "true"
     "--enable-continuous-cloudwatch-log" = "true"
-    "--additional-python-modules"        = "prophet"
+    "--additional-python-modules"        = "prophet,statsmodels==0.14.0"
     "--source_catalog_database"          = module.department_hr_and_od_data_source.raw_zone_catalog_database_name
     "--source_catalog_table_sickness"    = "staff_sickness"
     "--output_path"                      = "s3://${module.refined_zone_data_source.bucket_id}/hr-and-od/staff-sickness/"


### PR DESCRIPTION
- Added statsmodels==0.14.0 to additional python module to avoid _collections_ import issue.
- Added required date format parameter to reshape_time_series_data function call.
- Converted column names to lowercase to reflect datacatalog format.