### PR TITLE
add export bucket kms arn

### DIFF
--- a/terraform/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
+++ b/terraform/modules/db-snapshot-to-s3/40-s3-to-s3-copier-lambda.tf
@@ -55,6 +55,7 @@ data "aws_iam_policy_document" "s3_to_s3_copier_lambda" {
     resources = [
       var.rds_export_storage_bucket_arn,
       "${var.rds_export_storage_bucket_arn}/*",
+      var.rds_export_storage_kms_key_arn,
       var.zone_kms_key_arn,
       var.zone_bucket_arn,
       "${var.zone_bucket_arn}/*",


### PR DESCRIPTION
s3-to-s3 copier lambda is currently failing in the production api account with an AccessDenied error. This change will allow the lambda role to decrypt the exported RDS snapshot files. 