### PR TITLE
move bucket creation out of liberator module

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -447,24 +447,24 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "rds_export_storag
   }
 }
 
-#module "deprecated_rds_export_storage" {
-#  source = "../modules/s3-bucket"
-#
-#  tags              = module.tags.values
-#  project           = var.project
-#  environment       = var.environment
-#  identifier_prefix = "${local.identifier_prefix}-dp"
-#  bucket_name       = "RDS Export Storage"
-#  bucket_identifier = "rds-export-storage"
-#}
+module "deprecated_rds_export_storage" {
+  source = "../modules/s3-bucket"
 
-#resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_export_storage_encryption" {
-#  bucket = module.deprecated_rds_export_storage.bucket_id
-#
-#  rule {
-#    apply_server_side_encryption_by_default {
-#      sse_algorithm = "aws:kms"
-#    }
-#    bucket_key_enabled = true
-#  }
-#}
+  tags              = module.tags.values
+  project           = var.project
+  environment       = var.environment
+  identifier_prefix = "${local.identifier_prefix}-dp"
+  bucket_name       = "RDS Export Storage"
+  bucket_identifier = "rds-export-storage"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_export_storage_encryption" {
+  bucket = module.deprecated_rds_export_storage.bucket_id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -447,24 +447,24 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "rds_export_storag
   }
 }
 
-module "deprecated_rds_export_storage" {
-  source = "../modules/s3-bucket"
+#module "deprecated_rds_export_storage" {
+#  source = "../modules/s3-bucket"
+#
+#  tags              = module.tags.values
+#  project           = var.project
+#  environment       = var.environment
+#  identifier_prefix = "${local.identifier_prefix}-dp"
+#  bucket_name       = "RDS Export Storage"
+#  bucket_identifier = "rds-export-storage"
+#}
 
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = "${local.identifier_prefix}-dp"
-  bucket_name       = "RDS Export Storage"
-  bucket_identifier = "rds-export-storage"
-}
-
-resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_export_storage_encryption" {
-  bucket = module.deprecated_rds_export_storage.bucket_id
-
-  rule {
-    apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
-    }
-    bucket_key_enabled = true
-  }
-}
+#resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_export_storage_encryption" {
+#  bucket = module.deprecated_rds_export_storage.bucket_id
+#
+#  rule {
+#    apply_server_side_encryption_by_default {
+#      sse_algorithm = "aws:kms"
+#    }
+#    bucket_key_enabled = true
+#  }
+#}

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -105,3 +105,8 @@ module "liberator_rds_snapshot_to_s3" {
   backdated_workflow_name        = aws_glue_workflow.parking_liberator_backdated_data.name
   backdated_workflow_arn         = aws_glue_workflow.parking_liberator_backdated_data.arn
 }
+
+moved {
+  from = module.liberator_db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket_id
+  to   = module.deprecated_rds_export_storage.aws_s3_bucket.bucket_id
+}

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -26,29 +26,6 @@ module "liberator_dump_to_rds_snapshot" {
   vpc_id                     = data.aws_vpc.network.id
 }
 
-module "liberator_db_snapshot_to_s3" {
-  count                          = 1
-  source                         = "../modules/db-snapshot-to-s3"
-  tags                           = module.tags.values
-  project                        = var.project
-  environment                    = var.environment
-  identifier_prefix              = "${local.identifier_prefix}-dp"
-  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
-  zone_kms_key_arn               = module.landing_zone.kms_key_arn
-  zone_bucket_arn                = module.landing_zone.bucket_arn
-  zone_bucket_id                 = module.landing_zone.bucket_id
-  rds_export_storage_bucket_arn  = module.rds_export_storage.bucket_arn
-  rds_export_storage_bucket_id   = module.rds_export_storage.bucket_id
-  rds_export_storage_kms_key_arn = module.rds_export_storage.kms_key_arn
-  rds_export_storage_kms_key_id  = module.rds_export_storage.kms_key_id
-  service_area                   = "parking"
-  rds_instance_ids               = [for item in module.liberator_dump_to_rds_snapshot : item.rds_instance_id]
-  workflow_name                  = aws_glue_workflow.parking_liberator_data.name
-  workflow_arn                   = aws_glue_workflow.parking_liberator_data.arn
-  backdated_workflow_name        = aws_glue_workflow.parking_liberator_backdated_data.name
-  backdated_workflow_arn         = aws_glue_workflow.parking_liberator_backdated_data.arn
-}
-
 resource "aws_glue_workflow" "parking_liberator_data" {
   # Components for this workflow are managed mainly in etl/38-aws-glue-job-parking.tf by parking officers
   # There are couple of other resources that are part of the ingestion process, but the core ETL configuration is in the file mentioned above

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -26,6 +26,29 @@ module "liberator_dump_to_rds_snapshot" {
   vpc_id                     = data.aws_vpc.network.id
 }
 
+module "liberator_db_snapshot_to_s3" {
+  count                          = 1
+  source                         = "../modules/db-snapshot-to-s3"
+  tags                           = module.tags.values
+  project                        = var.project
+  environment                    = var.environment
+  identifier_prefix              = "${local.identifier_prefix}-dp"
+  lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
+  zone_kms_key_arn               = module.landing_zone.kms_key_arn
+  zone_bucket_arn                = module.landing_zone.bucket_arn
+  zone_bucket_id                 = module.landing_zone.bucket_id
+  rds_export_storage_bucket_arn  = module.rds_export_storage.bucket_arn
+  rds_export_storage_bucket_id   = module.rds_export_storage.bucket_id
+  rds_export_storage_kms_key_arn = module.rds_export_storage.kms_key_arn
+  rds_export_storage_kms_key_id  = module.rds_export_storage.kms_key_id
+  service_area                   = "parking"
+  rds_instance_ids               = [for item in module.liberator_dump_to_rds_snapshot : item.rds_instance_id]
+  workflow_name                  = aws_glue_workflow.parking_liberator_data.name
+  workflow_arn                   = aws_glue_workflow.parking_liberator_data.arn
+  backdated_workflow_name        = aws_glue_workflow.parking_liberator_backdated_data.name
+  backdated_workflow_arn         = aws_glue_workflow.parking_liberator_backdated_data.arn
+}
+
 resource "aws_glue_workflow" "parking_liberator_data" {
   # Components for this workflow are managed mainly in etl/38-aws-glue-job-parking.tf by parking officers
   # There are couple of other resources that are part of the ingestion process, but the core ETL configuration is in the file mentioned above

--- a/terraform/modules/db-snapshot-to-s3/10-s3.tf
+++ b/terraform/modules/db-snapshot-to-s3/10-s3.tf
@@ -1,13 +1,1 @@
-module "rds_export_storage" {
-  source = "../s3-bucket"
 
-  tags              = var.tags
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = var.identifier_prefix
-  bucket_name       = "RDS Export Storage"
-  bucket_identifier = "rds-export-storage${var.aws_account_suffix}"
-  role_arns_to_share_access_with = [
-    aws_iam_role.rds_snapshot_to_s3_lambda.arn
-  ]
-}


### PR DESCRIPTION
Allow for the destruction of the other resources created by the liberator_db_snapshot_to_s3 module without destroying / recreating the rds export bucket which is not empty.