### PR TITLE
add layers variable

### DIFF
--- a/terraform/modules/aws-lambda/02-inputs-optional.tf
+++ b/terraform/modules/aws-lambda/02-inputs-optional.tf
@@ -86,3 +86,9 @@ variable "lambda_role_arn" {
   description = "ARN of the IAM Role to use for the Lambda Function"
   default     = null
 }
+
+variable "layers" {
+  type        = list(string)
+  description = "List of ARNs for Lambda Layers to attach to the Lambda Function"
+  default     = []
+}

--- a/terraform/modules/aws-lambda/30-lambda.tf
+++ b/terraform/modules/aws-lambda/30-lambda.tf
@@ -14,6 +14,7 @@ resource "aws_lambda_function" "lambda" {
   s3_key           = var.s3_key
   timeout          = var.lambda_timeout
   memory_size      = var.lambda_memory_size
+  layers           = var.layers
 
   dynamic "environment" {
     for_each = local.environment_map


### PR DESCRIPTION
Allows the attachment of layers to deployed AWS Lambda functions using a _layers_ variable which takes a list of arns. 