### PR TITLE
Share key with preprod

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -5,11 +5,11 @@ locals {
     Name         = "${var.identifier_prefix}-qlik-sense-restore"
   }
 
-  backup_ami_id_to_restore = "ami-0462df3547bccd38d"
-  ec2_tags_for_restore = {
-    BackupPolicy = title(var.environment)
-    Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
-  }
+  # backup_ami_id_to_restore = "ami-0462df3547bccd38d"
+  # ec2_tags_for_restore = {
+  #   BackupPolicy = title(var.environment)
+  #   Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
+  # }
 }
 
 resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod" {
@@ -90,38 +90,38 @@ resource "aws_instance" "qlik_sense_pre_prod_instance" {
   }
 }
 
-resource "aws_instance" "qlik_sense_pre_prod_instance_restore_2" {
-  count                  = !var.is_production_environment && var.is_live_environment ? 1 : 0
-  ami                    = local.backup_ami_id_to_restore
-  instance_type          = "c5.4xlarge"
-  subnet_id              = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
-  vpc_security_group_ids = [aws_security_group.qlik_sense.id]
+# resource "aws_instance" "qlik_sense_pre_prod_instance_restore_2" {
+#   count                  = !var.is_production_environment && var.is_live_environment ? 1 : 0
+#   ami                    = local.backup_ami_id_to_restore
+#   instance_type          = "c5.4xlarge"
+#   subnet_id              = data.aws_secretsmanager_secret_version.subnet_value_for_qlik_sense_pre_prod_instance[0].secret_string
+#   vpc_security_group_ids = [aws_security_group.qlik_sense.id]
 
-  private_dns_name_options {
-    enable_resource_name_dns_a_record = true
-  }
+#   private_dns_name_options {
+#     enable_resource_name_dns_a_record = true
+#   }
 
-  iam_instance_profile        = aws_iam_instance_profile.qlik_sense.id
-  disable_api_termination     = true
-  key_name                    = aws_key_pair.qlik_sense_server_key.key_name
-  tags                        = merge(var.tags, local.ec2_tags_for_restore)
-  associate_public_ip_address = false
+#   iam_instance_profile        = aws_iam_instance_profile.qlik_sense.id
+#   disable_api_termination     = true
+#   key_name                    = aws_key_pair.qlik_sense_server_key.key_name
+#   tags                        = merge(var.tags, local.ec2_tags_for_restore)
+#   associate_public_ip_address = false
 
-  root_block_device {
-    encrypted             = true
-    delete_on_termination = false
-    kms_key_id            = aws_kms_key.key.arn
-    tags                  = merge(var.tags, local.ec2_tags_for_restore)
-    volume_size           = 1000
-    volume_type           = "gp3"
-  }
+#   root_block_device {
+#     encrypted             = true
+#     delete_on_termination = false
+#     kms_key_id            = aws_kms_key.key.arn
+#     tags                  = merge(var.tags, local.ec2_tags_for_restore)
+#     volume_size           = 1000
+#     volume_type           = "gp3"
+#   }
 
-  lifecycle {
-    ignore_changes = [ami, subnet_id]
-  }
+#   lifecycle {
+#     ignore_changes = [ami, subnet_id]
+#   }
 
-  metadata_options {
-    http_tokens   = "required"
-    http_endpoint = "enabled"
-  }
-}
+#   metadata_options {
+#     http_tokens   = "required"
+#     http_endpoint = "enabled"
+#   }
+# }

--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -5,11 +5,11 @@ locals {
     Name         = "${var.identifier_prefix}-qlik-sense-restore"
   }
 
-  # backup_ami_id_to_restore = "ami-0462df3547bccd38d"
-  # ec2_tags_for_restore = {
-  #   BackupPolicy = title(var.environment)
-  #   Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
-  # }
+  backup_ami_id_to_restore = "ami-0462df3547bccd38d"
+  ec2_tags_for_restore = {
+    BackupPolicy = title(var.environment)
+    Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
+  }
 }
 
 resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod" {


### PR DESCRIPTION
Share the prod key with pre-prod deployment role, so the AMI using it can be restored on pre-prod.