### PR TITLE
remove ami launch permissions

### DIFF
--- a/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
+++ b/terraform/modules/qlik-sense-server/13-aws-ec2-pre-prod.tf
@@ -12,12 +12,6 @@ locals {
   }
 }
 
-resource "aws_ami_launch_permission" "ami_permissions_for_pre_prod" {
-  count      = var.is_production_environment ? 1 : 0
-  image_id   = local.backup_ami_id_to_restore
-  account_id = data.aws_secretsmanager_secret_version.pre_production_account_id[0].secret_string
-}
-
 data "aws_secretsmanager_secret" "pre_production_account_id" {
   count = var.is_production_environment ? 1 : 0
   name  = "manual/pre-production-account-id"


### PR DESCRIPTION
Removes AMI launch permissions that were needed for stg to access a qlik backup. That ami no longer exists so this is causing the core branch to fail.