### PR TITLE
add read policies for departments to access redshift

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -720,3 +720,27 @@ data "aws_iam_policy_document" "glue_access_to_watermarks_table" {
   }
 
 }
+
+//Redshfift
+
+data "aws_iam_policy_document" "redshift_department_read_access" {
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "redshift:DescribeClusters",
+      "redshift:DescribeClusterSnapshots",
+      "redshift:DescribeEvents",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sqlworkbench:GetUserInfo",
+      "sqlworkbench:GetAccountInfo"
+    ]
+    resources = ["*"]
+  }
+}

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -8,7 +8,8 @@ data "aws_iam_policy_document" "sso_staging_user_policy" {
     ] : [
     data.aws_iam_policy_document.s3_department_access.json,
     data.aws_iam_policy_document.glue_access.json,
-    data.aws_iam_policy_document.secrets_manager_read_only.json
+    data.aws_iam_policy_document.secrets_manager_read_only.json,
+    data.aws_iam_policy_document.redshift_department_read_access.json
   ]
 }
 

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -4,6 +4,7 @@ data "aws_iam_policy_document" "sso_staging_user_policy" {
     data.aws_iam_policy_document.s3_department_access.json,
     data.aws_iam_policy_document.glue_access.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
+    data.aws_iam_policy_document.redshift_department_read_access.json,
     data.aws_iam_policy_document.notebook_access[0].json
     ] : [
     data.aws_iam_policy_document.s3_department_access.json,


### PR DESCRIPTION
Adds read access policies to the department sso groups to allow users to see the clusters in the console and access the query editor. 

This doesn't grant any access to data from the cluster without a valid db user login. Only changes staging for testing.