### PR TITLE
Dpp 533 testing export connector for mtfh dynamodb tables

### DIFF
--- a/scripts/jobs/ingest_tables_from_dynamo_db.py
+++ b/scripts/jobs/ingest_tables_from_dynamo_db.py
@@ -44,8 +44,8 @@ for table_name in table_names:
 
     data_frame = source_dynamic_frame.toDF()
 
-    # Drop all rows where all values are null NOTE: must be done before
-    # add_import_time_columns
+    # Drop all rows where all values are null
+    # NOTE: must be done before add_import_time_columns
     data_frame = data_frame.na.drop("all")
     data_frame_with_import_columns = add_import_time_columns(data_frame)
 

--- a/scripts/jobs/ingest_tables_from_dynamo_db.py
+++ b/scripts/jobs/ingest_tables_from_dynamo_db.py
@@ -24,8 +24,6 @@ logger = glue_context.get_logger()
 s3_target = get_glue_env_var("s3_target")
 table_names = get_glue_env_var("table_names").split(",")
 role_arn = get_glue_env_var("role_arn")
-number_of_workers = int(get_glue_env_var("number_of_workers"))
-worker_type = get_glue_env_var("worker_type")
 
 for table_name in table_names:
     logger.info(f"Starting import for table {table_name}")

--- a/scripts/jobs/ingest_tables_from_dynamo_db.py
+++ b/scripts/jobs/ingest_tables_from_dynamo_db.py
@@ -1,19 +1,24 @@
 import sys
+
+from awsglue.context import GlueContext
+from awsglue.dynamicframe import DynamicFrame
+from awsglue.job import Job
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from awsglue.context import GlueContext
-from awsglue.job import Job
-from awsglue.dynamicframe import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var, add_import_time_columns, PARTITION_KEYS
+from scripts.helpers.helpers import (
+    PARTITION_KEYS,
+    add_import_time_columns,
+    get_glue_env_var,
+)
 
-args = getResolvedOptions(sys.argv, ['JOB_NAME'])
+args = getResolvedOptions(sys.argv, ["JOB_NAME"])
 
 sc = SparkContext()
 glue_context = GlueContext(sc)
 job = Job(glue_context)
-job.init(args['JOB_NAME'], args)
+job.init(args["JOB_NAME"], args)
 logger = glue_context.get_logger()
 
 s3_target = get_glue_env_var("s3_target")
@@ -22,42 +27,39 @@ role_arn = get_glue_env_var("role_arn")
 number_of_workers = int(get_glue_env_var("number_of_workers"))
 worker_type = get_glue_env_var("worker_type")
 
-# this is the number of partitions to use whilst reading, default 1, max 1000000
-# Recommened calculation for splits, if using G.1X is: splits =  4 * (numWorkers - 1)
-# Recommened calculation for splits, if using G.2X workers is: splits = 8 * (numWorkers - 1)
-# ref: https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-connect-dynamodb-home.html
-if worker_type == "G.2X":
-    number_of_splits = 8 * (number_of_workers - 1)
-else:
-    number_of_splits = 4 * (number_of_workers - 1)
-
 for table_name in table_names:
     logger.info(f"Starting import for table {table_name}")
     read_dynamo_db_options = {
         "dynamodb.input.tableName": table_name,
-        "dynamodb.splits": f"{number_of_splits}", 
+        "dynamodb.splits": f"{number_of_splits}",
         "dynamodb.sts.roleArn": role_arn,
     }
 
     source_dynamic_frame = glue_context.create_dynamic_frame.from_options(
         connection_type="dynamodb",
         connection_options=read_dynamo_db_options,
-        tranformation_ctx=f"{table_name}_source_data"
+        tranformation_ctx=f"{table_name}_source_data",
     )
 
     data_frame = source_dynamic_frame.toDF()
-    data_frame = data_frame.na.drop('all') # Drop all rows where all values are null NOTE: must be done before add_import_time_columns
+    data_frame = data_frame.na.drop(
+        "all"
+    )  # Drop all rows where all values are null NOTE: must be done before add_import_time_columns
     data_frame_with_import_columns = add_import_time_columns(data_frame)
 
-    dynamic_frame_to_write = DynamicFrame.fromDF(data_frame_with_import_columns, glue_context, f"{table_name}_output_data")
+    dynamic_frame_to_write = DynamicFrame.fromDF(
+        data_frame_with_import_columns, glue_context, f"{table_name}_output_data"
+    )
 
     glue_context.write_dynamic_frame.from_options(
         frame=dynamic_frame_to_write,
         connection_type="s3",
         format="parquet",
-        connection_options={ "path": f"{s3_target}/{table_name}", "partitionKeys": PARTITION_KEYS },
-        transformation_ctx=f"{table_name}_output_data"
+        connection_options={
+            "path": f"{s3_target}/{table_name}",
+            "partitionKeys": PARTITION_KEYS,
+        },
+        transformation_ctx=f"{table_name}_output_data",
     )
 
 job.commit()
-

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -29,7 +29,7 @@ module "ingest_mtfh_rentsense_tables" {
     "--role_arn"            = data.aws_ssm_parameter.role_arn_to_access_housing_tables.value
     "--s3_target"           = "s3://${module.landing_zone.bucket_id}/mtfh/"
     "--enable-job-insights" = "true"
-    "--enable-auto-scaling" = "false"
+    "--enable-auto-scaling" = "true"
   }
 
   crawler_details = {

--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -28,8 +28,6 @@ module "ingest_mtfh_rentsense_tables" {
     "--table_names"         = "TenureInformation,Persons,ContactDetails,Assets,Accounts,EqualityInformation,HousingRegister,HousingRepairsOnline,PatchesAndAreas,Processes,Notes", # This is a comma delimited list of Dynamo DB table names to be imported
     "--role_arn"            = data.aws_ssm_parameter.role_arn_to_access_housing_tables.value
     "--s3_target"           = "s3://${module.landing_zone.bucket_id}/mtfh/"
-    "--number_of_workers"   = local.number_of_workers_for_mtfh_ingestion
-    "--worker_type"         = local.worker_type
     "--enable-job-insights" = "true"
     "--enable-auto-scaling" = "false"
   }


### PR DESCRIPTION
Changes the dynamodb connection options to use the export connector rather than the ETL connector that was previously used. 

This method does not require the splits option so parameters and calculation associated with this have been removed. 

Auto-scaling of workers has been re-enabled to allow for inactive workers to be removed while the export action takes place. 