### PR TITLE
Added 82-academy-pre-production-raw-zone-data.tf as a clone of 83-...-test.tf with "test" removed from code

### DIFF
--- a/terraform/core/82-academy-pre-production-raw-zone-data.tf
+++ b/terraform/core/82-academy-pre-production-raw-zone-data.tf
@@ -29,7 +29,7 @@ resource "aws_glue_crawler" "revenue_raw_zone" {
 
         Partitions = {  
             AddOrUpdateBehavior = "InheritFromTable"  
-         }
+        }
     })
 }
 
@@ -62,6 +62,6 @@ resource "aws_glue_crawler" "bens_housing_needs_raw_zone" {
 
         Partitions = {  
             AddOrUpdateBehavior = "InheritFromTable"  
-         }  
+        }  
     })
 }


### PR DESCRIPTION
Reinistating the the crawlers for Academy raw zones in Pre-Production only, to catch the data that is copied over from Production.