### PR TITLE
fix the lambda deployment

### DIFF
--- a/terraform/modules/aws-lambda/30-lambda.tf
+++ b/terraform/modules/aws-lambda/30-lambda.tf
@@ -57,5 +57,9 @@ resource "aws_s3_object" "lambda" {
   key        = var.s3_key
   source     = data.archive_file.lambda.output_path
   acl        = "private"
+  # Add a metadata attribute to create a traceable record of the version of the file uploaded to S3
+  metadata = {
+    last_updated = data.archive_file.lambda.output_base64sha256
+  }
   depends_on = [data.archive_file.lambda]
 }


### PR DESCRIPTION
when change the main.py file, it cannot create a new zip file as s3 object, so it will deploy (terraform) the old version zip file to AWS. Now, by adding metadata, make sure it will create new zip file if the source code changes.

Still have an issue using my git in vscode, let me submit the PR using the github UI.