### PR TITLE
DPP-673 fix g-drive lambda re-create

### DIFF
--- a/terraform/modules/g-drive-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/g-drive-to-s3/02-inputs-optional.tf
@@ -15,3 +15,22 @@ variable "ingestion_schedule_enabled" {
   type        = bool
   default     = true
 }
+
+
+variable "lambda_source_dir" {
+  description = "Directory containing the Lambda Function source code"
+  type        = string
+  default     = "../../lambdas/g_drive_to_s3"
+}
+
+variable "lambda_output_path" {
+  description = "Path to the Lambda artefact zip file"
+  type        = string
+  default     = "../../lambdas/g_drive_to_s3.zip"
+}
+
+variable "lambda_name_underscore" {
+  description = "Name of the Lambda function"
+  type        = string
+  default     = "g_drive_to_s3"
+}


### PR DESCRIPTION
The logic is `source code change -> tringer  local-exec to install  -> tringer the creatation of archive_file`

1) Added a `null_resource `to ensure that the installation happens only when there are changes to the source code. Then, use 'local-exec' for the required packages.
2) Incorporated `depends_on = [null_resource.run_install_requirements]` to check for the necessity of creation of zip file. If no installation has been done, then the zip file should not be created.

These steps will ensure that a zip file is generated only when there are changes to the source code. 