### PR TITLE
DPP-637 change wildcard to match the patterns correctly

### DIFF
--- a/terraform/modules/g-drive-to-s3/10-lambda.tf
+++ b/terraform/modules/g-drive-to-s3/10-lambda.tf
@@ -109,7 +109,7 @@ resource "null_resource" "run_install_requirements" {
   # Fileset used to make sure only run if there are files in the source dir
   count = length(fileset("${path.module}/../../../lambdas/g_drive_to_s3", "**/*")) > 0 ? 1 : 0
   triggers = {
-    dir_sha1 = sha1(join("", [for f in fileset(path.module, "../../../lambdas/g_drive_to_s3/**") : filesha1("${path.module}/${f}")]))
+    dir_sha1 = sha1(join("", [for f in fileset(path.module, "../../../lambdas/g_drive_to_s3/*") : filesha1("${path.module}/${f}")]))
   }
 
   provisioner "local-exec" {


### PR DESCRIPTION
The double asterisks ** is a glob pattern that matches files and directories recursively.

we only need match the files in the g_drive_to_s3. Compared with this module, https://github.com/LBHackney-IT/Data-Platform/blob/2a79f611790b3e6928e542b3f394fda882e5b00c/terraform/modules/aws-lambda/30-lambda.tf#L45
I've realised I only need one "*"