### PR TITLE
remove the typo "and"

### DIFF
--- a/scripts/jobs/parking/parking_cycle_hangar_met_fail_monthly_format.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_met_fail_monthly_format.py
@@ -89,7 +89,7 @@ SELECT
     time_taken, hangar_or_corral,
     /* Add the collection of signoff month & year */
     CASE
-        When sign_off_year != '1899' AND AND sign_off_month != '' Then sign_off_month
+        When sign_off_year != '1899' AND sign_off_month != '' Then sign_off_month
         ELSE CASE
                 When repair_date like '%/%'Then substr(repair_date, 4, 2)
                 ELSE substr(cast(repair_date as string),6, 2)


### PR DESCRIPTION
Glue failure detected for job: parking_cycle_hangar_met_fail_monthly_format.

This Glue Job fails; since there has been no recent change to the Python script, I suspect there might be a minor issue with the SQL. There is a typo in "and".

I attempted to run this SQL in Athena but am not entirely sure how Mike checked it before merging it into the Main branch.