### PR TITLE
add permission and tidy up

### DIFF
--- a/terraform/etl/49-lambda-streetscene-ingestion.tf
+++ b/terraform/etl/49-lambda-streetscene-ingestion.tf
@@ -76,7 +76,7 @@ resource "aws_iam_policy" "streetscene_policies" {
 }
 
 # Assume Role Policy (a must for creating IAM roles)
-data "aws_iam_policy_document" "lambda_assume_role" {
+data "aws_iam_policy_document" "streetscene_lambda_assume_role" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {
@@ -90,7 +90,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 resource "aws_iam_role" "streetscene_street_systems_ingestion" {
   count              = local.create_street_systems_resource_count
   name               = "streetscene_street_systems_ingestion_lambda_role"
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.streetscene_lambda_assume_role.json
 }
 
 # Attach execution policies to the lambda role


### PR DESCRIPTION
I've addressed two tiny issues and spent some time tidying up the Terraform file, hoping to make it more user-friendly for our colleagues.
1. added `aws_lambda_permission `to invoke the Lambda function to resolve the issue Marta mentioned about CloudWatch not functioning as a trigger (a necessity for triggering Lambda functions).
2. changed the crawler name, which must be the same in both the Lambda and `aws_glue_crawler `block.
3. tidied up the massive permission block by using a nested map - this has made about 50 lines of code redundant.
4. attempted to add layer ARNs to the output and then use them. However, the issue is that in the ETL directory, there is no existing .tf file that references the `aws-lambda-layers` module, so I couldn't use the layer ARNs from its output. To simplify, I added a local variable.
5. did a little naming convention things, e.g. the lambda name because resource or module names are recommended to use snake_case.

I'm not 100% sure whether replacing "`arn:aws:lambda:eu-west-2:336392948345:layer:AWSSDKPandas-Python39:12`" with current account's layer called "`panas-2-1-4-layer`" is correct. I can't find the ID 336392948345 in any of my granted AWS account IDs. Could someone help me double-check?

Could you add your ideas or tweak the code directly to make it even more readable for other colleagues. Thank you.

