### PR TITLE
Grant Lambda  role access to RDS export bucket

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -450,12 +450,13 @@ module "deprecated_rds_export_storage" {
 module "addresses_api_rds_export_storage" {
   source = "../modules/s3-bucket"
 
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "RDS Export Storage"
-  bucket_identifier = "rds-export-storage"
+  tags                           = module.tags.values
+  project                        = var.project
+  environment                    = var.environment
+  identifier_prefix              = local.identifier_prefix
+  bucket_name                    = "RDS Export Storage"
+  bucket_identifier              = "rds-export-storage"
+  role_arns_to_share_access_with = module.db_snapshot_to_s3[0].rds_snapshot_to_s3_lambda_role_arn
 
   providers = {
     aws = aws.aws_api_account
@@ -467,7 +468,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "addresses_api_rds
 
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "aws:kms"
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = module.addresses_api_rds_export_storage.kms_key_arn
     }
     bucket_key_enabled = true
   }

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -456,7 +456,7 @@ module "addresses_api_rds_export_storage" {
   identifier_prefix              = local.identifier_prefix
   bucket_name                    = "RDS Export Storage"
   bucket_identifier              = "rds-export-storage"
-  role_arns_to_share_access_with = module.db_snapshot_to_s3[0].rds_snapshot_to_s3_lambda_role_arn
+  role_arns_to_share_access_with = local.is_production_environment ? [module.db_snapshot_to_s3[0].rds_snapshot_to_s3_lambda_role_arn] : []
 
   providers = {
     aws = aws.aws_api_account

--- a/terraform/modules/db-snapshot-to-s3/99-outputs.tf
+++ b/terraform/modules/db-snapshot-to-s3/99-outputs.tf
@@ -8,3 +8,8 @@ output "rds_snapshot_service_arn" {
   description = "RDS Snapshot Service ARN"
   value       = aws_iam_role.rds_snapshot_export_service.arn
 }
+
+output "rds_snapshot_to_s3_lambda_role_arn" {
+  description = "RDS Snapshot to S3 Lambda Role ARN"
+  value       = aws_iam_role.rds_snapshot_to_s3_lambda.arn
+}


### PR DESCRIPTION
This grants access to a lambda role used to export an RDS snapshot in the API account.