### PR TITLE
remove ast literal evaluation from parking RDS export lambdas

### DIFF
--- a/lambdas/export_rds_snapshot_to_s3/main.py
+++ b/lambdas/export_rds_snapshot_to_s3/main.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import ast
 
 import boto3
 from botocore.exceptions import ClientError
@@ -13,13 +12,11 @@ def lambda_handler(event, context):
     print("## EVENT")
     print(event)
 
+    snapshot_identifier = event["detail"]["SourceIdentifier"]
+    source_arn = event["detail"]["SourceArn"]
     bucket_name = os.environ["BUCKET_NAME"]
     iam_role_arn = os.environ["IAM_ROLE_ARN"]
     kms_key_id = os.environ["KMS_KEY_ID"]
-
-    event = ast.literal_eval(event)
-    snapshot_identifier = event["detail"]["SourceIdentifier"]
-    source_arn = event["detail"]["SourceArn"]
 
     try:
         rds.start_export_task(

--- a/lambdas/export_rds_snapshot_to_s3/main.py
+++ b/lambdas/export_rds_snapshot_to_s3/main.py
@@ -7,6 +7,10 @@ from botocore.exceptions import ClientError
 logger = logging.getLogger()
 rds = boto3.client("rds")
 
+BUCKET_NAME = os.environ["BUCKET_NAME"]
+IAM_ROLE_ARN = os.environ["IAM_ROLE_ARN"]
+KMS_KEY_ID = os.environ["KMS_KEY_ID"]
+
 
 def lambda_handler(event, context):
     print("## EVENT")
@@ -14,25 +18,22 @@ def lambda_handler(event, context):
 
     snapshot_identifier = event["detail"]["SourceIdentifier"]
     source_arn = event["detail"]["SourceArn"]
-    bucket_name = os.environ["BUCKET_NAME"]
-    iam_role_arn = os.environ["IAM_ROLE_ARN"]
-    kms_key_id = os.environ["KMS_KEY_ID"]
 
     try:
         rds.start_export_task(
             ExportTaskIdentifier=snapshot_identifier,
             SourceArn=source_arn,
-            S3BucketName=bucket_name,
-            IamRoleArn=iam_role_arn,
-            KmsKeyId=kms_key_id,
+            S3BucketName=BUCKET_NAME,
+            IamRoleArn=IAM_ROLE_ARN,
+            KmsKeyId=KMS_KEY_ID,
         )
         logger.info(
-            f"Exported RDS snapshot {snapshot_identifier} to S3 bucket {bucket_name}"
+            f"Exported RDS snapshot {snapshot_identifier} to S3 bucket {BUCKET_NAME}"
         )
     except ClientError as e:
         logger.error(
             f"Failed to export RDS snapshot {snapshot_identifier} to S3 bucket"
-            f" {bucket_name}: {e}"
+            f" {BUCKET_NAME}: {e}"
         )
         raise e
 

--- a/lambdas/export_rds_snapshot_to_s3/main.py
+++ b/lambdas/export_rds_snapshot_to_s3/main.py
@@ -5,6 +5,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 rds = boto3.client("rds")
 
 BUCKET_NAME = os.environ["BUCKET_NAME"]

--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -91,10 +91,7 @@ def lambda_handler(event, context) -> None:
 
     source_bucket = os.environ["SOURCE_BUCKET"]
     target_bucket = os.environ["TARGET_BUCKET"]
-    if "SOURCE_PREFIX" in os.environ:
-        source_prefix = os.environ["SOURCE_PREFIX"]
-    else:
-        source_prefix = ""
+
     if "TARGET_PREFIX" in os.environ:
         target_prefix = os.environ["TARGET_PREFIX"] + "/"
     else:

--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -1,5 +1,4 @@
 import os
-import ast
 
 import boto3
 
@@ -101,11 +100,10 @@ def lambda_handler(event, context) -> None:
     else:
         target_prefix = ""
 
-    event = ast.literal_eval(event)
     snapshot_id = event["detail"]["SourceIdentifier"]
 
     s3_copy_folder(
-        s3, source_bucket, source_prefix, target_bucket, target_prefix, snapshot_id
+        s3, source_bucket, snapshot_id, target_bucket, target_prefix, snapshot_id
     )
 
     if "WORKFLOW_NAME" in os.environ:


### PR DESCRIPTION
Address incorrect parsing of the RDS event resulting in the following error. 

`[ERROR] ValueError: malformed node or string:`