### PR TITLE
skip awsbackup snapshots

### DIFF
--- a/docker/sql-to-parquet/delete_db_snapshots_in_db.py
+++ b/docker/sql-to-parquet/delete_db_snapshots_in_db.py
@@ -12,7 +12,12 @@ print("Found ", len(snapshots), " snapshots")
 
 for snapshot in snapshots:
   snapshot_id = snapshot['DBSnapshotIdentifier']
-  print("Deleting snapshot ", snapshot_id)
-  rds.delete_db_snapshot(
-    DBSnapshotIdentifier=snapshot_id
-  )
+
+  if snapshot_id.startswith('awsbackup'):
+    print("Skipping snapshot ", snapshot_id)
+    continue
+  else:
+    print("Deleting snapshot ", snapshot_id)
+    rds.delete_db_snapshot(
+      DBSnapshotIdentifier=snapshot_id
+    )

--- a/docker/sql-to-parquet/delete_db_snapshots_in_db.py
+++ b/docker/sql-to-parquet/delete_db_snapshots_in_db.py
@@ -15,7 +15,6 @@ for snapshot in snapshots:
 
   if snapshot_id.startswith('awsbackup'):
     print("Skipping snapshot ", snapshot_id)
-    continue
   else:
     print("Deleting snapshot ", snapshot_id)
     rds.delete_db_snapshot(


### PR DESCRIPTION
Automatic backups were enabled on the RDS database and these cannot be deleted which causes the script to fail.

Added a condition to skip these backups and delete the created snapshots as before. 