### PR TITLE
Set Default Glue Parameters

### DIFF
--- a/terraform/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/aws-glue-job/10-aws-glue-job.tf
@@ -58,9 +58,12 @@ resource "aws_glue_job" "job" {
       "--extra-py-files"                   = "s3://${local.scripts_bucket_id}/${var.helper_module_key},s3://${local.scripts_bucket_id}/${var.pydeequ_zip_key}"
       "--extra-jars"                       = local.extra_jars
       "--enable-continuous-cloudwatch-log" = "true"
-      "--enable-metrics"                   = ""
+      "--enable-metrics"                   = "true"
       "--enable-spark-ui"                  = "true"
       "--spark-event-logs-path"            = local.spark_ui_storage
+      "--enable-auto-scaling"              = "true"
+      "--enable-job-insights"              = "true"
+      "--enable-observability-metrics"     = "true"
   })
 }
 


### PR DESCRIPTION
Enables the following by default:

- auto-scaling of glue workers
- job metrics
- job insights
- observability metrics

Although auto-scaling is only available for Glue 3.0+, I've checked the small number of Glue 2.0 jobs will ignore this parameter and run as usual. The other parameters are for job monitoring and available for all versions. 