### PR TITLE
add aws_lambda_permission to invoke the lambda function using cloudwatch event

### DIFF
--- a/terraform/etl/48-lambda-gov-notify-ingestion.tf
+++ b/terraform/etl/48-lambda-gov-notify-ingestion.tf
@@ -198,19 +198,19 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_govnotify" {
   source_arn    = aws_cloudwatch_event_rule.govnotify_housing_repairs_trigger_event[0].arn
 }
 
-# Create a CloudWatch Event Target to trigger the GovNotify Housing Repairs Lambda function.
-resource "aws_cloudwatch_event_target" "govnotify_housing_repairs_trigger_event_target" {
-  count     = local.create_govnotify_resource_count
-  rule      = aws_cloudwatch_event_rule.govnotify_housing_repairs_trigger_event[0].name
-  target_id = "govnotify-housing-repairs-trigger-event-target"
-  arn       = module.gov-notify-ingestion-housing-repairs[0].lambda_function_arn
-  input     = <<EOF
-  {
-   "table_names": ${jsonencode(local.govnotify_tables)}
-  }
-  EOF
-  depends_on = [module.gov-notify-ingestion-housing-repairs, aws_lambda_permission.allow_cloudwatch_to_call_govnotify]
-}
+# # Create a CloudWatch Event Target to trigger the GovNotify Housing Repairs Lambda function.
+# resource "aws_cloudwatch_event_target" "govnotify_housing_repairs_trigger_event_target" {
+#   count     = local.create_govnotify_resource_count
+#   rule      = aws_cloudwatch_event_rule.govnotify_housing_repairs_trigger_event[0].name
+#   target_id = "govnotify-housing-repairs-trigger-event-target"
+#   arn       = module.gov-notify-ingestion-housing-repairs[0].lambda_function_arn
+#   input     = <<EOF
+#   {
+#    "table_names": ${jsonencode(local.govnotify_tables)}
+#   }
+#   EOF
+#   depends_on = [module.gov-notify-ingestion-housing-repairs, aws_lambda_permission.allow_cloudwatch_to_call_govnotify]
+# }
 
 resource "aws_glue_crawler" "govnotify_housing_repairs_landing_zone" {
   for_each = { for idx, source in local.govnotify_tables : idx => source }


### PR DESCRIPTION
This is related to this [ticket ](https://hackney.atlassian.net/browse/DPP-674). Anna mentioned the lambda trigger can not be attached. After I tested in dev account, which shows its AWS lambda permission issue.

I am adding this permission to allow CloudWatch to trigger the Lambda. After we add the permission, then destroy and relaunch the resource "aws_cloudwatch_event_target" "govnotify_housing_repairs_trigger_event_target", it will work as the trigger correctly in the console.