### PR TITLE
DPP-654: only shedule it in stg and remove import of rs_command

### DIFF
--- a/scripts/jobs/academy_data/load_all_academy_data_into_redshift.py
+++ b/scripts/jobs/academy_data/load_all_academy_data_into_redshift.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional
 import boto3
 from scripts.helpers.helpers import get_secret_dict, get_glue_env_var
-from scripts.helpers.redshift_helpers import rs_command
 import redshift_connector
 
 environment = get_glue_env_var("environment")
@@ -11,53 +10,56 @@ role_arn = get_glue_env_var("role_arn")
 base_s3_url = get_glue_env_var("base_s3_url")
 
 def rs_command(query: str, fetch_results: bool = False, allow_commit: bool = True, database_name: str = 'academy') -> Optional[List[Dict]]:
-   """Executes a SQL query against a Redshift database, optionally fetching results.
+    """Executes a SQL query against a Redshift database, optionally fetching results.
 
-   Args:
-       query (str): The SQL query to execute.
-       fetch_results (bool): Whether to fetch and return the query results (default False).
-       allow_commit (bool): Whether to allow committing the transaction (default True).
-       database_name: Name of the database to connect to, defaults to 'academy'.
+    Args:
+        query (str): The SQL query to execute.
+        fetch_results (bool): Whether to fetch and return the query results (default False).
+        allow_commit (bool): Whether to allow committing the transaction (default True).
+        database_name: Name of the database to connect to, defaults to 'academy'.
 
-   Returns:
-       Optional[List[Dict]]: A list of dictionaries representing rows returned by the query if fetch_results is True; otherwise None.
-   """
-   creds = get_secret_dict('/data-and-insight/redshift-serverless-connection', 'eu-west-2')
-   try:
-       # Connects to Redshift cluster using AWS credentials
-       conn = redshift_connector.connect(
-           host=creds['host'],
-           database=database_name,
-           user=creds['user'],
-           password=creds['password']
-       )
-       
-       # autocommit is off by default. 
-       if allow_commit:
-           # Add this line to handle commands like CREATE EXTERNAL TABLE
-           conn.autocommit = True
+    Returns:
+        Optional[List[Dict]]: A list of dictionaries representing rows returned by the query if fetch_results is True; otherwise None.
+    """
+    creds = get_secret_dict('/data-and-insight/redshift-serverless-connection', 'eu-west-2')
+    conn = None
+    cursor = None   
+    try:
+        # Connects to Redshift cluster using AWS credentials
+        conn = redshift_connector.connect(
+            host=creds['host'],
+            database=database_name,
+            user=creds['user'],
+            password=creds['password']
+        )
+        
+        # autocommit is off by default. 
+        if allow_commit:
+            # Add this line to handle commands like CREATE EXTERNAL TABLE
+            conn.autocommit = True
 
-       cursor = conn.cursor()
+        cursor = conn.cursor()
 
-       # Execute the query
-       cursor.execute(query)
-       
-       # Fetch the results if required
-       if fetch_results:
-           result = cursor.fetchall()
-           return [dict(row) for row in result] if result else []
-       elif allow_commit:
-           # Commit the transaction only if allowed and needed
-           conn.commit()
+        # Execute the query
+        cursor.execute(query)
+        
+        # Fetch the results if required
+        if fetch_results:
+            columns = [desc[0] for desc in cursor.description]  # Get column names
+            result = cursor.fetchall()
+            return [dict(zip(columns, row)) for row in result] if result else []
+        elif allow_commit:
+            # Commit the transaction only if allowed and needed
+            conn.commit()
 
-   except redshift_connector.Error as e:
-       raise e
-   finally:
-       if cursor:
-           cursor.close()
-       if conn:
-           conn.close()
-   return None  # Return None if fetch_results is False or if there's an error
+    except redshift_connector.Error as e:
+        raise e
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()
+    return None  # Return None if fetch_results is False or if there's an error
 
 def get_all_tables(glue_client: Any, database_name: str, pattern: str = '') -> List[Dict]:
     """Retrieve all table metadata from Glue catalog for a specific database."""

--- a/terraform/core/51-load-all-academy-data-into-redshift-serverless.tf
+++ b/terraform/core/51-load-all-academy-data-into-redshift-serverless.tf
@@ -1,5 +1,5 @@
 module "load_all_academy_data_into_redshift" {
-  count = local.is_live_environment ? 1 : 0
+  count                           = local.is_live_environment && !local.is_production_environment ? 1 : 0
   tags  = module.tags.values
   source                          = "../modules/aws-glue-job"
   is_live_environment             = local.is_live_environment
@@ -18,7 +18,7 @@ module "load_all_academy_data_into_redshift" {
   glue_job_timeout                = 220
   schedule                        = "cron(15 7 ? * MON-FRI *)"
   job_parameters = {
-    "--additional-python-modules"        = "redshift_connector==2.1.0"
+    "--additional-python-modules"        = "botocore==1.27.59, redshift_connector==2.1.0"
     "--environment"                      = var.environment
     # This is the ARN of the IAM role used by Redshift Serverless. We have count in redshift-serverless module so we need to use index 0 to get the ARN.
     "--role_arn"                         = try(module.redshift_serverless[0].redshift_serverless_role_arn, "") 


### PR DESCRIPTION
I've tried to:
1) correct an import error in etl script
2) avoid to deploy to prod since we have not used redshfit serverless in prod for the step. It really costs money to update this daily both in prod and stg.
Thanks for reviewing.