### PR TITLE
Dpp 660 extend lambda timeout

### DIFF
--- a/terraform/core/28-glue-gchat-failure-notification.tf
+++ b/terraform/core/28-glue-gchat-failure-notification.tf
@@ -24,6 +24,7 @@ module "glue-failure-alert-notifications" {
   lambda_name                    = "glue-failure-gchat-notifications"
   lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
   cloudwatch_event_pattern       = jsonencode(local.glue_failure_cloudwatch_event_pattern)
+  timeout                        = 10
 
   secret_name             = "${local.short_identifier_prefix}glue-failure-gchat-webhook-url"
   secrets_manager_kms_key = aws_kms_key.secrets_manager_key

--- a/terraform/modules/glue-failure-alert-notifications/02-inputs-optional.tf
+++ b/terraform/modules/glue-failure-alert-notifications/02-inputs-optional.tf
@@ -2,3 +2,9 @@ variable "lambda_environment_variables" {
   description = "An object containing environment variables to be used in the Lambda"
   type        = map(string)
 }
+
+variable "timeout" {
+  description = "The amount of time your Lambda Function has to run in seconds"
+  type        = number
+  default     = 3
+}

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -94,6 +94,7 @@ resource "aws_lambda_function" "lambda" {
   s3_bucket         = var.lambda_artefact_storage_bucket
   s3_key            = "${local.lambda_name_underscore}.zip"
   s3_object_version = aws_s3_object.lambda.version_id
+  timeout           = var.timeout
   environment {
     variables = var.lambda_environment_variables
   }


### PR DESCRIPTION
Extends the timeout for the Glue failure alerts lambda from 3s to 10s.

Additionally adds the ability to set the timeout in the terraform module.

This is to address a bug where the lambda would successfully send a message but timeout before completing then retry resulting in duplicate messages. The runtime is generally around 2.5s so setting this to 10s should provide ample time to complete.