### PR TITLE
add rds bucket

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -457,3 +457,14 @@ module "deprecated_rds_export_storage" {
   bucket_name       = "RDS Export Storage"
   bucket_identifier = "rds-export-storage"
 }
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_export_storage_encryption" {
+  bucket = module.deprecated_rds_export_storage.bucket_id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -448,7 +448,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "rds_export_storag
 }
 
 module "deprecated_rds_export_storage" {
-  source = "../s3-bucket"
+  source = "../modules/s3-bucket"
 
   tags              = module.tags.values
   project           = var.project

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -446,3 +446,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "rds_export_storag
     bucket_key_enabled = true
   }
 }
+
+module "deprecated_rds_export_storage" {
+  source = "../s3-bucket"
+
+  tags              = module.tags.values
+  project           = var.project
+  environment       = var.environment
+  identifier_prefix = "${local.identifier_prefix}-dp"
+  bucket_name       = "RDS Export Storage"
+  bucket_identifier = "rds-export-storage"
+}


### PR DESCRIPTION
This bucket was originally created by the `liberator_db_snapshot_to_s3` module which was removed in (#1490) causing the deployment to want to remove the bucket.

