### PR TITLE
Attempt #2: revenues-raw-zone crawler

### DIFF
--- a/terraform/core/82-academy-pre-production-revenues-raw-zone.tf
+++ b/terraform/core/82-academy-pre-production-revenues-raw-zone.tf
@@ -1,0 +1,26 @@
+#revenues raw zone crawler
+resource "aws_glue_crawler" "revenues_raw_zone" {
+    count = !local.is_production_environment ? 1 : 0
+    tags = module.tags.values
+
+    database_name = module.department_revenues.raw_zone_catalog_database_name
+    name = "${local.short_identifier_prefix}revenues-raw-zone"
+    role = aws_iam_role.glue_role.arn
+
+    s3_target {
+        path = "s3://${module.raw_zone.bucket_id}/revenues/"
+    }
+
+    configuration = jsonencode({
+        Version = 1.0
+        Grouping = {
+            TableLevelConfiguration = 3
+            TableGroupingPolicy = "CombineCompatibleSchemas"   
+        }
+        CrawlerOutput = {
+            Partitions = {  
+                AddOrUpdateBehavior = "InheritFromTable"  
+            }
+        }
+    })
+}


### PR DESCRIPTION
Attempt #2 after the previous failed PR on branch DPP-593

Note: This is only revenues. 

If this succeeds i will submit a further PR to officially create the bens-housing-needs-raw-zone crawler that was similarly never created in code.
There is no practical reason to put them both the same Terraform .tf file.