### PR TITLE
add aws_region data source

### DIFF
--- a/terraform/core/03-input-derived.tf
+++ b/terraform/core/03-input-derived.tf
@@ -33,6 +33,8 @@ data "aws_caller_identity" "api_account" {
   provider = aws.aws_api_account
 }
 
+data "aws_region" "current" {}
+
 locals {
   glue_crawler_excluded_blobs = [
     "*.json",

--- a/terraform/etl/03-input-derived.tf
+++ b/terraform/etl/03-input-derived.tf
@@ -32,6 +32,8 @@ data "aws_caller_identity" "api_account" {
   provider = aws.aws_api_account
 }
 
+data "aws_region" "current" {}
+
 locals {
   glue_crawler_excluded_blobs = [
     "*.json",


### PR DESCRIPTION
adds a data object to retrieve the region for the current provider

for instances where you might want to discover the region being used and infer things like arns:

arn:aws:service:**${data.aws_region.current.name}**...

ref: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region