### PR TITLE
add missing comma to Academy step function definition

### DIFF
--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -111,7 +111,7 @@ module "copy_academy_landing_to_raw" {
 
 }
 
-## Academy State Machine
+## Academy State Machine.
 
 locals {
   academy_state_machine_count = local.is_live_environment ? 1 : 0

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -250,7 +250,7 @@ module "academy_state_machine" {
             "Parameters": {
               "JobName": "${module.copy_academy_landing_to_raw[0].job_name}}",
               "Arguments": {
-                "--table_filter_expression.$": "$.landingToRaw.FilterString"
+                "--table_filter_expression.$": "$.landingToRaw.FilterString",
                 "--s3_prefix.$": "$.landingToRaw.S3Prefix"
               }
             },


### PR DESCRIPTION
Comma missing from Step Function definition creating invalid json. 