### PR TITLE
Remove academy glue jobs

### DIFF
--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -42,57 +42,6 @@ locals {
   academy_ingestion_max_concurrent_runs = local.is_live_environment ? length(local.table_filter_expressions) : 1
 }
 
-resource "aws_glue_trigger" "filter_ingestion_tables" {
-  for_each = local.table_filter_expressions
-  tags     = module.tags.values
-  name     = "${local.short_identifier_prefix}academy_revs_and_bens_ingestion_trigger-${each.key}"
-  type     = "CONDITIONAL"
-  enabled  = local.is_production_environment
-
-  actions {
-    job_name = module.ingest_academy_revenues_and_benefits_housing_needs_to_landing_zone[each.key].job_name
-  }
-
-  predicate {
-    conditions {
-      crawler_name = module.academy_mssql_database_ingestion[0].crawler_name
-      crawl_state  = "SUCCEEDED"
-    }
-  }
-}
-
-module "ingest_academy_revenues_and_benefits_housing_needs_to_landing_zone" {
-  trigger_enabled = false
-  for_each        = local.table_filter_expressions
-  tags            = module.tags.values
-
-  source                    = "../modules/aws-glue-job"
-  is_live_environment       = local.is_live_environment
-  is_production_environment = local.is_production_environment
-
-  job_name                       = "${local.short_identifier_prefix}Academy Revs & Bens Housing Needs Database Ingestion-${each.key}"
-  script_s3_object_key           = aws_s3_object.ingest_database_tables_via_jdbc_connection.key
-  environment                    = var.environment
-  pydeequ_zip_key                = aws_s3_object.pydeequ.key
-  helper_module_key              = aws_s3_object.helpers.key
-  jdbc_connections               = [module.academy_mssql_database_ingestion[0].jdbc_connection_name]
-  glue_role_arn                  = aws_iam_role.glue_role.arn
-  glue_temp_bucket_id            = module.glue_temp_storage.bucket_id
-  glue_scripts_bucket_id         = module.glue_scripts.bucket_id
-  spark_ui_output_storage_id     = module.spark_ui_output_storage.bucket_id
-  glue_job_timeout               = 420
-  glue_version                   = "4.0"
-  glue_job_worker_type           = "G.1X"
-  number_of_workers_for_glue_job = 2
-  job_parameters = {
-    "--source_data_database"        = module.academy_mssql_database_ingestion[0].ingestion_database_name
-    "--s3_ingestion_bucket_target"  = "s3://${module.landing_zone.bucket_id}/academy/"
-    "--s3_ingestion_details_target" = "s3://${module.landing_zone.bucket_id}/academy/ingestion-details/"
-    "--table_filter_expression"     = each.value
-    "--conf"                        = "spark.sql.legacy.timeParserPolicy=LEGACY --conf spark.sql.legacy.parquet.int96RebaseModeInRead=LEGACY --conf spark.sql.legacy.parquet.int96RebaseModeInWrite=LEGACY --conf spark.sql.legacy.parquet.datetimeRebaseModeInRead=LEGACY --conf spark.sql.legacy.parquet.datetimeRebaseModeInWrite=LEGACY"
-  }
-}
-
 resource "aws_glue_crawler" "academy_revenues_and_benefits_housing_needs_landing_zone" {
   tags = module.tags.values
 

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -330,7 +330,7 @@ resource "aws_iam_policy" "academy_step_functions_policy" {
   count  = local.academy_state_machine_count
   name   = "${local.short_identifier_prefix}academy-step-functions-policy"
   tags   = module.tags.values
-  policy = data.aws_iam_policy_document.academy_step_functions_policy.json
+  policy = data.aws_iam_policy_document.academy_step_functions_policy[0].json
 }
 
 resource "aws_iam_policy_attachment" "academy_step_functions_policy_attachment" {


### PR DESCRIPTION
Removes the Academy table ingestion Glue jobs and triggers that are no longer necessary as they have been replaced by a single job from `module "academy_glue_job"`

Also includes resource index key that was previously (#1492)