### PR TITLE
remove push_down_predicate arguments

### DIFF
--- a/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
+++ b/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
@@ -29,7 +29,8 @@ AmazonS3_node1625732038443 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_cedar_payments",
     transformation_ctx="AmazonS3_node1625732038443",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +38,6 @@ AmazonS3_node1631887639199 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1631887639199",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
+++ b/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
@@ -29,7 +29,8 @@ AmazonS3_node1628173244776 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1628173244776",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +38,8 @@ AmazonS3_node1638273151502 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_summary",
     transformation_ctx="AmazonS3_node1638273151502",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_deployment_target_details.py
+++ b/scripts/jobs/parking/parking_deployment_target_details.py
@@ -36,8 +36,6 @@ AmazonS3_node1633593610551 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_visit_req_timings",
     transformation_ctx="AmazonS3_node1633593610551",
-    #teporarily removed while table partitions are fixed
-    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -54,8 +52,6 @@ AmazonS3_node1633594330463 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_beat_visit_requirements",
     transformation_ctx="AmazonS3_node1633594330463",
-    #teporarily removed while table partitions are fixed
-    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_deployment_target_details.py
+++ b/scripts/jobs/parking/parking_deployment_target_details.py
@@ -29,7 +29,6 @@ AmazonS3_node1632912445458 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1632912445458",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -37,7 +36,8 @@ AmazonS3_node1633593610551 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_visit_req_timings",
     transformation_ctx="AmazonS3_node1633593610551",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -45,7 +45,8 @@ AmazonS3_node1633593851886 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_ceo_on_street",
     transformation_ctx="AmazonS3_node1633593851886",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -53,7 +54,8 @@ AmazonS3_node1633594330463 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="ceo_beat_visit_requirements",
     transformation_ctx="AmazonS3_node1633594330463",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node ApplyMapping

--- a/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
+++ b/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
@@ -34,7 +34,8 @@ S3bucketrefinedparking_permit_denormalised_data_node1 = (
         database="dataplatform-"+environment+"-liberator-refined-zone",
         table_name="parking_permit_denormalised_data",
         transformation_ctx="S3bucketrefinedparking_permit_denormalised_data_node1",
-        push_down_predicate=create_pushdown_predicate("import_date", 7),
+        #teporarily removed while table partitions are fixed
+        #push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 
@@ -62,7 +63,6 @@ AmazonS3parkingrawltn_london_fields_node1657536241729 = (
         database="parking-raw-zone",
         table_name="ltn_london_fields",
         transformation_ctx="AmazonS3parkingrawltn_london_fields_node1657536241729",
-        push_down_predicate=create_pushdown_predicate("import_date", 7),
     )
 )
 

--- a/scripts/jobs/parking/parking_permit_street_stress.py
+++ b/scripts/jobs/parking/parking_permit_street_stress.py
@@ -50,7 +50,8 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
+++ b/scripts/jobs/parking/parking_permit_street_stress_with_cpz.py
@@ -50,7 +50,8 @@ AmazonS3_node1681807784480 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_permit_denormalised_data",
     transformation_ctx="AmazonS3_node1681807784480",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_suspensions_processed.py
+++ b/scripts/jobs/parking/parking_suspensions_processed.py
@@ -43,7 +43,8 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL

--- a/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
+++ b/scripts/jobs/parking/parking_suspensions_processed_with_finyear.py
@@ -43,7 +43,8 @@ AmazonS3_node1661350417347 = glueContext.create_dynamic_frame.from_catalog(
     database="dataplatform-" + environment + "-liberator-refined-zone",
     table_name="parking_suspension_denormalised_data",
     transformation_ctx="AmazonS3_node1661350417347",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    #teporarily removed while table partitions are fixed
+    #push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3
@@ -51,7 +52,6 @@ AmazonS3_node1702397632233 = glueContext.create_dynamic_frame.from_catalog(
     database="parking-raw-zone",
     table_name="calendar",
     transformation_ctx="AmazonS3_node1702397632233",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node SQL


### PR DESCRIPTION
Partially reverses #1623  which added `push_down_predicate` arguments to the creation of DynamicFrames. Some of the tables have been partitioned in a way that doesn't include the `import_date` partition and others do not have a new partition created daily and have sparse partition structure. 

These `push_down_predicate` arguments have been:
- commented out for tables that need repartitioning with the intention of reintroducing them once this work has been done. This makes it easier to find the relevant tables and reintroduce them than were they to be removed entirely.
- removed for tables which don't have daily partitions, these should not be reintroduced and are small tables to begin with.

This addresses the 8 failing jobs 05/03/2024