### PR TITLE
Share the latest prod backup ami with pre-prod

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -1,19 +1,31 @@
 locals {
-    backup_ami_id = "ami-0b08cd4ad0a6162e3"
-    ec2_tags = {
-        BackupPolicy  = title(var.environment)
-        Name          = "${var.identifier_prefix}-qlik-sense-restore"
-    }
+  backup_ami_id = "ami-0b08cd4ad0a6162e3"
+  ec2_tags = {
+    BackupPolicy = title(var.environment)
+    Name         = "${var.identifier_prefix}-qlik-sense-restore"
+  }
+
+  backup_ami_id_to_restore = "ami-0462df3547bccd38d"
+  ec2_tags_for_restore = {
+    BackupPolicy = title(var.environment)
+    Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
+  }
+}
+
+resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod" {
+  count      = var.is_production_environment ? 1 : 0
+  image_id   = local.backup_ami_id_to_restore
+  account_id = data.aws_secretsmanager_secret_version.pre_production_account_id[0].secret_string
 }
 
 data "aws_secretsmanager_secret" "pre_production_account_id" {
-  count         = var.is_production_environment ? 1 : 0
-  name          = "manual/pre-production-account-id"
+  count = var.is_production_environment ? 1 : 0
+  name  = "manual/pre-production-account-id"
 }
 
 data "aws_secretsmanager_secret_version" "pre_production_account_id" {
-  count         = var.is_production_environment ? 1 : 0
-  secret_id     = data.aws_secretsmanager_secret.pre_production_account_id[0].id
+  count     = var.is_production_environment ? 1 : 0
+  secret_id = data.aws_secretsmanager_secret.pre_production_account_id[0].id
 }
 
 #value manually managed in secrets manager on pre-prod
@@ -43,11 +55,11 @@ data "aws_secretsmanager_secret_version" "subnet_value_for_qlik_sense_pre_prod_i
 }
 
 resource "aws_instance" "qlik_sense_pre_prod_instance" {
-  count                     = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  ami                       = local.backup_ami_id
-  instance_type             = "c5.4xlarge"
-  subnet_id                 = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
-  vpc_security_group_ids    = [aws_security_group.qlik_sense.id]
+  count                  = !var.is_production_environment && var.is_live_environment ? 1 : 0
+  ami                    = local.backup_ami_id
+  instance_type          = "c5.4xlarge"
+  subnet_id              = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
+  vpc_security_group_ids = [aws_security_group.qlik_sense.id]
 
   private_dns_name_options {
     enable_resource_name_dns_a_record = true
@@ -60,12 +72,12 @@ resource "aws_instance" "qlik_sense_pre_prod_instance" {
   associate_public_ip_address = false
 
   root_block_device {
-    encrypted               = true
-    delete_on_termination   = false
-    kms_key_id              = aws_kms_key.key.arn
-    tags                    = merge(var.tags, local.ec2_tags)
-    volume_size             = 1000
-    volume_type             = "gp3"
+    encrypted             = true
+    delete_on_termination = false
+    kms_key_id            = aws_kms_key.key.arn
+    tags                  = merge(var.tags, local.ec2_tags)
+    volume_size           = 1000
+    volume_type           = "gp3"
   }
 
   lifecycle {


### PR DESCRIPTION
Share the latest prod Qlik backup AMI with pre-prod, so it can be used to restore a new instance.