### PR TITLE
llpg rds snapshot to s3

### DIFF
--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -26,29 +26,6 @@ module "liberator_dump_to_rds_snapshot" {
   vpc_id                     = data.aws_vpc.network.id
 }
 
-module "liberator_db_snapshot_to_s3" {
-  count                          = 1
-  source                         = "../modules/db-snapshot-to-s3"
-  tags                           = module.tags.values
-  project                        = var.project
-  environment                    = var.environment
-  identifier_prefix              = "${local.identifier_prefix}-dp"
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  zone_kms_key_arn               = module.landing_zone.kms_key_arn
-  zone_bucket_arn                = module.landing_zone.bucket_arn
-  zone_bucket_id                 = module.landing_zone.bucket_id
-  rds_export_storage_bucket_arn  = module.rds_export_storage.bucket_arn
-  rds_export_storage_bucket_id   = module.rds_export_storage.bucket_id
-  rds_export_storage_kms_key_arn = module.rds_export_storage.kms_key_arn
-  rds_export_storage_kms_key_id  = module.rds_export_storage.kms_key_id
-  service_area                   = "parking"
-  rds_instance_ids               = [for item in module.liberator_dump_to_rds_snapshot : item.rds_instance_id]
-  workflow_name                  = aws_glue_workflow.parking_liberator_data.name
-  workflow_arn                   = aws_glue_workflow.parking_liberator_data.arn
-  backdated_workflow_name        = aws_glue_workflow.parking_liberator_backdated_data.name
-  backdated_workflow_arn         = aws_glue_workflow.parking_liberator_backdated_data.arn
-}
-
 resource "aws_glue_workflow" "parking_liberator_data" {
   # Components for this workflow are managed mainly in etl/38-aws-glue-job-parking.tf by parking officers
   # There are couple of other resources that are part of the ingestion process, but the core ETL configuration is in the file mentioned above
@@ -80,8 +57,6 @@ data "aws_iam_policy_document" "lambda_assume_role" {
   }
 }
 
-### New modules for liberator ingestion
-
 module "liberator_rds_snapshot_to_s3" {
   count                          = 1
   source                         = "../modules/rds-snapshot-to-s3"
@@ -94,7 +69,6 @@ module "liberator_rds_snapshot_to_s3" {
   rds_export_bucket_id           = module.rds_export_storage.bucket_id
   rds_export_storage_kms_key_arn = module.rds_export_storage.kms_key_arn
   rds_export_storage_kms_key_id  = module.rds_export_storage.kms_key_id
-  rds_snapshot_service_arn       = module.liberator_db_snapshot_to_s3[0].rds_snapshot_service_arn
   target_bucket_arn              = module.landing_zone.bucket_arn
   target_bucket_id               = module.landing_zone.bucket_id
   target_bucket_kms_key_arn      = module.landing_zone.kms_key_arn

--- a/terraform/modules/db-snapshot-to-s3/25-rds-to-s3-queue.tf
+++ b/terraform/modules/db-snapshot-to-s3/25-rds-to-s3-queue.tf
@@ -128,7 +128,7 @@ resource "aws_sns_topic_subscription" "subscribe_sqs_to_sns_topic" {
 
 resource "aws_lambda_event_source_mapping" "event_source_mapping" {
   event_source_arn = aws_sqs_queue.rds_snapshot_to_s3.arn
-  enabled          = false
+  enabled          = true
   function_name    = aws_lambda_function.rds_snapshot_to_s3_lambda.arn
   batch_size       = 1
 }

--- a/terraform/modules/rds-snapshot-to-s3/01-inputs-required.tf
+++ b/terraform/modules/rds-snapshot-to-s3/01-inputs-required.tf
@@ -65,7 +65,3 @@ variable "rds_export_storage_kms_key_id" {
 variable "target_bucket_kms_key_id" {
   type = string
 }
-
-variable "rds_snapshot_service_arn" {
-  type = string
-}


### PR DESCRIPTION
Removes the superseded liberator ingestion module. 

Re-enables the event source mapping to trigger addresses API snapshot export.