### PR TITLE
DPP-673 fix the installation usinig make file

### DIFF
--- a/lambdas/g_drive_to_s3/Makefile
+++ b/lambdas/g_drive_to_s3/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install
+.PHONY: install-requirements
 
 install-requirements:
 	python3 -m venv venv


### PR DESCRIPTION
A bug, but good news, is a different one. This is to fix the error after deploying which showing below ([URL](https://github.com/LBHackney-IT/Data-Platform/actions/runs/8552149339/job/23432786063))


> │ Error running command 'make install-requirements': exit status 2. Output:
> │ python3 -m venv venv
> │ Error: Command
> │ '['/home/runner/work/Data-Platform/Data-Platform/lambdas/g_drive_to_s3/venv/bin/python3',
> │ '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit
> │ status 1.
> │ make: *** [Makefile:4: install-requirements] Error 1
