### PR TITLE
use the specific verison of urllib3

### DIFF
--- a/terraform/modules/g-drive-to-s3/10-lambda.tf
+++ b/terraform/modules/g-drive-to-s3/10-lambda.tf
@@ -138,7 +138,9 @@ resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.g_drive_to_s3_copier_lambda.key
   source_code_hash = data.archive_file.lambda.output_base64sha256
-  layers           = ["arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:google-apis-layer:1"]
+  layers           = [
+    "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:urllib3-1-26-18-layer:1",
+    "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:layer:google-apis-layer:1"]
   timeout          = local.lambda_timeout
   memory_size      = local.lambda_memory_size
 


### PR DESCRIPTION
In staging, the lambda shows a version conflict error:
`urllib3 version 2 requires OpenSSL 1.1.1 or newer, but ours is 1.0.2k-fips`
use lower version urllib3 to solve the issue 