### PR TITLE
Stg Reworked RDS Snapshot to s3

### DIFF
--- a/lambdas/s3-to-s3-export-copier-python/main.py
+++ b/lambdas/s3-to-s3-export-copier-python/main.py
@@ -1,0 +1,171 @@
+
+import json
+import boto3
+
+AWS_REGION = "eu-west-2"
+
+def s3_copy_folder(s3_client, source_bucket_name: str, source_path: str, target_bucket_name: str, target_path: str, snapshot_time: str, export_task_identifier: dict[str, str], is_backdated: bool):
+    """
+    List objects in source bucket and copy to target bucket.
+    Partitioned by year, month, day, date. Where import is backdated, use snapshot time instead of today's date. 
+
+    Args:
+        s3_client (): A low-level client representing Amazon Simple Storage Service (S3)
+        source_bucket_name (str): name of source bucket
+        source_path (str): prefix for source objects
+        target_bucket_name (str): name of target bucket
+        target_path (str): prefix for target objects
+        snapshot_time (str): time the snapshot was created
+        export_task_identifier (dict): 
+        is_backdated (bool): 
+    """
+
+    print("source_bucket_name", source_bucket_name)
+    print("target_bucket_name", target_bucket_name)
+    print("source_path", source_path)
+    print("target_path", target_path)
+    print("snapshot_time", snapshot_time)
+    print("export_task_identifier", export_task_identifier)
+    print("is_backdated", is_backdated)
+    print()
+
+    # Plan, list through the source, if got continuation token, recursive
+    list_response = None
+
+    while True:
+        list_objects_params = {
+            'Bucket': source_bucket_name,
+            'Prefix': source_path,
+            'ContinuationToken': list_response.get('NextContinuationToken') if list_response else None
+        }
+        print("continuation token", list_response.get('NextContinuationToken') if list_response else None)
+
+        list_response = s3_client.list_objects_v2(**list_objects_params)
+        contents = list_response.get('Contents', [])
+        print("list response contents", contents)
+
+        for file in contents:
+            if not file['Key'].endswith(".parquet"):
+                continue
+
+            snap_shot_name, database_name, table_name = file['Key'].split('/', 2)
+            file_name = file['Key'][len(f"{snap_shot_name}/{database_name}/{table_name}") + 1:]
+            parquet_file_name = get_parquet_file_name(file_name)
+
+            print("fileName:", file_name)
+            print("parquetFileName:", parquet_file_name)
+
+            copy_object_params = {
+                'Bucket': target_bucket_name,
+                'CopySource': f"{source_bucket_name}/{file['Key']}",
+                'Key': f"{target_path}/{database_name}/{table_name}/import_year={year}/import_month={month}/import_day={day}/import_date={date}/{parquet_file_name}",
+                'ACL': 'bucket-owner-full-control',
+            }
+            print("copyObjectParams", copy_object_params)
+
+            try:
+                s3_client.copy_object(**copy_object_params)
+            except Exception as e:
+                print(e)
+
+        if not list_response.get('IsTruncated') or not list_response.get('NextContinuationToken'):
+            break
+
+    
+
+
+
+def get_date_time(snapshot_time: str, export_task_identifier: str, is_backdated: bool) -> tuple[str, str, str, str] | None:
+    """
+    Get date and time from snapshot_time. If backdated, use date from exportTaskIdentifier.
+
+    Args:
+        snapshot_time (str): _description_
+        export_task_identifier (str): _description_
+        is_backdated (bool): _description_
+    """
+    if is_backdated:
+        # example task identifier string: "ExportTaskIdentifier":"sql-to-parquet-22-06-01-backdated"
+        year = f"20{export_task_identifier.split('-')[3]}"
+        month, day = export_task_identifier.split('-')[4:6]
+        date = f"{year}-{month}-{day}"
+        return day, month, year, date
+    else:
+        # example output "SnapshotTime": "2020-03-27T20:48:42.023Z"
+        year, month, day = snapshot_time.split('-')[0:3]
+        date = f"{year}-{month}-{day}"
+        return day, month, year, date
+    
+    
+def get_parquet_file_name(file_name):
+    # Your get_parquet_file_name function logic here...
+
+def start_workflow_run(workflow_name):
+    # Your start_workflow_run function logic here...
+
+def start_backdated_workflow_run(workflow_name, import_date):
+    # Your start_backdated_workflow_run function logic here...
+
+def lambda_handler(event, context):
+    rds_client = boto3.client("rds", region_name=AWS_REGION)
+    s3_client = boto3.client("s3", region_name=AWS_REGION)
+    sqs_client = boto3.client("sqs", region_name=AWS_REGION)
+
+    for record in event['Records']:
+        message = json.loads(record['body'])
+        print("event", record)
+        print("message.ExportTaskIdentifier", message['ExportTaskIdentifier'])
+        
+        describe_export_tasks = rds_client.describe_export_tasks(
+            ExportTaskIdentifier=message['ExportTaskIdentifier']
+        )
+
+        print("describe_export_tasks", describe_export_tasks)
+
+        if not describe_export_tasks or not describe_export_tasks['ExportTasks'] or len(describe_export_tasks['ExportTasks']) == 0:
+            raise Exception('describe_export_tasks or its child ExportTasks is missing')
+
+        export_task_status = describe_export_tasks['ExportTasks'][-1]
+
+        # Don't re-queue if status is canceled
+        if export_task_status['Status'] == 'CANCELED':
+            continue
+
+        # Check to see if the export has finished
+        if export_task_status['Status'] != 'COMPLETE':
+            # If NOT then requeue the event with an extended delay
+            print(record['eventSourceARN'])
+
+            queue_name = record['eventSourceARN'].split(':')[-1]
+
+            get_queue_url_response = sqs_client.get_queue_url(QueueName=queue_name)
+
+            print(get_queue_url_response)
+
+            sqs_client.send_message(
+                QueueUrl=get_queue_url_response['QueueUrl'],
+                MessageBody=record['body'],
+                DelaySeconds=300
+            )
+            continue
+
+        source_bucket_name = message['ExportBucket']
+        target_bucket_name = bucket_destination
+        path_prefix = f"{message['ExportTaskIdentifier']}"
+        snapshot_time = export_task_status['SnapshotTime']
+        is_backdated = False
+
+        # Example: sql-to-parquet-2021-07-01-override - backdated ingestion so use time from snapshot instead of today
+        pattern = r'^sql-to-parquet-\d\d\d\d-\d\d-\d\d-backdated$'
+        if pattern.match(path_prefix):
+            is_backdated = True
+
+        # If it has copy the files from s3 bucket A => s3 bucket B
+        s3_copy_folder(s3_client, source_bucket_name, path_prefix, target_bucket_name, target_service_area, snapshot_time, path_prefix, is_backdated)
+
+        if workflow_name and not is_backdated:
+            start_workflow_run(workflow_name)
+
+        if backdated_workflow_name and is_backdated:
+            day, month, year, date = get_date_time(snapshot_time, path_prefix, is_backdated)
+            start_backdated_workflow_run(backdated_workflow_name, date)

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -27,7 +27,7 @@ module "liberator_dump_to_rds_snapshot" {
 }
 
 module "liberator_db_snapshot_to_s3" {
-  count                          = 1
+  count                          = local.is_production_environment ? 1 : 0
   source                         = "../modules/db-snapshot-to-s3"
   tags                           = module.tags.values
   project                        = var.project

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -75,3 +75,25 @@ data "aws_iam_policy_document" "lambda_assume_role" {
     }
   }
 }
+
+### New modules for liberator ingestion
+
+module "liberator_rds_snapshot_to_s3" {
+  count                          = local.is_production_environment ? 0 : 1
+  source                         = "../modules/rds-snapshot-to-s3"
+  tags                           = module.tags.values
+  identifier_prefix              = local.identifier_prefix
+  project                        = var.project
+  environment                    = var.environment
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+  zone_kms_key_arn               = module.landing_zone.kms_key_arn
+  zone_bucket_arn                = module.landing_zone.bucket_arn
+  zone_bucket_id                 = module.landing_zone.bucket_id
+  service_area                   = "parking"
+  rds_instance_ids               = [for item in module.liberator_dump_to_rds_snapshot : item.rds_instance_id]
+  rds_instance_arns              = [for item in module.liberator_dump_to_rds_snapshot : item.rds_instance_arn]
+  workflow_name                  = aws_glue_workflow.parking_liberator_data.name
+  workflow_arn                   = aws_glue_workflow.parking_liberator_data.arn
+  backdated_workflow_name        = aws_glue_workflow.parking_liberator_backdated_data.name
+  backdated_workflow_arn         = aws_glue_workflow.parking_liberator_backdated_data.arn
+}

--- a/terraform/modules/aws-lambda/30-lambda.tf
+++ b/terraform/modules/aws-lambda/30-lambda.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "lambda" {
   }
   tags = var.tags
 
-  depends_on = [null_resource.run_install_requirements[0], data.archive_file.lambda]
+  depends_on = [null_resource.run_install_requirements[0], data.archive_file.lambda, resource.aws_s3_object.lambda]
 }
 
 data "archive_file" "lambda" {
@@ -53,7 +53,7 @@ resource "null_resource" "run_install_requirements" {
 
 resource "aws_s3_object" "lambda" {
   bucket     = var.lambda_artefact_storage_bucket
-  key        = "${local.lambda_name_underscore}.zip"
+  key        = var.s3_key
   source     = data.archive_file.lambda.output_path
   acl        = "private"
   depends_on = [data.archive_file.lambda]

--- a/terraform/modules/rds-snapshot-to-s3/00-init.tf
+++ b/terraform/modules/rds-snapshot-to-s3/00-init.tf
@@ -1,0 +1,14 @@
+/* This defines the configuration of Terraform and AWS required Terraform Providers.
+   As this is a module, we don't have any explicity Provider blocks declared, as these
+   will be inherited from the parent Terraform.
+*/
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/terraform/modules/rds-snapshot-to-s3/01-inputs-required.tf
+++ b/terraform/modules/rds-snapshot-to-s3/01-inputs-required.tf
@@ -1,0 +1,48 @@
+variable "tags" {
+  description = "AWS tags"
+  type        = map(string)
+}
+
+variable "project" {
+  description = "The project name."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment e.g. Dev, Stg, Prod, Mgmt."
+  type        = string
+}
+
+variable "identifier_prefix" {
+  description = "Project wide resource identifier prefix"
+  type        = string
+}
+
+variable "lambda_artefact_storage_bucket" {
+  type = string
+}
+
+variable "zone_kms_key_arn" {
+  type = string
+}
+
+variable "zone_bucket_arn" {
+  type = string
+}
+
+variable "zone_bucket_id" {
+  type = string
+}
+
+variable "service_area" {
+  description = "Name of service area where data is to be sent, e.g. 'housing'"
+  type        = string
+}
+
+variable "rds_instance_ids" {
+  type = list(string)
+}
+
+variable "rds_instance_arns" {
+  type = list(string)
+}

--- a/terraform/modules/rds-snapshot-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/rds-snapshot-to-s3/02-inputs-optional.tf
@@ -1,0 +1,29 @@
+variable "workflow_name" {
+  description = "Optional. The name of a workflow to run on completion. This workflow will be run after each database has been added to s3"
+  type        = string
+  default     = ""
+}
+
+variable "workflow_arn" {
+  description = "Optional. The arn of a workflow to run on completion. This workflow will be run after each database has been added to s3"
+  type        = string
+  default     = ""
+}
+
+variable "backdated_workflow_name" {
+  description = "Optional. The name of a workflow to run on completion. This workflow will be run after each database has been added to s3 for backdated data ingestion"
+  type        = string
+  default     = ""
+}
+
+variable "backdated_workflow_arn" {
+  description = "Optional. The arn of a workflow to run on completion. This workflow will be run after each database has been added to s3 for backdated data ingestion"
+  type        = string
+  default     = ""
+}
+
+variable "aws_account_suffix" {
+  description = "Optional. Suffix to be used for certain resources such as S3 buckets to avoid conflicts with existing setups. This is primarily for development purposes on sandbox account"
+  type        = string
+  default     = ""
+}

--- a/terraform/modules/rds-snapshot-to-s3/03-input-derived.tf
+++ b/terraform/modules/rds-snapshot-to-s3/03-input-derived.tf
@@ -1,0 +1,5 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  lambda_timeout = 900
+}

--- a/terraform/modules/rds-snapshot-to-s3/99-outputs.tf
+++ b/terraform/modules/rds-snapshot-to-s3/99-outputs.tf
@@ -1,0 +1,4 @@
+output "cloudwatch_event_rule_names" {
+  description = "The names of the CloudWatch Event Rules"
+  value       = [for rule in aws_cloudwatch_event_rule.rds_event_rule : rule.name]
+}

--- a/terraform/modules/rds-snapshot-to-s3/eventbridge.tf
+++ b/terraform/modules/rds-snapshot-to-s3/eventbridge.tf
@@ -1,0 +1,33 @@
+locals {
+  rds_instances = [for i in range(length(var.rds_instance_ids)) : {
+    id  = var.rds_instance_ids[i]
+    arn = var.rds_instance_arns[i]
+  }]
+}
+
+resource "aws_cloudwatch_event_rule" "rds_event_rule" {
+  for_each = { for instance in local.rds_instances : instance.id => instance }
+
+  name        = "rds-event-rule-${each.value.id}"
+  description = "Capture RDS Event 0161 for ${each.value.id}"
+
+  event_pattern = jsonencode({
+    source      = ["aws.rds"],
+    detail-type = ["RDS DB Instance Event"],
+    resources   = [each.value.arn],
+    detail = {
+      EventCategories = ["snapshot"],
+      SourceType      = ["db-instance"],
+      Message         = ["RDS-EVENT-0161"]
+    }
+  })
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "rds_event_target" {
+  for_each = { for instance in local.rds_instances : instance.id => instance }
+
+  rule = aws_cloudwatch_event_rule.rds_event_rule[each.key].name
+  arn  = module.rds-to-s3-copier.lambda_function_arn
+}

--- a/terraform/modules/rds-snapshot-to-s3/iam.tf
+++ b/terraform/modules/rds-snapshot-to-s3/iam.tf
@@ -1,0 +1,19 @@
+data "aws_iam_policy_document" "ecs_execution_role" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_execution_role" {
+  name               = "${var.identifier_prefix}-ecs-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_execution_role.json
+}

--- a/terraform/modules/rds-snapshot-to-s3/lambda.tf
+++ b/terraform/modules/rds-snapshot-to-s3/lambda.tf
@@ -1,0 +1,12 @@
+module "rds-to-s3-copier" {
+  source                         = "../aws-lambda"
+  lambda_name                    = "rds-to-s3-copier"
+  runtime                        = "python3.8"
+  handler                        = "lambda_function.lambda_handler"
+  lambda_artefact_storage_bucket = var.lambda_artefact_storage_bucket
+  lambda_source_dir              = "../../lambdas/s3-to-s3-export-copier-python"
+  lambda_output_path             = "../../lambdas/rds-to-s3-copier.zip"
+  s3_key                         = "rds-to-s3-copier.zip"
+  identifier_prefix              = var.identifier_prefix
+  tags                           = var.tags
+}

--- a/terraform/modules/sql-to-rds-snapshot/99-outputs.tf
+++ b/terraform/modules/sql-to-rds-snapshot/99-outputs.tf
@@ -14,3 +14,7 @@ output "cloudwatch_event_rule_name" {
 output "cloudwatch_event_rule_arn" {
   value = module.sql_to_parquet.event_rule_arns[0]
 }
+
+output "rds_instance_arn" {
+  value = aws_db_instance.ingestion_db.arn
+}


### PR DESCRIPTION
This PR deploys a new module to stg for testing that creates:

- cloudwatch event rule that detects the completion of the liberator RDS snapshot export to s3
- event rule target that invokes a lambda to copy the snapshot export to the raw zone

There are also changes to existing modules:
- output of instance arns from the `sql-to-rds-snapshot` module, these are needed to reference as resources to watch in the new cloudwatch event rule
- update to the `aws-lambda` module so it uses the `s3_key` variable when creating the zipped lambda file resource in s3

This is largely to poc the implementation in stg will invoke the lambda when the ecs task finishes exporting a snapshot from the liberator landing zone bucket. The lambda code in `main.py` is work in progress, I'll raise a separate PR for a more complete version. 

There are also a number of variables in `terraform/modules/rds-snapshot-to-s3/02-inputs-optional.tf` these are for functionality that can be copied over from the existing module `terraform/modules/db-snapshot-to-s3` assuming this implementation works as planned and can replace this module in prod. 