### PR TITLE
deploy liberator_db_snapshot_to_s3 to all envs

### DIFF
--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -27,7 +27,7 @@ module "liberator_dump_to_rds_snapshot" {
 }
 
 module "liberator_db_snapshot_to_s3" {
-  count                          = local.is_production_environment ? 1 : 0
+  count                          = 1
   source                         = "../modules/db-snapshot-to-s3"
   tags                           = module.tags.values
   project                        = var.project


### PR DESCRIPTION
removing this from production also destroys the associated bucket, which would be bad, so adding back to all environments