### PR TITLE
create pass role policy for departments

### DIFF
--- a/terraform/modules/department/01-inputs-required.tf
+++ b/terraform/modules/department/01-inputs-required.tf
@@ -9,7 +9,7 @@ variable "is_live_environment" {
 }
 
 variable "environment" {
-  description = "Environment e.g. Dev, Stg, Prod, Mgmt."
+  description = "Environment e.g. dev, stg, prod."
   type        = string
 }
 

--- a/terraform/modules/department/01-inputs-required.tf
+++ b/terraform/modules/department/01-inputs-required.tf
@@ -9,7 +9,7 @@ variable "is_live_environment" {
 }
 
 variable "environment" {
-  description = "Environment e.g. dev, stg, prod."
+  description = "Environment e.g. stg, prod."
   type        = string
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -769,8 +769,7 @@ data "aws_iam_policy_document" "glue_pass_role_to_secrets_manager_for_notebook_u
 }
 
 resource "aws_iam_policy" "glue_pass_role_to_secrets_manager_for_notebook_use" {
-  tags = var.tags
-
+  tags   = var.tags
   name   = lower("${var.identifier_prefix}-${local.department_identifier}-glue-pass-role-to-secrets-manager-for-notebook-use")
   policy = data.aws_iam_policy_document.glue_pass_role_to_secrets_manager_for_notebook_use.json
 }

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -750,8 +750,8 @@ data "aws_iam_policy_document" "redshift_department_read_access" {
 }
 
 
-// Glue Agents can pass their role to Secrets Manager for notebook use
-data "aws_iam_policy_document" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+// Glue job runner pass role to glue for notebook use
+data "aws_iam_policy_document" "glue_runner_pass_role_to_glue_for_notebook_use" {
   statement {
     effect = "Allow"
     actions = [
@@ -768,8 +768,8 @@ data "aws_iam_policy_document" "glue_pass_role_to_secrets_manager_for_notebook_u
   }
 }
 
-resource "aws_iam_policy" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+resource "aws_iam_policy" "glue_runner_pass_role_to_glue_for_notebook_use" {
   tags   = var.tags
-  name   = lower("${var.identifier_prefix}-${local.department_identifier}-glue-pass-role-to-secrets-manager-for-notebook-use")
-  policy = data.aws_iam_policy_document.glue_pass_role_to_secrets_manager_for_notebook_use.json
+  name   = lower("${var.identifier_prefix}-${local.department_identifier}-glue-runner-pass-role-to-glue-for-notebook-use")
+  policy = data.aws_iam_policy_document.glue_runner_pass_role_to_glue_for_notebook_use.json
 }

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -763,7 +763,7 @@ data "aws_iam_policy_document" "glue_pass_role_to_secrets_manager_for_notebook_u
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
-      values   = ["secretsmanager.amazonaws.com"]
+      values   = ["glue.amazonaws.com"]
     }
   }
 }

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -449,16 +449,6 @@ data "aws_iam_policy_document" "secrets_manager_read_only" {
       var.secrets_manager_kms_key.arn
     ]
   }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "iam:PassRole",
-    ]
-    resources = [
-      "arn:aws:iam::34566344452:role/dataplatform-stg-glue-data-and-insight"
-    ]
-  }
 }
 
 resource "aws_iam_policy" "secrets_manager_read_only" {
@@ -757,4 +747,30 @@ data "aws_iam_policy_document" "redshift_department_read_access" {
     ]
     resources = ["*"]
   }
+}
+
+
+// Glue Agents can pass their role to Secrets Manager for notebook use
+data "aws_iam_policy_document" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = [
+      aws_iam_role.glue_agent.arn
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["secretsmanager.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+  tags = var.tags
+
+  name   = lower("${var.identifier_prefix}-${local.department_identifier}-glue-pass-role-to-secrets-manager-for-notebook-use")
+  policy = data.aws_iam_policy_document.glue_pass_role_to_secrets_manager_for_notebook_use.json
 }

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -87,3 +87,9 @@ resource "aws_iam_role_policy_attachment" "glue_access_to_watermarks_table" {
   role       = aws_iam_role.glue_agent.name
   policy_arn = aws_iam_policy.glue_access_to_watermarks_table.arn
 }
+
+resource "aws_iam_role_policy_attachment" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+  count      = var.environment == "Prod" ? 0 : 1
+  role       = aws_iam_role.glue_agent.name
+  policy_arn = aws_iam_policy.glue_pass_role_to_secrets_manager_for_notebook_use.arn
+}

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -89,7 +89,7 @@ resource "aws_iam_role_policy_attachment" "glue_access_to_watermarks_table" {
 }
 
 resource "aws_iam_role_policy_attachment" "glue_pass_role_to_secrets_manager_for_notebook_use" {
-  count      = var.environment == "Prod" ? 0 : 1
+  count      = var.environment == "prod" ? 0 : 1
   role       = aws_iam_role.glue_agent.name
   policy_arn = aws_iam_policy.glue_pass_role_to_secrets_manager_for_notebook_use.arn
 }

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -88,8 +88,8 @@ resource "aws_iam_role_policy_attachment" "glue_access_to_watermarks_table" {
   policy_arn = aws_iam_policy.glue_access_to_watermarks_table.arn
 }
 
-resource "aws_iam_role_policy_attachment" "glue_pass_role_to_secrets_manager_for_notebook_use" {
+resource "aws_iam_role_policy_attachment" "glue_runner_pass_role_to_glue_for_notebook_use" {
   count      = var.environment == "prod" ? 0 : 1
   role       = aws_iam_role.glue_agent.name
-  policy_arn = aws_iam_policy.glue_pass_role_to_secrets_manager_for_notebook_use.arn
+  policy_arn = aws_iam_policy.glue_runner_pass_role_to_glue_for_notebook_use.arn
 }


### PR DESCRIPTION
Users have experienced the following error when attempting to use Glue interactive sessions:
`Following exception encountered while creating session: An error occurred (AccessDeniedException) when calling the CreateSession operation: User: arn:aws:sts::*:assumed-role/dataplatform-stg-glue-data-and-insight/GlueJobRunnerSession is not authorized to perform: iam:PassRole on resource: arn:aws:iam::*:role/dataplatform-stg-glue-data-and-insight because no identity-based policy allows the iam:PassRole action `

These changes allow Glue job runners to pass the department IAM role to the Glue service in order to create sessions and access resources that would be available to a Glue script run in a non-interactive session i.e. when run as a job.

ref: https://docs.aws.amazon.com/glue/latest/dg/glue-is-security.html
