### PR TITLE
DPP-546 improve database ingestion details

### DIFF
--- a/scripts/helpers/database_ingestion_helpers.py
+++ b/scripts/helpers/database_ingestion_helpers.py
@@ -1,5 +1,6 @@
-import boto3
 import re
+from typing import List, Dict, Optional, Union
+from datetime import datetime
 
 def get_all_database_tables(glue_client, source_catalog_database, table_filter_expression=None):
     all_tables = []
@@ -29,15 +30,46 @@ def get_filtered_tables(tables, table_filter_expression):
 
     return filtered_tables
 
-def update_table_ingestion_details(table_ingestion_details, table_name, minutes_taken, error, error_details):
-    table_ingestion_details.append(
-        {
-            "table_name": table_name,
-            "minutes_taken": minutes_taken,
-            "error": error,
-            "error_details": str(error_details)
-        }
-    )
+def update_table_ingestion_details(
+    table_ingestion_details: List[Dict[str, Union[str, int, None]]],
+    table_name: str,
+    minutes_taken: int,
+    error: bool,
+    error_details: Optional[str],
+    run_datetime: Optional[datetime] = None,
+    row_count: Optional[int] = None,
+    run_id: Optional[int] = None
+) -> List[Dict[str, Union[str, int, None]]]:
+    """
+    Updates the details of table ingestion by appending a new record to the
+    list of ingestion details.
+
+    Parameters:
+    - table_ingestion_details: A list of dictionaries with details of table ingestions.
+    - table_name: The name of the table.
+    - minutes_taken: The number of minutes the ingestion took.
+    - error: Boolean indicating if there was an error during ingestion.
+    - error_details: Optional string detailing the error if any.
+    - run_datetime: Optional datetime when the ingestion run occurred. Defaults to current datetime if not provided.
+    - row_count: Optional number of rows ingested.
+    - run_id: Optional identifier for the ingestion run.
+
+    Returns:
+    - The updated list of table ingestion details.
+    """
+    if run_datetime is None:
+        run_datetime = datetime.now()
+
+    table_ingestion_details.append({
+        "table_name": table_name,
+        "minutes_taken": minutes_taken,
+        "error": error,
+        "error_details": str(error_details) if error_details else None,
+        "run_datetime": run_datetime.isoformat(),
+        "row_count": row_count,
+        "run_id": run_id
+    })
 
     return table_ingestion_details
+
 

--- a/scripts/helpers/database_ingestion_helpers.py
+++ b/scripts/helpers/database_ingestion_helpers.py
@@ -34,7 +34,7 @@ def update_table_ingestion_details(
     table_ingestion_details: List[Dict[str, Union[str, int, None]]],
     table_name: str,
     minutes_taken: int,
-    error: bool,
+    error: str,
     error_details: Optional[str],
     run_datetime: Optional[datetime] = None,
     row_count: Optional[int] = None,
@@ -48,7 +48,7 @@ def update_table_ingestion_details(
     - table_ingestion_details: A list of dictionaries with details of table ingestions.
     - table_name: The name of the table.
     - minutes_taken: The number of minutes the ingestion took.
-    - error: Boolean indicating if there was an error during ingestion.
+    - error: str the allowed value are 'False' and 'True', indicating if there was an error during ingestion.
     - error_details: Optional string detailing the error if any.
     - run_datetime: Optional datetime when the ingestion run occurred. Defaults to current datetime if not provided.
     - row_count: Optional number of rows ingested.

--- a/scripts/jobs/ingest_database_tables_via_jdbc_connection.py
+++ b/scripts/jobs/ingest_database_tables_via_jdbc_connection.py
@@ -1,6 +1,7 @@
 import sys
 import boto3
 import time
+from datetime import datetime
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
@@ -22,6 +23,8 @@ spark = glue_context.spark_session
 job = Job(glue_context)
 job.init(args['JOB_NAME'], args)
 
+job_run_id = args['JOB_RUN_ID'] # Get the job run id for logging purposes
+
 source_catalog_database = get_glue_env_var('source_data_database', '')
 s3_ingestion_bucket_target = get_glue_env_var('s3_ingestion_bucket_target', '')
 s3_ingestion_details_target = get_glue_env_var('s3_ingestion_details_target', '')
@@ -37,6 +40,7 @@ num_copied_tables = 0
 
 for table in database_tables:
     start = time.time()
+    run_start_time = datetime.now() # Get the start time of the run for logging purposes
     logger.info(f"Reading in table: {table}, preparing to write table to s3. Timer started")
     try:
         source_ddf = glue_context.create_dynamic_frame.from_catalog(
@@ -47,6 +51,7 @@ for table in database_tables:
 
         data_frame = source_ddf.toDF()
         data_frame = data_frame.na.drop('all') # Drop all rows where all values are null NOTE: must be done before add_import_time_columns
+        row_count = data_frame.count()  # Capture row count of the DataFrame for logging purposes
         data_frame_with_import_columns = add_import_time_columns(data_frame)
 
         dynamic_frame_to_write = DynamicFrame.fromDF(data_frame_with_import_columns, glue_context, f"{table}_output_data")
@@ -68,12 +73,24 @@ for table in database_tables:
         num_copied_tables += 1
         logger.info(f'Copied: {num_copied_tables} tables')
         table_ingestion_details = update_table_ingestion_details(table_ingestion_details=table_ingestion_details,
-                                                                    table_name=table, minutes_taken=minutes_taken, error='False', error_details='None')
+                                                                 table_name=table,
+                                                                 minutes_taken=minutes_taken,
+                                                                 error='False',
+                                                                 error_details='None',
+                                                                 run_datetime=run_start_time,
+                                                                 row_count=row_count,
+                                                                 run_id=job_run_id)
 
     except Exception as e:
         logger.info(f"Failed to ingest table: {table}, error: {e}")
         table_ingestion_details = update_table_ingestion_details(table_ingestion_details=table_ingestion_details,
-                                                                    table_name=table, minutes_taken=0, error='True', error_details=e)
+                                                                 table_name=table, 
+                                                                 minutes_taken=0, 
+                                                                 error='True', 
+                                                                 error_details=str(e),
+                                                                 run_datetime=run_start_time, 
+                                                                 row_count=0, 
+                                                                 run_id=job_run_id)
 
 table_ingestion_details_df = spark_session.createDataFrame([Row(**i) for i in table_ingestion_details])
 table_ingestion_details_ddf = DynamicFrame.fromDF(table_ingestion_details_df, glue_context, "table_ingestion_details")

--- a/scripts/jobs/ingest_database_tables_via_jdbc_connection.py
+++ b/scripts/jobs/ingest_database_tables_via_jdbc_connection.py
@@ -2,6 +2,7 @@ import sys
 import boto3
 import time
 from datetime import datetime
+
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext

--- a/scripts/tests/test_update_table_ingestion_details.py
+++ b/scripts/tests/test_update_table_ingestion_details.py
@@ -1,40 +1,57 @@
+from datetime import datetime
 from scripts.helpers.database_ingestion_helpers import update_table_ingestion_details
 
 class TestDatabaseIngestionHelpers:
-  def test_update_table_ingestion_details_adds_one_table_ingestion_details(self):
-    table = []
+    def test_update_table_ingestion_details_adds_one_table_ingestion_details(self):
+        table = []
+        run_datetime = datetime(2024, 3, 27, 12, 0)  
 
-    expected_response = [
-      {
-        "table_name": "testTable",
-        "minutes_taken": 3,
-        "error": "False",
-        "error_details": "None"
-      }
-    ]
+        expected_response = [
+            {
+                "table_name": "testTable",
+                "minutes_taken": 3,
+                "error": "False",
+                "error_details": "None",
+                "run_datetime": run_datetime.isoformat(),  
+                "row_count": 100,  
+                "run_id": "exampleRunId"  
+            }
+        ]
 
-    update_table_ingestion_details(table, table_name="testTable", minutes_taken=3, error="False", error_details="None")
+        update_table_ingestion_details(table, table_name="testTable", minutes_taken=3, error="False", error_details="None",
+                                       run_datetime=run_datetime, row_count=100, run_id="exampleRunId")
 
-    assert table == expected_response
+        assert table == expected_response
 
-  def test_update_table_ingestion_details_adds_multiple_table_ingestion_details(self):
-    table = []
+    def test_update_table_ingestion_details_adds_multiple_table_ingestion_details(self):
+        table = []
+        run_datetime1 = datetime(2024, 3, 27, 12, 0)
+        run_datetime2 = datetime(2024, 3, 27, 13, 0)  
 
-    expected_response = [
-      {
-        "table_name": "testTable",
-        "minutes_taken": 3,
-        "error": "False",
-        "error_details": "None"
-      },
-      {
-        "table_name": "testTable2",
-        "minutes_taken": 0,
-        "error": "True",
-        "error_details": "Cannot execute query 'SELECT * FROM db.table'"
-      },
-    ]
-    update_table_ingestion_details(table, table_name="testTable", minutes_taken=3, error="False", error_details="None")
-    update_table_ingestion_details(table, table_name="testTable2", minutes_taken=0, error="True", error_details="Cannot execute query 'SELECT * FROM db.table'")
+        expected_response = [
+            {
+                "table_name": "testTable",
+                "minutes_taken": 3,
+                "error": "False",
+                "error_details": "None",
+                "run_datetime": run_datetime1.isoformat(),
+                "row_count": 100,
+                "run_id": "exampleRunId1"
+            },
+            {
+                "table_name": "testTable2",
+                "minutes_taken": 0,
+                "error": "True",
+                "error_details": "Cannot execute query 'SELECT * FROM db.table'",
+                "run_datetime": run_datetime2.isoformat(),
+                "row_count": 0, 
+                "run_id": "exampleRunId2"
+            },
+        ]
 
-    assert table == expected_response
+        update_table_ingestion_details(table, table_name="testTable", minutes_taken=3, error="False", error_details="None",
+                                       run_datetime=run_datetime1, row_count=100, run_id="exampleRunId1")
+        update_table_ingestion_details(table, table_name="testTable2", minutes_taken=0, error="True", error_details="Cannot execute query 'SELECT * FROM db.table'",
+                                       run_datetime=run_datetime2, row_count=0, run_id="exampleRunId2")
+
+        assert table == expected_response


### PR DESCRIPTION
1) update the helper function "update_table_ingestion_details"  by added run_datetime, row_count, run_id. these are mentioned in the ticket;
2) tweaked the main glue script and tested in stg which works well. new parquet files with all information created (please see the comments in the ticket -[DPP-546](https://hackney.atlassian.net/browse/DPP-546)). All work fine.

[DPP-546]: https://hackney.atlassian.net/browse/DPP-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ