### PR TITLE
DPP-677 add linter to check changed python files

### DIFF
--- a/.github/workflows/flake8_linter_python_files.yml
+++ b/.github/workflows/flake8_linter_python_files.yml
@@ -1,0 +1,39 @@
+name: Lint Python Files - Flake8
+# flake8 to check the syntax of changed files but ingore E501 error (line too long)
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # Ensure the entire history is fetched
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    
+    - name: Install Flake8
+      run: pip install flake8
+      
+    - name: Get Changed Files
+      id: changed-files
+      uses: tj-actions/changed-files@v44
+      with:
+        files: |
+          **.py
+
+    - name: Lint Changed Python Files
+      if: steps.changed-files.outputs.any_changed == 'true'
+      run: |
+        CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
+        IFS=' ' read -r -a FILE_ARRAY <<< "$CHANGED_FILES"
+        for FILE in "${FILE_ARRAY[@]}"
+        do
+          flake8 $FILE --ignore=E501
+        done
+

--- a/.github/workflows/flake8_linter_python_files.yml
+++ b/.github/workflows/flake8_linter_python_files.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     
     - name: Install Flake8
       run: pip install flake8


### PR DESCRIPTION
- A linter has been created using Flake8 to check the syntax of changed files. It will check every new push/commit and only affect the changed files, not the entire repository.
- The E501 error (line too long) has been ignored, as it only permits 80 characters. Everyone has a slightly different style of commenting, which is not a significant issue for readability.
- The linter takes approximately 15-20 seconds (fast)to check a large Python file, based on testing.
- Through the linter, we can identify common Python syntax errors in advance rather than after deployment. For example, an error might occur before "Error message: NameError: name 'current_date' is not defined". There are also suggestions to improve the quality of our code.