### PR TITLE
DPP-662 add pushdown predicates

### DIFF
--- a/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
+++ b/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ AmazonS3_node1625732038443 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cedar_payments",
     transformation_ctx="AmazonS3_node1625732038443",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1631887639199 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1631887639199",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
+++ b/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
@@ -29,7 +29,7 @@ AmazonS3_node1625732038443 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cedar_payments",
     transformation_ctx="AmazonS3_node1625732038443",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1631887639199 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1631887639199",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
+++ b/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ AmazonS3_node1628173244776 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1628173244776",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1638273151502 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_summary",
     transformation_ctx="AmazonS3_node1638273151502",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
+++ b/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
@@ -29,7 +29,7 @@ AmazonS3_node1628173244776 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1628173244776",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1638273151502 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_summary",
     transformation_ctx="AmazonS3_node1638273151502",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation.py
@@ -12,6 +12,7 @@ from scripts.helpers.helpers import (
     create_pushdown_predicate_for_max_date_partition_value,
     get_glue_env_var,
     get_latest_partitions,
+    create_pushdown_predicate,
 )
 
 
@@ -36,6 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -57,6 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -64,6 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -71,6 +77,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation.py
@@ -37,7 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -61,7 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -69,7 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -77,7 +77,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation_update.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation_update.py
@@ -37,7 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -61,7 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -69,7 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -77,7 +77,7 @@ AmazonS3_node1701953849263 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation_update",
     transformation_ctx="AmazonS3_node1701953849263",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -85,7 +85,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation_update.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation_update.py
@@ -12,6 +12,7 @@ from scripts.helpers.helpers import (
     create_pushdown_predicate_for_max_date_partition_value,
     get_glue_env_var,
     get_latest_partitions,
+    create_pushdown_predicate,
 )
 
 
@@ -36,6 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -57,6 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -64,6 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -71,6 +77,7 @@ AmazonS3_node1701953849263 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation_update",
     transformation_ctx="AmazonS3_node1701953849263",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -78,6 +85,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation_wait.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation_wait.py
@@ -12,6 +12,7 @@ from scripts.helpers.helpers import (
     create_pushdown_predicate_for_max_date_partition_value,
     get_glue_env_var,
     get_latest_partitions,
+    create_pushdown_predicate,
 )
 
 
@@ -36,6 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -57,6 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -64,6 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -71,6 +77,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangar_allocation_wait.py
+++ b/scripts/jobs/parking/parking_cycle_hangar_allocation_wait.py
@@ -37,7 +37,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="parking_parking_ops_cycle_hangar_list",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1697705005761 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1697705005761",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1697704537304 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cycle_hangars_denormalisation",
     transformation_ctx="AmazonS3_node1697704537304",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -61,7 +61,7 @@ AmazonS3_node1697705499200 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_allocations",
     transformation_ctx="AmazonS3_node1697705499200",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -69,7 +69,7 @@ AmazonS3_node1697704672904 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_hangar_waiting_list",
     transformation_ctx="AmazonS3_node1697704672904",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -77,7 +77,7 @@ AmazonS3_node1697704891824 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_licence_party",
     transformation_ctx="AmazonS3_node1697704891824",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_cycle_hangars_denormalisation_update.py
+++ b/scripts/jobs/parking/parking_cycle_hangars_denormalisation_update.py
@@ -5,7 +5,13 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate_for_max_date_partition_value,
+    create_pushdown_predicate,
+)
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -29,6 +35,7 @@ liberator_license_party_node1628255463015 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_licence_party",
         transformation_ctx="liberator_license_party_node1628255463015",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -38,6 +45,7 @@ liberator_hangar_details_node1628254576316 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_details",
         transformation_ctx="liberator_hangar_details_node1628254576316",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -47,6 +55,7 @@ liberator_hangar_types_node1628254679074 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_types",
         transformation_ctx="liberator_hangar_types_node1628254679074",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -56,6 +65,7 @@ liberator_hangar_allocations_node1628254680802 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_allocations",
         transformation_ctx="liberator_hangar_allocations_node1628254680802",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 

--- a/scripts/jobs/parking/parking_cycle_hangars_denormalisation_update.py
+++ b/scripts/jobs/parking/parking_cycle_hangars_denormalisation_update.py
@@ -35,7 +35,7 @@ liberator_license_party_node1628255463015 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_licence_party",
         transformation_ctx="liberator_license_party_node1628255463015",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -45,7 +45,7 @@ liberator_hangar_details_node1628254576316 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_details",
         transformation_ctx="liberator_hangar_details_node1628254576316",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -55,7 +55,7 @@ liberator_hangar_types_node1628254679074 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_types",
         transformation_ctx="liberator_hangar_types_node1628254679074",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -65,7 +65,7 @@ liberator_hangar_allocations_node1628254680802 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_hangar_allocations",
         transformation_ctx="liberator_hangar_allocations_node1628254680802",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 

--- a/scripts/jobs/parking/parking_dc_liberator_latest_permit_status.py
+++ b/scripts/jobs/parking/parking_dc_liberator_latest_permit_status.py
@@ -5,7 +5,12 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate,
+)
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -27,6 +32,7 @@ S3bucket_node1 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-"+environment+"-liberator-raw-zone",
     table_name="liberator_permit_status",
     transformation_ctx="S3bucket_node1",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_dc_liberator_latest_permit_status.py
+++ b/scripts/jobs/parking/parking_dc_liberator_latest_permit_status.py
@@ -32,7 +32,7 @@ S3bucket_node1 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-"+environment+"-liberator-raw-zone",
     table_name="liberator_permit_status",
     transformation_ctx="S3bucket_node1",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_deployment_target_details.py
+++ b/scripts/jobs/parking/parking_deployment_target_details.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ AmazonS3_node1632912445458 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1632912445458",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1633593610551 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_visit_req_timings",
     transformation_ctx="AmazonS3_node1633593610551",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1633593851886 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1633593851886",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1633594330463 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_beat_visit_requirements",
     transformation_ctx="AmazonS3_node1633594330463",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_deployment_target_details.py
+++ b/scripts/jobs/parking/parking_deployment_target_details.py
@@ -29,7 +29,7 @@ AmazonS3_node1632912445458 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1632912445458",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1633593610551 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_visit_req_timings",
     transformation_ctx="AmazonS3_node1633593610551",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1633593851886 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1633593851886",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1633594330463 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_beat_visit_requirements",
     transformation_ctx="AmazonS3_node1633594330463",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_estate_waiting_list_live_permits_type_gds.py
+++ b/scripts/jobs/parking/parking_estate_waiting_list_live_permits_type_gds.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -30,6 +30,7 @@ S3bucketraw_zoneliberator_permit_estate_wl_node1 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_permit_estate_wl",
         transformation_ctx="S3bucketraw_zoneliberator_permit_estate_wl_node1",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -38,6 +39,7 @@ AmazonS3parking_permit_denormalised_gds_street_llpg_node1640271444228 = glueCont
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="AmazonS3parking_permit_denormalised_gds_street_llpg_node1640271444228",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_estate_waiting_list_live_permits_type_gds.py
+++ b/scripts/jobs/parking/parking_estate_waiting_list_live_permits_type_gds.py
@@ -30,7 +30,7 @@ S3bucketraw_zoneliberator_permit_estate_wl_node1 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_permit_estate_wl",
         transformation_ctx="S3bucketraw_zoneliberator_permit_estate_wl_node1",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -39,7 +39,7 @@ AmazonS3parking_permit_denormalised_gds_street_llpg_node1640271444228 = glueCont
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="AmazonS3parking_permit_denormalised_gds_street_llpg_node1640271444228",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_gds_permit_change_comparison.py
+++ b/scripts/jobs/parking/parking_gds_permit_change_comparison.py
@@ -30,7 +30,7 @@ S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1 = glueConte
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_gds_permit_change_comparison.py
+++ b/scripts/jobs/parking/parking_gds_permit_change_comparison.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -30,6 +30,7 @@ S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1 = glueConte
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_pcn_create_event_log.py
+++ b/scripts/jobs/parking/parking_pcn_create_event_log.py
@@ -159,7 +159,7 @@ DataSource0 = glueContext.create_dynamic_frame.from_catalog(
     database = "dataplatform-" + environment + "-liberator-raw-zone",
     table_name = "liberator_pcn_audit",
     transformation_ctx = "DataSource0",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_audit": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]

--- a/scripts/jobs/parking/parking_pcn_create_event_log.py
+++ b/scripts/jobs/parking/parking_pcn_create_event_log.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.dynamicframe import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -155,7 +155,12 @@ job.init(args['JOB_NAME'], args)
 ## @args: [database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_audit", transformation_ctx = "DataSource0"]
 ## @return: DataSource0
 ## @inputs: []
-DataSource0 = glueContext.create_dynamic_frame.from_catalog(database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_audit", transformation_ctx = "DataSource0")
+DataSource0 = glueContext.create_dynamic_frame.from_catalog(
+    database = "dataplatform-" + environment + "-liberator-raw-zone",
+    table_name = "liberator_pcn_audit",
+    transformation_ctx = "DataSource0",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_audit": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]
 ## @return: Transform0

--- a/scripts/jobs/parking/parking_pcn_daily_print_monitoring.py
+++ b/scripts/jobs/parking/parking_pcn_daily_print_monitoring.py
@@ -42,7 +42,7 @@ raw_zone_liberator_pcn_tickets_node1666105465609 = (
         database="dataplatform-"+environment+"-liberator-raw-zone",
         table_name="liberator_pcn_tickets",
         transformation_ctx="raw_zone_liberator_pcn_tickets_node1666105465609",
-        push_down_predicate=create_pushdown_predicate("import_date",1)
+        push_down_predicate=create_pushdown_predicate("import_date",7)
     )
 )
 print(f"loading raw_zone_liberator_pcn_tickets_node1666105465609 {(time.time() - start_time)/60:.2f} minutes")
@@ -55,7 +55,7 @@ raw_zone_liberator_pcn_audit_node1 = glueContext.create_dynamic_frame.from_catal
     database="dataplatform-"+environment+"-liberator-raw-zone",
     table_name="liberator_pcn_audit",
     transformation_ctx="raw_zone_liberator_pcn_audit_node1",
-    push_down_predicate=create_pushdown_predicate("import_date",1)
+    push_down_predicate=create_pushdown_predicate("import_date",7)
 )
 print(f"loading raw_zone_liberator_pcn_audit_node1 {(time.time() - start_time)/60:.2f} minutes")
 

--- a/scripts/jobs/parking/parking_pcn_report_summary.py
+++ b/scripts/jobs/parking/parking_pcn_report_summary.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.dynamicframe import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -59,7 +59,12 @@ job.init(args['JOB_NAME'], args)
 ## @args: [database = "dataplatform-" + environment + "-liberator-refined-zone", table_name = "pcnfoidetails_pcn_foi_full", transformation_ctx = "DataSource0"]
 ## @return: DataSource0
 ## @inputs: []
-DataSource0 = glueContext.create_dynamic_frame.from_catalog(database = "dataplatform-" + environment + "-liberator-refined-zone", table_name = "pcnfoidetails_pcn_foi_full", transformation_ctx = "DataSource0")
+DataSource0 = glueContext.create_dynamic_frame.from_catalog(
+    database = "dataplatform-" + environment + "-liberator-refined-zone",
+    table_name = "pcnfoidetails_pcn_foi_full",
+    transformation_ctx = "DataSource0",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"pcnfoidetails_pcn_foi_full": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]
 ## @return: Transform0

--- a/scripts/jobs/parking/parking_pcn_report_summary.py
+++ b/scripts/jobs/parking/parking_pcn_report_summary.py
@@ -63,7 +63,7 @@ DataSource0 = glueContext.create_dynamic_frame.from_catalog(
     database = "dataplatform-" + environment + "-liberator-refined-zone",
     table_name = "pcnfoidetails_pcn_foi_full",
     transformation_ctx = "DataSource0",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"pcnfoidetails_pcn_foi_full": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]

--- a/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
+++ b/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
@@ -34,7 +34,7 @@ S3bucketrefinedparking_permit_denormalised_data_node1 = (
         database="dataplatform-"+environment+"-liberator-refined-zone",
         table_name="parking_permit_denormalised_data",
         transformation_ctx="S3bucketrefinedparking_permit_denormalised_data_node1",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -44,7 +44,7 @@ AmazonS3rawliberator_permit_llpg_node1657535904691 = (
         database="dataplatform-"+environment+"-liberator-raw-zone",
         table_name="liberator_permit_llpg",
         transformation_ctx="AmazonS3rawliberator_permit_llpg_node1657535904691",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -53,7 +53,7 @@ AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004 = glueCon
     database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api",
     table_name="unrestricted_address_api_dbo_hackney_address",
     transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3 - parking raw - ltn_london_fields
@@ -62,7 +62,7 @@ AmazonS3parkingrawltn_london_fields_node1657536241729 = (
         database="parking-raw-zone",
         table_name="ltn_london_fields",
         transformation_ctx="AmazonS3parkingrawltn_london_fields_node1657536241729",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 

--- a/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
+++ b/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
@@ -1,3 +1,4 @@
+from calendar import c
 import sys
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
@@ -5,7 +6,12 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate,
+)
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -28,6 +34,7 @@ S3bucketrefinedparking_permit_denormalised_data_node1 = (
         database="dataplatform-"+environment+"-liberator-refined-zone",
         table_name="parking_permit_denormalised_data",
         transformation_ctx="S3bucketrefinedparking_permit_denormalised_data_node1",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -37,6 +44,7 @@ AmazonS3rawliberator_permit_llpg_node1657535904691 = (
         database="dataplatform-"+environment+"-liberator-raw-zone",
         table_name="liberator_permit_llpg",
         transformation_ctx="AmazonS3rawliberator_permit_llpg_node1657535904691",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -45,6 +53,7 @@ AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004 = glueCon
     database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api",
     table_name="unrestricted_address_api_dbo_hackney_address",
     transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3 - parking raw - ltn_london_fields
@@ -53,6 +62,7 @@ AmazonS3parkingrawltn_london_fields_node1657536241729 = (
         database="parking-raw-zone",
         table_name="ltn_london_fields",
         transformation_ctx="AmazonS3parkingrawltn_london_fields_node1657536241729",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 

--- a/scripts/jobs/parking/parking_permit_street_stress.py
+++ b/scripts/jobs/parking/parking_permit_street_stress.py
@@ -34,7 +34,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -42,7 +42,7 @@ AmazonS3_node1681807440414 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="geolive_parking_order",
     transformation_ctx="AmazonS3_node1681807440414",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -50,7 +50,7 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_permit_street_stress.py
+++ b/scripts/jobs/parking/parking_permit_street_stress.py
@@ -5,7 +5,13 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate_for_max_date_partition_value,
+    create_pushdown_predicate,
+)
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -28,6 +34,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -35,6 +42,7 @@ AmazonS3_node1681807440414 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="geolive_parking_order",
     transformation_ctx="AmazonS3_node1681807440414",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -42,6 +50,7 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
+++ b/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
@@ -34,7 +34,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -42,7 +42,7 @@ AmazonS3_node1681807440414 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="geolive_parking_order",
     transformation_ctx="AmazonS3_node1681807440414",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -50,7 +50,7 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
+++ b/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
@@ -5,7 +5,13 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate_for_max_date_partition_value,
+    create_pushdown_predicate,
+)
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -28,6 +34,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_llpg",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -35,6 +42,7 @@ AmazonS3_node1681807440414 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="geolive_parking_order",
     transformation_ctx="AmazonS3_node1681807440414",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -42,6 +50,7 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary.py
+++ b/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.dynamicframe import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -91,7 +91,12 @@ job.init(args['JOB_NAME'], args)
 ## @args: [database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_ic", transformation_ctx = "DataSource0"]
 ## @return: DataSource0
 ## @inputs: []
-DataSource0 = glueContext.create_dynamic_frame.from_catalog(database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_ic", transformation_ctx = "DataSource0")
+DataSource0 = glueContext.create_dynamic_frame.from_catalog(
+    database = "dataplatform-" + environment + "-liberator-raw-zone",
+    table_name = "liberator_pcn_ic",
+    transformation_ctx = "DataSource0",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
+)
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_ic": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]
 ## @return: Transform0

--- a/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary.py
+++ b/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary.py
@@ -95,7 +95,7 @@ DataSource0 = glueContext.create_dynamic_frame.from_catalog(
     database = "dataplatform-" + environment + "-liberator-raw-zone",
     table_name = "liberator_pcn_ic",
     transformation_ctx = "DataSource0",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_ic": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]

--- a/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary_qtr.py
+++ b/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary_qtr.py
@@ -99,7 +99,7 @@ DataSource0 = glueContext.create_dynamic_frame.from_catalog(
     database = "dataplatform-" + environment + "-liberator-raw-zone",
     table_name = "liberator_pcn_ic",
     transformation_ctx = "DataSource0",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_ic": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]

--- a/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary_qtr.py
+++ b/scripts/jobs/parking/parking_reps_and_appeals_correspondance_kpi_gds_summary_qtr.py
@@ -1,12 +1,14 @@
 import sys
+
+from awsglue.context import GlueContext
+from awsglue.dynamicframe import DynamicFrame
+from awsglue.job import Job
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from awsglue.context import GlueContext
-from awsglue.job import Job
-from awsglue.dynamicframe import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import create_pushdown_predicate, get_glue_env_var
+
 environment = get_glue_env_var("environment")
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -93,7 +95,12 @@ job.init(args['JOB_NAME'], args)
 ## @args: [database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_ic", transformation_ctx = "DataSource0"]
 ## @return: DataSource0
 ## @inputs: []
-DataSource0 = glueContext.create_dynamic_frame.from_catalog(database = "dataplatform-" + environment + "-liberator-raw-zone", table_name = "liberator_pcn_ic", transformation_ctx = "DataSource0")
+DataSource0 = glueContext.create_dynamic_frame.from_catalog(
+    database = "dataplatform-" + environment + "-liberator-raw-zone",
+    table_name = "liberator_pcn_ic",
+    transformation_ctx = "DataSource0",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
+)
 ## @type: SqlCode
 ## @args: [sqlAliases = {"liberator_pcn_ic": DataSource0}, sqlName = SqlQuery0, transformation_ctx = "Transform0"]
 ## @return: Transform0

--- a/scripts/jobs/parking/parking_school_street_vrms.py
+++ b/scripts/jobs/parking/parking_school_street_vrms.py
@@ -29,7 +29,7 @@ S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1 = glueConte
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1647531223393 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="school_street_uprn",
     transformation_ctx="AmazonS3_node1647531223393",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_school_street_vrms.py
+++ b/scripts/jobs/parking/parking_school_street_vrms.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1 = glueConte
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_gds_street_llpg",
     transformation_ctx="S3liberator_refinedparking_permit_denormalised_gds_street_llpg_node1",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1647531223393 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="school_street_uprn",
     transformation_ctx="AmazonS3_node1647531223393",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_suspension_de-normalised_data.py
+++ b/scripts/jobs/parking/parking_suspension_de-normalised_data.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ AmazonS3_node1627053246341 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_suspension_change",
     transformation_ctx="AmazonS3_node1627053246341",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1627053109317 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1627053109317",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1627053334221 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_suspension",
     transformation_ctx="AmazonS3_node1627053334221",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1625732651466 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_status",
     transformation_ctx="AmazonS3_node1625732651466",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_suspension_de-normalised_data.py
+++ b/scripts/jobs/parking/parking_suspension_de-normalised_data.py
@@ -29,7 +29,7 @@ AmazonS3_node1627053246341 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_suspension_change",
     transformation_ctx="AmazonS3_node1627053246341",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1627053109317 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1627053109317",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1627053334221 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_suspension",
     transformation_ctx="AmazonS3_node1627053334221",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1625732651466 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_status",
     transformation_ctx="AmazonS3_node1625732651466",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_suspensions_processed.py
+++ b/scripts/jobs/parking/parking_suspensions_processed.py
@@ -35,7 +35,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -43,7 +43,7 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_suspensions_processed.py
+++ b/scripts/jobs/parking/parking_suspensions_processed.py
@@ -5,7 +5,13 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate_for_max_date_partition_value,
+    create_pushdown_predicate,
+)
 
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -29,6 +35,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +43,7 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
+++ b/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
@@ -5,7 +5,13 @@ from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS, create_pushdown_predicate_for_max_date_partition_value
+from scripts.helpers.helpers import (
+    get_glue_env_var,
+    get_latest_partitions,
+    PARTITION_KEYS,
+    create_pushdown_predicate_for_max_date_partition_value,
+    create_pushdown_predicate,
+)
 
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
@@ -29,6 +35,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1658997944648",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +43,7 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +51,7 @@ AmazonS3_node1702397632233 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1702397632233",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
+++ b/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
@@ -35,7 +35,7 @@ AmazonS3_node1658997944648 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_activity",
     transformation_ctx="AmazonS3_node1658997944648",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -43,7 +43,7 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -51,7 +51,7 @@ AmazonS3_node1702397632233 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1702397632233",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_voucher_de_normalised.py
+++ b/scripts/jobs/parking/parking_voucher_de_normalised.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ AmazonS3_node1648207907397 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_voucher",
     transformation_ctx="AmazonS3_node1648207907397",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -36,6 +37,7 @@ AmazonS3_node1648208237020 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_fta",
     transformation_ctx="AmazonS3_node1648208237020",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -43,6 +45,7 @@ AmazonS3_node1648208633220 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_printing",
     transformation_ctx="AmazonS3_node1648208633220",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3
@@ -50,6 +53,7 @@ AmazonS3_node1649411092913 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_evouchersession",
     transformation_ctx="AmazonS3_node1649411092913",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_voucher_de_normalised.py
+++ b/scripts/jobs/parking/parking_voucher_de_normalised.py
@@ -29,7 +29,7 @@ AmazonS3_node1648207907397 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_voucher",
     transformation_ctx="AmazonS3_node1648207907397",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +37,7 @@ AmazonS3_node1648208237020 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_fta",
     transformation_ctx="AmazonS3_node1648208237020",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,7 @@ AmazonS3_node1648208633220 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_printing",
     transformation_ctx="AmazonS3_node1648208633220",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +53,7 @@ AmazonS3_node1649411092913 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_evouchersession",
     transformation_ctx="AmazonS3_node1649411092913",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
+++ b/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
@@ -6,7 +6,7 @@ from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue import DynamicFrame
 
-from scripts.helpers.helpers import get_glue_env_var
+from scripts.helpers.helpers import get_glue_env_var, create_pushdown_predicate
 environment = get_glue_env_var("environment")
 
 
@@ -29,6 +29,7 @@ S3bucketRawliberator_permit_fta_node1 = glueContext.create_dynamic_frame.from_ca
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_fta",
     transformation_ctx="S3bucketRawliberator_permit_fta_node1",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node Amazon S3 - raw - liberator_permit_renewals
@@ -37,6 +38,7 @@ AmazonS3rawliberator_permit_renewals_node1643219669907 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_permit_renewals",
         transformation_ctx="AmazonS3rawliberator_permit_renewals_node1643219669907",
+        push_down_predicate=create_pushdown_predicate("import_date", 1),
     )
 )
 
@@ -45,6 +47,7 @@ AmazonS3refineddc_liberator_latest_permit_status_node1643219673143 = glueContext
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="dc_liberator_latest_permit_status",
     transformation_ctx="AmazonS3refineddc_liberator_latest_permit_status_node1643219673143",
+    push_down_predicate=create_pushdown_predicate("import_date", 1),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
+++ b/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
@@ -29,7 +29,7 @@ S3bucketRawliberator_permit_fta_node1 = glueContext.create_dynamic_frame.from_ca
     database="dataplatform-" + environment + "-liberator-raw-zone",
     table_name="liberator_permit_fta",
     transformation_ctx="S3bucketRawliberator_permit_fta_node1",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3 - raw - liberator_permit_renewals
@@ -38,7 +38,7 @@ AmazonS3rawliberator_permit_renewals_node1643219669907 = (
         database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_permit_renewals",
         transformation_ctx="AmazonS3rawliberator_permit_renewals_node1643219669907",
-        push_down_predicate=create_pushdown_predicate("import_date", 1),
+        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -47,7 +47,7 @@ AmazonS3refineddc_liberator_latest_permit_status_node1643219673143 = glueContext
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="dc_liberator_latest_permit_status",
     transformation_ctx="AmazonS3refineddc_liberator_latest_permit_status_node1643219673143",
-    push_down_predicate=create_pushdown_predicate("import_date", 1),
+    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping


### PR DESCRIPTION
Adds push_down_predicate argument to 23 Parking Glue jobs to limit the data read when creating DynamicFrames.

Extends the buffer from 1 day to 7 in the script `scripts/jobs/parking/parking_pcn_daily_print_monitoring.py`.