### PR TITLE
use layer instead of generating in virtual env

### DIFF
--- a/lambdas/g_drive_to_s3/main.py
+++ b/lambdas/g_drive_to_s3/main.py
@@ -8,7 +8,7 @@ from os import path, getenv, mkdir, listdir, rmdir, remove
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
 from oauth2client.service_account import ServiceAccountCredentials
-from dotenv import load_dotenv
+# from dotenv import load_dotenv
 from datetime import datetime
 
 
@@ -65,7 +65,7 @@ def run_glue_workflows():
             print(e)
 
 def lambda_handler(event, lambda_context):
-    load_dotenv()
+    # load_dotenv()
 
     google_service_account_credentials_secret_arn = getenv("GOOGLE_SERVICE_ACCOUNT_CREDENTIALS_SECRET_ARN")
 

--- a/terraform/modules/g-drive-to-s3/10-lambda.tf
+++ b/terraform/modules/g-drive-to-s3/10-lambda.tf
@@ -110,11 +110,11 @@ resource "null_resource" "run_install_requirements" {
     dir_sha1 = sha1(join("", [for f in fileset(path.module, "../../../lambdas/g_drive_to_s3/*") : filesha1("${path.module}/${f}")]))
   }
 
-  provisioner "local-exec" {
-    interpreter = ["bash", "-c"]
-    command     = "make install-requirements"
-    working_dir = "${path.module}/../../../lambdas/g_drive_to_s3/"
-  }
+#   provisioner "local-exec" {
+#     interpreter = ["bash", "-c"]
+#     command     = "make install-requirements"
+#     working_dir = "${path.module}/../../../lambdas/g_drive_to_s3/"
+#   }
 }
 
 resource "aws_s3_object" "g_drive_to_s3_copier_lambda" {
@@ -138,6 +138,7 @@ resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.g_drive_to_s3_copier_lambda.key
   source_code_hash = data.archive_file.lambda.output_base64sha256
+  layers           = ["arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:google-apis-layer:1"]
   timeout          = local.lambda_timeout
   memory_size      = local.lambda_memory_size
 


### PR DESCRIPTION
1.	Add a layer, which include OAuth2Client and Google-API-Python-Client.
2.	I have not deleted the Makefile, Pipfile, etc., since, if we don't use local-exec, they won't be triggered. If all works fine, we can delete them later.
3.	Comment out the import of dotenv, which is used to load the .env file into the environment; we don't need it.

Thanks again, Tim, for your discussion, ideas, and review.