### PR TITLE
fix venv creation issue

### DIFF
--- a/lambdas/g_drive_to_s3/Makefile
+++ b/lambdas/g_drive_to_s3/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install-requirements
 
 install-requirements:
-	rm -rf venv/
+	sudo apt-get install python3-venv
 	python3 -m venv venv
 	# the requirements are generated so that the packages
 	# could be downloaded and packaged up for the lambda


### PR DESCRIPTION
working with Tim to get this venv issue fixed. looks needs sudo install the python3-venv. see the URL https://askubuntu.com/questions/1268833/error-command-path-to-env-bin-python3-7-im-ensurepip-upgrade#:~:text=After%20this%3A%20python3.10%20%2Dm%20venv%20venv%20works%20fine!
