### PR TITLE
remove liberator ingestion resources from dev

### DIFF
--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -10,7 +10,7 @@ module "liberator_data_storage" {
 }
 
 module "liberator_dump_to_rds_snapshot" {
-  count                      = 1
+  count                      = local.is_live_environment ? 1 : 0
   source                     = "../modules/sql-to-rds-snapshot"
   tags                       = module.tags.values
   project                    = var.project
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 module "liberator_rds_snapshot_to_s3" {
-  count                          = 1
+  count                          = local.is_live_environment ? 1 : 0
   source                         = "../modules/rds-snapshot-to-s3"
   tags                           = module.tags.values
   identifier_prefix              = local.identifier_prefix


### PR DESCRIPTION
Removing resources associated with the Liberator ingestion from the dev environment. 

These were causing issues when trying to deploy new instances of these resources with following error:

 ```
Error: Invalid for_each argument
│
│   on ..\modules\rds-snapshot-to-s3\eventbridge.tf line 13, in resource "aws_cloudwatch_event_rule" "rds_snapshot_created_event_rule":
│   13:   for_each = { for instance in local.rds_instances : http://instance.id  => instance }
│     ├────────────────
│     │ local.rds_instances is tuple with 1 element
│
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of     
│ keys that will identify the instances of this resource.
│
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map
│ values.
│
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to
│ fully converge.
```