### PR TITLE
Move addresses api export bucket

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -468,3 +468,25 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "deprecated_rds_ex
     bucket_key_enabled = true
   }
 }
+
+module "addresses_api_rds_export_storage" {
+  source = "../modules/s3-bucket"
+
+  tags              = module.tags.values
+  project           = var.project
+  environment       = var.environment
+  identifier_prefix = local.identifier_prefix
+  bucket_name       = "RDS Export Storage"
+  bucket_identifier = "rds-export-storage"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "addresses_api_rds_export_storage" {
+  bucket = module.addresses_api_rds_export_storage.bucket_id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}

--- a/terraform/core/29-db-snapshot-to-s3.tf
+++ b/terraform/core/29-db-snapshot-to-s3.tf
@@ -39,3 +39,8 @@ moved {
   from = module.db_snapshot_to_s3.module.rds_export_storage.aws_s3_bucket.bucket
   to   = module.db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket
 }
+
+moved {
+  from = module.db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket
+  to   = module.addresses_api_rds_export_storage.aws_s3_bucket.bucket
+}

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -107,6 +107,6 @@ module "liberator_rds_snapshot_to_s3" {
 }
 
 moved {
-  from = module.liberator_db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket
-  to   = module.deprecated_rds_export_storage.aws_s3_bucket.bucket
+  from = module.liberator_db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket_id
+  to   = module.deprecated_rds_export_storage.aws_s3_bucket.bucket_id
 }

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -107,6 +107,6 @@ module "liberator_rds_snapshot_to_s3" {
 }
 
 moved {
-  from = module.liberator_db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket_id
-  to   = module.deprecated_rds_export_storage.aws_s3_bucket.bucket_id
+  from = module.liberator_db_snapshot_to_s3[0].module.rds_export_storage.aws_s3_bucket.bucket
+  to   = module.deprecated_rds_export_storage.aws_s3_bucket.bucket
 }


### PR DESCRIPTION
Moves bucket resource out of the db_snapshot_to_s3 module and creates it as its own resource. 