### PR TITLE
DPP-673 remove the existing venv

### DIFF
--- a/lambdas/g_drive_to_s3/Makefile
+++ b/lambdas/g_drive_to_s3/Makefile
@@ -1,6 +1,7 @@
 .PHONY: install-requirements
 
 install-requirements:
+	rm -rf venv/
 	python3 -m venv venv
 	# the requirements are generated so that the packages
 	# could be downloaded and packaged up for the lambda


### PR DESCRIPTION
Sorry for bothering you so many times. 

There is a new error. I searched online, and it mentioned that venv already exist. I thought the venv would recreate every time in a clean environment when we trigger the CI/CD. It seems this is not the case. (I will spend time on understanding our GitHub runner later)

I will add the line `rm -rf venv/ `to remove the virtual environment if it exists (due to previous failures). If the venv does not exist, this line will not cause an error.

│ Error: local-exec provisioner error
│ 
│   with module.parking_eta_decision_records[0].module.import_file_from_g_drive.null_resource.run_install_requirements[0],
│   on ../modules/g-drive-to-s3/10-lambda.tf line 115, in resource "null_resource" "run_install_requirements":
│  115:   provisioner "local-exec" ***
│ 
│ Error running command 'make install-requirements': exit status 2. Output:
│ python3 -m venv venv
│ Error: [Errno 17] File exists:
│ '/home/runner/work/Data-Platform/Data-Platform/lambdas/g_drive_to_s3/venv'
│ make: *** [Makefile:4: install-requirements] Error 1
