### PR TITLE
Dpp 584 academy patch

### DIFF
--- a/state-machine-definitions/academy_ingestion.asl.json
+++ b/state-machine-definitions/academy_ingestion.asl.json
@@ -102,8 +102,8 @@
             ],
             "Default": "Copy to Raw Map"
         },
-        "Wait": {
-            "Type": "WaitAfterGetCrawlerChoice",
+        "WaitAfterGetCrawlerChoice": {
+            "Type": "Wait",
             "Seconds": 600,
             "Next": "GetCrawler"
         },

--- a/state-machine-definitions/academy_ingestion.asl.json
+++ b/state-machine-definitions/academy_ingestion.asl.json
@@ -134,7 +134,7 @@
             "ItemSelector": {
                 "FilterString.$": "$$.Map.Item.Value.FilterString",
                 "S3Prefix.$": "$$.Map.Item.Value.S3Prefix",
-                "GlueDatabaseTarget": "$$.Map.Item.Value.GlueDatabaseTarget"
+                "GlueDatabaseTarget.$": "$$.Map.Item.Value.GlueDatabaseTarget"
             },
             "End": true,
             "ResultPath": "$.copyToRawOutput"

--- a/state-machine-definitions/academy_ingestion.asl.json
+++ b/state-machine-definitions/academy_ingestion.asl.json
@@ -62,6 +62,46 @@
             "Next": "Copy to Raw Map",
             "ResultPath": "$.crawlerOutput"
         },
+        "GetCrawler": {
+            "Type": "Task",
+            "Next": "Choice",
+            "Parameters": {
+                "Name": "${AcademyCrawlerName}"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+            "ResultPath": "$.GetCrawlerOutput",
+            "Retry": [
+                {
+                    "ErrorEquals": [
+                        "States.ALL"
+                    ],
+                    "BackoffRate": 2,
+                    "IntervalSeconds": 1,
+                    "MaxAttempts": 8
+                }
+            ]
+        },
+        "Choice": {
+            "Type": "Choice",
+            "Choices": [
+                {
+                    "Variable": "$.GetCrawlerOutput.Crawler.State",
+                    "StringMatches": "RUNNING",
+                    "Next": "Wait"
+                },
+                {
+                    "Variable": "$.GetCrawlerOutput.Crawler.State",
+                    "StringMatches": "STOPPING",
+                    "Next": "Wait"
+                }
+            ],
+            "Default": "Copy to Raw Map"
+        },
+        "Wait": {
+            "Type": "Wait",
+            "Seconds": 600,
+            "Next": "GetCrawler"
+        },
         "Copy to Raw Map": {
             "Type": "Map",
             "ItemProcessor": {

--- a/state-machine-definitions/academy_ingestion.asl.json
+++ b/state-machine-definitions/academy_ingestion.asl.json
@@ -59,12 +59,17 @@
                 "Name": "${AcademyCrawlerName}"
             },
             "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
-            "Next": "Copy to Raw Map",
+            "Next": "WaitAfterStartCrawler",
             "ResultPath": "$.crawlerOutput"
+        },
+        "WaitAfterStartCrawler": {
+            "Type": "Wait",
+            "Seconds": 600,
+            "Next": "GetCrawler"
         },
         "GetCrawler": {
             "Type": "Task",
-            "Next": "Choice",
+            "Next": "GetCrawlerChoice",
             "Parameters": {
                 "Name": "${AcademyCrawlerName}"
             },
@@ -81,24 +86,24 @@
                 }
             ]
         },
-        "Choice": {
+        "GetCrawlerChoice": {
             "Type": "Choice",
             "Choices": [
                 {
                     "Variable": "$.GetCrawlerOutput.Crawler.State",
                     "StringMatches": "RUNNING",
-                    "Next": "Wait"
+                    "Next": "WaitAfterGetCrawlerChoice"
                 },
                 {
                     "Variable": "$.GetCrawlerOutput.Crawler.State",
                     "StringMatches": "STOPPING",
-                    "Next": "Wait"
+                    "Next": "WaitAfterGetCrawlerChoice"
                 }
             ],
             "Default": "Copy to Raw Map"
         },
         "Wait": {
-            "Type": "Wait",
+            "Type": "WaitAfterGetCrawlerChoice",
             "Seconds": 600,
             "Next": "GetCrawler"
         },

--- a/state-machine-definitions/academy_ingestion.asl.json
+++ b/state-machine-definitions/academy_ingestion.asl.json
@@ -77,7 +77,8 @@
                             "JobName": "${AcademyLandingToRawGlueJobName}",
                             "Arguments": {
                                 "--table_filter_expression.$": "$.FilterString",
-                                "--s3_prefix.$": "$.S3Prefix"
+                                "--s3_prefix.$": "$.S3Prefix",
+                                "--glue_database_name_target": "$.GlueDatabaseTarget"
                             }
                         },
                         "End": true
@@ -87,7 +88,8 @@
             "ItemsPath": "$.LandingToRaw",
             "ItemSelector": {
                 "FilterString.$": "$$.Map.Item.Value.FilterString",
-                "S3Prefix.$": "$$.Map.Item.Value.S3Prefix"
+                "S3Prefix.$": "$$.Map.Item.Value.S3Prefix",
+                "GlueDatabaseTarget": "$$.Map.Item.Value.GlueDatabaseTarget"
             },
             "End": true,
             "ResultPath": "$.copyToRawOutput"

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -100,7 +100,7 @@ module "copy_academy_landing_to_raw" {
     "--s3_prefix"                        = ""
     "--table_filter_expression"          = ""
     "--glue_database_name_source"        = aws_glue_catalog_database.landing_zone_academy.name
-    "--glue_database_name_target"        = module.department_revenues.raw_zone_catalog_database_name
+    "--glue_database_name_target"        = ""
     "--enable-glue-datacatalog"          = "true"
     "--enable-continuous-cloudwatch-log" = "true"
     "--enable-auto-scaling"              = "true"
@@ -122,12 +122,14 @@ locals {
     TableFilters = local.academy_table_filters
     LandingToRaw = [
       {
-        S3Prefix     = "revenues/",
-        FilterString = "(^lbhaliverbviews_core_(?!hb).*|^lbhaliverbviews_current_(?!hb).*|^lbhaliverbviews_xdbvw_.*)"
+        S3Prefix           = "revenues/",
+        FilterString       = "(^lbhaliverbviews_core_(?!hb).*|^lbhaliverbviews_current_(?!hb).*|^lbhaliverbviews_xdbvw_.*)",
+        GlueDatabaseTarget = module.department_revenues.raw_zone_catalog_database_name
       },
       {
-        S3Prefix     = "benefits/",
-        FilterString = "(^lbhaliverbviews_core_hb.*|^lbhaliverbviews_current_hb.*)"
+        S3Prefix           = "benefits-housing-needs/",
+        FilterString       = "(^lbhaliverbviews_core_hb.*|^lbhaliverbviews_current_hb.*)",
+        GlueDatabaseTarget = module.department_benefits_and_housing_needs.raw_zone_catalog_database_name
       }
     ]
   }

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -60,19 +60,6 @@ resource "aws_glue_crawler" "academy_revenues_and_benefits_housing_needs_landing
   })
 }
 
-resource "aws_glue_trigger" "academy_revenues_and_benefits_housing_needs_landing_zone_crawler" {
-  tags = module.tags.values
-
-  name     = "${local.short_identifier_prefix}academy-revenues-benefits-housing-needs-database-ingestion-crawler-trigger"
-  type     = "SCHEDULED"
-  schedule = "cron(15 8,12 ? * MON,TUE,WED,THU,FRI *)"
-  enabled  = local.is_production_environment
-
-  actions {
-    crawler_name = aws_glue_crawler.academy_revenues_and_benefits_housing_needs_landing_zone.name
-  }
-}
-
 module "copy_academy_landing_to_raw" {
   count = local.is_live_environment ? 1 : 0
   tags  = module.tags.values


### PR DESCRIPTION
- handling for crawler state to check if crawler is still running / stopping and catch errors
- remove crawler trigger, this is run as part of the orchestrated workflow so doesn't need to be scheduled
- better separation of benefits / revenues datasets