### PR TITLE
Attempt #2 of: bens-housing-needs-raw-zone crawler

### DIFF
--- a/terraform/core/82-academy-pre-production-bens-housing-needs-raw-zone.tf
+++ b/terraform/core/82-academy-pre-production-bens-housing-needs-raw-zone.tf
@@ -1,0 +1,26 @@
+#benefits-housing-needs raw zone crawler
+resource "aws_glue_crawler" "bens_housing_needs_raw_zone" {
+    count = !local.is_production_environment ? 1 : 0
+    tags = module.tags.values
+
+    database_name = module.department_benefits_and_housing_needs.raw_zone_catalog_database_name
+    name = "${local.short_identifier_prefix}bens-housing-needs-raw-zone"
+    role = aws_iam_role.glue_role.arn
+
+    s3_target {
+        path = "s3://${module.raw_zone.bucket_id}/benefits-housing-needs/"
+    }
+
+    configuration = jsonencode({
+        Version = 1.0
+        Grouping = {
+            TableLevelConfiguration = 3
+            TableGroupingPolicy = "CombineCompatibleSchemas"   
+        }
+        CrawlerOutput = {
+            Partitions = {  
+                AddOrUpdateBehavior = "InheritFromTable"  
+            }
+        }
+    })
+}


### PR DESCRIPTION
#2 of 2: the crawler for the  /benefits-housing-needs/ raw zone
replacing the previous crawler "bens-housing-needs-raw-zone" 
(which was deleted via the console after it was backed up via cloning) 
with a crawler with the exact same name via Terraform deployment.