### PR TITLE
add venv to docker container

### DIFF
--- a/docker/sql-to-parquet/Dockerfile
+++ b/docker/sql-to-parquet/Dockerfile
@@ -9,8 +9,12 @@ RUN apk add --update --no-cache \
 # Install AWS CLI
 RUN apk add --no-cache \
         python3 \
-        py3-pip \
-    && pip3 install --upgrade pip \
+        py3-pip
+        
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+RUN pip3 install --upgrade pip \
     && pip3 install awscli boto3 \
     && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Attempting to address the failing Build and Deploy SQL to Parquet Image to ECR action failure:

` > [3/6] RUN apk add --no-cache         python3         py3-pip     && pip3 install --upgrade pip     && pip3 install awscli boto3     && rm -rf /var/cache/apk/*:
1.954     deactivate
1.954     
1.954     The virtual environment is not deleted, and can be re-entered by re-sourcing
1.954     the activate file.
1.954     
1.954     To automatically manage virtual environments, consider using pipx (from the
1.954     pipx package).
1.954 
1.954 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
1.954 hint: See PEP 668 for the detailed specification.`