### PR TITLE
Mtfh state machine

### DIFF
--- a/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
+++ b/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
@@ -176,10 +176,10 @@ resource "aws_cloudwatch_event_target" "mtfh_export_trigger_event_target" {
   target_id = "mtfh-export-trigger-event-target"
   arn       = module.mtfh-state-machine[0].arn
   role_arn  = aws_iam_role.iam_for_sfn[0].arn
-  input = jsonencode({
-    for table in local.mtfh_tables :
-    table => "table name " + table
-  })
+  input = <<EOF
+  {
+   "table_name": "table"
+  }
 }
 
 resource "aws_iam_role" "iam_for_sfn" {

--- a/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
+++ b/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
@@ -1,6 +1,6 @@
 locals {
   mtfh_tables                    = ["TenureInformation", "Persons", "ContactDetails", "Assets", "Accounts", "EqualityInformation", "HousingRegister", "HousingRepairsOnline", "PatchesAndAreas", "Processes", "Notes"]
-  create_mtfh_sfn_resource_count = !local.is_production_environment ? 1 : 0
+  create_mtfh_sfn_resource_count = 1
 }
 
 data "aws_ssm_parameter" "role_arn_to_access_housing_tables_etl" {
@@ -172,7 +172,7 @@ resource "aws_cloudwatch_event_rule" "mtfh_export_trigger_event" {
   name                = "${local.short_identifier_prefix}mtfh-export-trigger-event"
   description         = "Trigger event for MTFH export"
   schedule_expression = "cron(0 0 * * ? *)"
-  is_enabled          = false
+  is_enabled          = local.is_production_environment ? true : false
   tags                = module.tags.values
 }
 

--- a/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
+++ b/terraform/etl/50-aws-lambda-export-dynamodb-pitr.tf
@@ -58,134 +58,134 @@ module "mtfh-state-maching" {
   tags              = module.tags.values
   definition        = <<EOF
   {
-  "Comment": "A description of my state machine",
-  "StartAt": "Get Table ARN",
-  "States": {
-    "Get Table ARN": {
-      "Type": "Task",
-      "Next": "Pass",
-      "Parameters": {
-        "SecretId": "${aws_secretsmanager_secret.mtfh_export_secret[0].name}"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
-      "ResultPath": "$.secretManagerResponse",
-      "InputPath": "$.tableName"
-    },
-    "Pass": {
-      "Type": "Pass",
-      "Next": "Lambda Invoke",
-      "Parameters": {
-        "table_name.$": "$.tableName",
-        "s3_bucket": "dataplatform-tim-landing-zone",
-        "s3_prefix": "mtfh-exports/",
-        "secrets.$": "States.StringToJson($.secretManagerResponse.SecretString)"
-      }
-    },
-    "Lambda Invoke": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
-      "Parameters": {
-        "FunctionName": "${module.export-mtfh-pitr[0].lambda_function_arn}",
-        "Payload.$": "$"
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 2,
-          "MaxAttempts": 6,
-          "BackoffRate": 2
-        }
-      ],
-      "Next": "Pass (1)",
-      "ResultPath": "$.lambdaResult"
-    },
-    "Pass (1)": {
-      "Type": "Pass",
-      "Next": "Choice",
-      "Parameters": {
-        "lambda_result_payload.$": "States.StringToJson($.lambdaResult.Payload)",
-        "status_code.$": "$.lambdaResult.StatusCode",
-        "secrets.$": "$.secrets"
-      }
-    },
-    "Choice": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.status_code",
-          "NumericEquals": 200,
-          "Next": "Wait After Lambda (30s)"
-        }
-      ],
-      "Default": "Fail (Default)"
-    },
-    "Wait After Lambda (30s)": {
-      "Type": "Wait",
-      "Seconds": 30,
-      "Next": "DescribeExport"
-    },
-    "DescribeExport": {
-      "Type": "Task",
-      "Parameters": {
-        "ExportArn.$": "$.lambda_result_payload.ExportDescription.ExportArn"
-      },
-      "Resource": "arn:aws:states:::aws-sdk:dynamodb:describeExport",
-      "Next": "DescribeExport State",
-      "Credentials": {
-        "RoleArn.$": "$.secrets.role_arn"
-      }
-    },
-    "DescribeExport State": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.ExportDescription.ExportStatus",
-          "StringEquals": "IN_PROGRESS",
-          "Next": "IN_PROGRESS Wait (30s)"
+    "Comment": "A description of my state machine",
+    "StartAt": "Get Table ARN",
+    "States": {
+      "Get Table ARN": {
+        "Type": "Task",
+        "Next": "Pass",
+        "Parameters": {
+          "SecretId": "${aws_secretsmanager_secret.mtfh_export_secret[0].name}"
         },
-        {
-          "Variable": "$.ExportDescription.ExportStatus",
-          "StringEquals": "FAILED",
-          "Next": "Fail (DescribeExport)"
-        },
-        {
-          "Variable": "$.ExportDescription.ExportStatus",
-          "StringEquals": "SUCCEEDED",
-          "Next": "Glue StartJobRun"
-        }
-      ],
-      "Default": "Fail (Default)"
-    },
-    "IN_PROGRESS Wait (30s)": {
-      "Type": "Wait",
-      "Seconds": 30,
-      "Next": "DescribeExport"
-    },
-    "Fail (Default)": {
-      "Type": "Fail"
-    },
-    "Fail (DescribeExport)": {
-      "Type": "Fail"
-    },
-    "Glue StartJobRun": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::glue:startJobRun",
-      "Parameters": {
-        "JobName": "${module.glue-mtfh-landing-to-raw[0].job_name}"
+        "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
+        "ResultPath": "$.secretManagerResponse",
+        "InputPath": "$.tableName"
       },
-      "Next": "Success"
-    },
-    "Success": {
-      "Type": "Succeed"
+      "Pass": {
+        "Type": "Pass",
+        "Next": "Lambda Invoke",
+        "Parameters": {
+          "table_name.$": "$.tableName",
+          "s3_bucket": "dataplatform-tim-landing-zone",
+          "s3_prefix": "mtfh-exports/",
+          "secrets.$": "States.StringToJson($.secretManagerResponse.SecretString)"
+        }
+      },
+      "Lambda Invoke": {
+        "Type": "Task",
+        "Resource": "arn:aws:states:::lambda:invoke",
+        "Parameters": {
+          "FunctionName": "${module.export-mtfh-pitr[0].lambda_function_arn}",
+          "Payload.$": "$"
+        },
+        "Retry": [
+          {
+            "ErrorEquals": [
+              "Lambda.ServiceException",
+              "Lambda.AWSLambdaException",
+              "Lambda.SdkClientException",
+              "Lambda.TooManyRequestsException"
+            ],
+            "IntervalSeconds": 2,
+            "MaxAttempts": 6,
+            "BackoffRate": 2
+          }
+        ],
+        "Next": "Pass (1)",
+        "ResultPath": "$.lambdaResult"
+      },
+      "Pass (1)": {
+        "Type": "Pass",
+        "Next": "Choice",
+        "Parameters": {
+          "lambda_result_payload.$": "States.StringToJson($.lambdaResult.Payload)",
+          "status_code.$": "$.lambdaResult.StatusCode",
+          "secrets.$": "$.secrets"
+        }
+      },
+      "Choice": {
+        "Type": "Choice",
+        "Choices": [
+          {
+            "Variable": "$.status_code",
+            "NumericEquals": 200,
+            "Next": "Wait After Lambda (30s)"
+          }
+        ],
+        "Default": "Fail (Default)"
+      },
+      "Wait After Lambda (30s)": {
+        "Type": "Wait",
+        "Seconds": 30,
+        "Next": "DescribeExport"
+      },
+      "DescribeExport": {
+        "Type": "Task",
+        "Parameters": {
+          "ExportArn.$": "$.lambda_result_payload.ExportDescription.ExportArn"
+        },
+        "Resource": "arn:aws:states:::aws-sdk:dynamodb:describeExport",
+        "Next": "DescribeExport State",
+        "Credentials": {
+          "RoleArn.$": "$.secrets.role_arn"
+        }
+      },
+      "DescribeExport State": {
+        "Type": "Choice",
+        "Choices": [
+          {
+            "Variable": "$.ExportDescription.ExportStatus",
+            "StringEquals": "IN_PROGRESS",
+            "Next": "IN_PROGRESS Wait (30s)"
+          },
+          {
+            "Variable": "$.ExportDescription.ExportStatus",
+            "StringEquals": "FAILED",
+            "Next": "Fail (DescribeExport)"
+          },
+          {
+            "Variable": "$.ExportDescription.ExportStatus",
+            "StringEquals": "SUCCEEDED",
+            "Next": "Glue StartJobRun"
+          }
+        ],
+        "Default": "Fail (Default)"
+      },
+      "IN_PROGRESS Wait (30s)": {
+        "Type": "Wait",
+        "Seconds": 30,
+        "Next": "DescribeExport"
+      },
+      "Fail (Default)": {
+        "Type": "Fail"
+      },
+      "Fail (DescribeExport)": {
+        "Type": "Fail"
+      },
+      "Glue StartJobRun": {
+        "Type": "Task",
+        "Resource": "arn:aws:states:::glue:startJobRun",
+        "Parameters": {
+          "JobName": "${module.glue-mtfh-landing-to-raw[0].job_name}"
+        },
+        "Next": "Success"
+      },
+      "Success": {
+        "Type": "Succeed"
+      }
     }
   }
-}
-EOF
+  EOF
 }
 
 resource "aws_iam_role" "iam_for_sfn" {
@@ -193,19 +193,19 @@ resource "aws_iam_role" "iam_for_sfn" {
   name               = "stepFunctionExecutionIAM"
   tags               = module.tags.values
   assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "states.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "states.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOF
 }
 
 resource "aws_iam_policy" "policy_invoke_lambda" {
@@ -213,21 +213,21 @@ resource "aws_iam_policy" "policy_invoke_lambda" {
   name   = "stepFunctionMTFHLambdaFunctionInvocationPolicy"
   tags   = module.tags.values
   policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "InvokeMTFHLambdaFunction",
-            "Effect": "Allow",
-            "Action": [
-                "lambda:InvokeFunction",
-                "lambda:InvokeAsync"
-            ],
-            "Resource": "${module.export-mtfh-pitr[0].lambda_function_arn}"
-        }
-    ]
-}
-EOF
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "InvokeMTFHLambdaFunction",
+              "Effect": "Allow",
+              "Action": [
+                  "lambda:InvokeFunction",
+                  "lambda:InvokeAsync"
+              ],
+              "Resource": "${module.export-mtfh-pitr[0].lambda_function_arn}"
+          }
+      ]
+  }
+  EOF
 }
 
 resource "aws_iam_policy" "policy_invoke_glue" {
@@ -235,18 +235,18 @@ resource "aws_iam_policy" "policy_invoke_glue" {
   name   = "stepFunctionMTFHGlueJobInvocationPolicy"
   tags   = module.tags.values
   policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "InvokeMTFHGlueJob",
-            "Effect": "Allow",
-            "Action": "glue:StartJobRun",
-            "Resource": "${module.glue-mtfh-landing-to-raw[0].job_arn}"
-        }
-    ]
-}
-EOF
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "InvokeMTFHGlueJob",
+              "Effect": "Allow",
+              "Action": "glue:StartJobRun",
+              "Resource": "${module.glue-mtfh-landing-to-raw[0].job_arn}"
+          }
+      ]
+  }
+  EOF
 }
 
 resource "aws_iam_policy" "retrievemtfhsecrets" {
@@ -254,18 +254,18 @@ resource "aws_iam_policy" "retrievemtfhsecrets" {
   name   = "stepFunctionMTFHSecretsRetrievalPolicy"
   tags   = module.tags.values
   policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "RetrieveMTFHSecrets",
-            "Effect": "Allow",
-            "Action": "secretsmanager:GetSecretValue",
-            "Resource": "${aws_secretsmanager_secret.mtfh_export_secret[0].arn}"
-        }
-    ]
-}
-EOF
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "RetrieveMTFHSecrets",
+              "Effect": "Allow",
+              "Action": "secretsmanager:GetSecretValue",
+              "Resource": "${aws_secretsmanager_secret.mtfh_export_secret[0].arn}"
+          }
+      ]
+  }
+  EOF
 }
 
 resource "aws_iam_policy" "role_can_assume_housing_reporting_role" {
@@ -273,18 +273,18 @@ resource "aws_iam_policy" "role_can_assume_housing_reporting_role" {
   name   = "${local.short_identifier_prefix}role_can_assume_housing_reporting_role"
   tags   = module.tags.values
   policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "roleCanAssumeRole",
-            "Effect": "Allow",
-            "Action": "sts:AssumeRole",
-            "Resource": "${data.aws_ssm_parameter.role_arn_to_access_housing_tables_etl.value}"
-        }
-    ]
-}
-EOF
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "roleCanAssumeRole",
+              "Effect": "Allow",
+              "Action": "sts:AssumeRole",
+              "Resource": "${data.aws_ssm_parameter.role_arn_to_access_housing_tables_etl.value}"
+          }
+      ]
+  }
+  EOF
 }
 
 resource "aws_iam_role_policy_attachment" "iam_for_sfn_attach_policy_invoke_lambda" {

--- a/terraform/modules/aws-step-functions/99-outputs.tf
+++ b/terraform/modules/aws-step-functions/99-outputs.tf
@@ -1,0 +1,4 @@
+output "arn" {
+  description = "value of the step function arn"
+  value       = aws_sfn_state_machine.step_function.arn
+}


### PR DESCRIPTION
Deploy MTFH state machine to all environments. 

Tidied up the permission resources.  

Enables an Eventbridge rule to trigger the state machine in production. 

This takes an array of table names from an Eventbridge event rule, passes them in a map to a lambda that triggers an export from the DynamoDB tables in the housing account which is then picked up by a subsequent Glue job and moved to the Raw zone.
<img width="562" alt="image" src="https://github.com/LBHackney-IT/Data-Platform/assets/61045197/e9cf7dbc-8567-4a6f-8299-0abb61e29464">
