### PR TITLE
update number of splits calculation

### DIFF
--- a/scripts/jobs/ingest_tables_from_dynamo_db.py
+++ b/scripts/jobs/ingest_tables_from_dynamo_db.py
@@ -20,18 +20,22 @@ s3_target = get_glue_env_var("s3_target")
 table_names = get_glue_env_var("table_names").split(",")
 role_arn = get_glue_env_var("role_arn")
 number_of_workers = int(get_glue_env_var("number_of_workers"))
+worker_type = get_glue_env_var("worker_type")
 
 # this is the number of partitions to use whilst reading, default 1, max 1000000
-# Recommened calculation for splits, if using standard workers is: splits =  (8 * numWorkers - 12)
-# Recommened calculation for splits, if using standard G.1X is: splits =  8 * (numWorkers - 1)
-number_of_splits = 8 * number_of_workers - 12
-
+# Recommened calculation for splits, if using G.1X is: splits =  4 * (numWorkers - 1)
+# Recommened calculation for splits, if using G.2X workers is: splits = 8 * (numWorkers - 1)
+# ref: https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect-dynamodb-home.html
+if worker_type == "G.2X":
+    number_of_splits = 8 * (number_of_workers - 1)
+else:
+    number_of_splits = 4 * (number_of_workers - 1)
 
 for table_name in table_names:
     logger.info(f"Starting import for table {table_name}")
     read_dynamo_db_options = {
         "dynamodb.input.tableName": table_name,
-        "dynamodb.splits": f"{number_of_splits}" , 
+        "dynamodb.splits": f"{number_of_splits}", 
         "dynamodb.sts.roleArn": role_arn,
     }
 

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -31,7 +31,7 @@ module "ingest_mtfh_rentsense_tables" {
     "--number_of_workers"   = local.number_of_workers_for_mtfh_ingestion
     "--worker_type"         = local.worker_type
     "--enable-job-insights" = "true"
-    "--enable-auto-scaling" = "true"
+    "--enable-auto-scaling" = "false"
   }
 
   crawler_details = {

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -1,5 +1,6 @@
 locals {
   number_of_workers_for_mtfh_rentsense_ingestion = 16
+  worker_type                                    = "G.1X"
 }
 
 module "ingest_mtfh_rentsense_tables" {
@@ -16,7 +17,7 @@ module "ingest_mtfh_rentsense_tables" {
   helper_module_key              = aws_s3_object.helpers.key
   glue_version                   = "4.0"
   glue_job_timeout               = "300"
-  glue_job_worker_type           = "G.1X"
+  glue_job_worker_type           = local.worker_type
   pydeequ_zip_key                = aws_s3_object.pydeequ.key
   number_of_workers_for_glue_job = local.number_of_workers_for_mtfh_rentsense_ingestion
   glue_scripts_bucket_id         = module.glue_scripts.bucket_id
@@ -28,6 +29,7 @@ module "ingest_mtfh_rentsense_tables" {
     "--role_arn"            = data.aws_ssm_parameter.role_arn_to_access_housing_tables.value
     "--s3_target"           = "s3://${module.landing_zone.bucket_id}/mtfh/"
     "--number_of_workers"   = local.number_of_workers_for_mtfh_ingestion
+    "--worker_type"         = local.worker_type
     "--enable-job-insights" = "true"
     "--enable-auto-scaling" = "true"
   }


### PR DESCRIPTION
Amending calculation for the number of splits to be used when reading from DynamoDB. 

This is now done dynamically based on the number and type of executors assigned to the Glue job.