### PR TITLE
Update snapshot copier lambda to handle backdated snapshots

### DIFF
--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -119,7 +119,7 @@ def lambda_handler(event, context) -> None:
     if "backdated" in snapshot_id.split("-"):
         print("## Backdated Workflow")
         workflow_name = os.environ["BACKDATED_WORKFLOW_NAME"]
-        year, month, day, date = get_date_time(snapshot_id)
+        _, _, _, date = get_date_time(snapshot_id)
         glue_client.update_workflow(
             Name=workflow_name, DefaultRunProperties={"import_date": date}
         )

--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -1,8 +1,14 @@
 import os
+import logging
+import re
 
 import boto3
 
-glue = boto3.client("glue")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+s3_client = boto3.client("s3")
+glue_client = boto3.client("glue")
 
 
 def get_date_time(source_identifier: str) -> tuple[str, str, str, str]:
@@ -12,11 +18,17 @@ def get_date_time(source_identifier: str) -> tuple[str, str, str, str]:
     Args:
         source_identifier (str): source identifier taken from the
         event, as implemented this will include datetime for the snapshot as
-        applicable in the form rds:sql-to-parquet-yy-mm-dd-hhmmss
+        applicable in the form rds:sql-to-parquet-yy-mm-dd-hhmmss or
+        rds:sql-to-parquet-yy-mm-dd-hhmmss-backdated
 
     Returns:
         tuple(str, str, str, str): year, month, day, date
     """
+
+    pattern = r"^rds:sql-to-parquet-(\d{2})-(\d{2})-(\d{2})-(\d{6})(-backdated)?$"
+
+    if not re.match(pattern, source_identifier):
+        raise ValueError("Invalid source identifier format")
 
     split_identifier = source_identifier.split("-")
     day = split_identifier[5]
@@ -89,7 +101,6 @@ def start_workflow_run(workflow_name: str, glue_client):
 def lambda_handler(event, context) -> None:
     print("## EVENT")
     print(event)
-    s3 = boto3.client("s3")
 
     source_bucket = os.environ["SOURCE_BUCKET"]
     target_bucket = os.environ["TARGET_BUCKET"]
@@ -102,20 +113,20 @@ def lambda_handler(event, context) -> None:
     snapshot_id = event["detail"]["SourceIdentifier"]
 
     s3_copy_folder(
-        s3, source_bucket, snapshot_id, target_bucket, target_prefix, snapshot_id
+        s3_client, source_bucket, snapshot_id, target_bucket, target_prefix, snapshot_id
     )
 
     if "backdated" in snapshot_id.split("-"):
         print("## Backdated Workflow")
         workflow_name = os.environ["BACKDATED_WORKFLOW_NAME"]
         year, month, day, date = get_date_time(snapshot_id)
-        glue.update_workflow(
+        glue_client.update_workflow(
             Name=workflow_name, DefaultRunProperties={"import_date": date}
         )
-        start_workflow_run(workflow_name, glue)
+        start_workflow_run(workflow_name, glue_client)
     elif "WORKFLOW_NAME" in os.environ:
         workflow_name = os.environ["WORKFLOW_NAME"]
-        start_workflow_run(workflow_name, glue)
+        start_workflow_run(workflow_name, glue_client)
 
 
 if __name__ == "__main__":

--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -82,7 +82,7 @@ def s3_copy_folder(
             try:
                 s3_client.copy_object(**copy_object_params)
             except Exception as e:
-                logger.error(f"Error in copying object: {e}")
+                logger.error(f"Error in copying object to s3: {e}")
 
 
 def start_workflow_run(workflow_name: str, glue_client):

--- a/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
+++ b/lambdas/rds_snapshot_export_s3_to_s3_copier/main.py
@@ -82,7 +82,7 @@ def s3_copy_folder(
             try:
                 s3_client.copy_object(**copy_object_params)
             except Exception as e:
-                print(e)
+                logger.error(f"Error in copying object: {e}")
 
 
 def start_workflow_run(workflow_name: str, glue_client):
@@ -95,12 +95,12 @@ def start_workflow_run(workflow_name: str, glue_client):
     try:
         glue_client.start_workflow_run(Name=workflow_name)
     except Exception as e:
-        print(e)
+        logger.error(f"Error starting workflow {workflow_name}: {e}")
 
 
 def lambda_handler(event, context) -> None:
-    print("## EVENT")
-    print(event)
+    logger.info("## EVENT")
+    logger.info(event)
 
     source_bucket = os.environ["SOURCE_BUCKET"]
     target_bucket = os.environ["TARGET_BUCKET"]
@@ -117,7 +117,7 @@ def lambda_handler(event, context) -> None:
     )
 
     if "backdated" in snapshot_id.split("-"):
-        print("## Backdated Workflow")
+        logger.info(f"## Backdated Workflow for snapshot id: {snapshot_id}")
         workflow_name = os.environ["BACKDATED_WORKFLOW_NAME"]
         _, _, _, date = get_date_time(snapshot_id)
         glue_client.update_workflow(

--- a/terraform/modules/rds-snapshot-to-s3/iam.tf
+++ b/terraform/modules/rds-snapshot-to-s3/iam.tf
@@ -218,7 +218,8 @@ data "aws_iam_policy_document" "rds_snapshot_s3_to_s3_copier_role_policy" {
 
   statement {
     actions = [
-      "glue:StartWorkflowRun"
+      "glue:StartWorkflowRun",
+      "glue:UpdateWorkflow"
     ]
     effect = "Allow"
     resources = [

--- a/terraform/modules/rds-snapshot-to-s3/lambda.tf
+++ b/terraform/modules/rds-snapshot-to-s3/lambda.tf
@@ -38,4 +38,5 @@ module "rds_snapshot_s3_to_s3_copier" {
     "TARGET_PREFIX"           = var.target_prefix
     "WORKFLOW_NAME"           = var.workflow_name
     "BACKDATED_WORKFLOW_NAME" = var.backdated_workflow_name
+  }
 }

--- a/terraform/modules/rds-snapshot-to-s3/lambda.tf
+++ b/terraform/modules/rds-snapshot-to-s3/lambda.tf
@@ -32,10 +32,10 @@ module "rds_snapshot_s3_to_s3_copier" {
   identifier_prefix              = var.identifier_prefix
   tags                           = var.tags
   environment_variables = {
-    "SOURCE_BUCKET" = var.rds_export_bucket_id
-    "TARGET_BUCKET" = var.target_bucket_id
-    "SOURCE_PREFIX" = var.source_prefix
-    "TARGET_PREFIX" = var.target_prefix
-    "WORKFLOW_NAME" = var.workflow_name
-  }
+    "SOURCE_BUCKET"           = var.rds_export_bucket_id
+    "TARGET_BUCKET"           = var.target_bucket_id
+    "SOURCE_PREFIX"           = var.source_prefix
+    "TARGET_PREFIX"           = var.target_prefix
+    "WORKFLOW_NAME"           = var.workflow_name
+    "BACKDATED_WORKFLOW_NAME" = var.backdated_workflow_name
 }


### PR DESCRIPTION
Adds handling of backdated snapshots to trigger the appropriate workflow.

Additional changes:
- validation that the snapshot id is in the expected format
- move print statements to log messages
- allow the "glue:UpdateWorkflow" action so that the Lambda can update the `import_date` value in the backdated workflow