### PR TITLE
create a new layer AWSSDKPandas (aka awswrangler)

### DIFF
--- a/lambdas/lambda_layers/requirements8.txt
+++ b/lambdas/lambda_layers/requirements8.txt
@@ -1,0 +1,1 @@
+awswrangler==3.7.2

--- a/terraform/core/44-lambda-layers.tf
+++ b/terraform/core/44-lambda-layers.tf
@@ -74,3 +74,14 @@ module "lambda_layer_7" {
   layer_name          = "s3fs-2023-12-2-layer"
   compatible_runtimes = ["python3.9"]
 }
+
+module "lambda_layer_8" {
+  count               = local.is_live_environment ? 1 : 0
+  source              = "../modules/aws-lambda-layers/"
+  lambda_name         = "lambda_layers"
+  tags                = module.tags.values
+  identifier_prefix   = local.short_identifier_prefix
+  layer_zip_file      = "layer8.zip"
+  layer_name          = "awswrangler-3-7-2-layer"
+  compatible_runtimes = ["python3.9"]
+}


### PR DESCRIPTION
This early PR (https://github.com/LBHackney-IT/Data-Platform/pull/1686) replaced arn:aws:lambda:eu-west-2:336392948345:layer:AWSSDKPandas-Python39:12 with panas-2-1-4-layer, which caused some issues when Marta used it in Lambda.

arn:aws:lambda:eu-west-2:336392948345:layer:AWSSDKPandas-Python39:12 is an AWS built-in layer managed by AWS on account 336392948345.
We can install this AWSSDKPandas (also known as awswrangler - https://github.com/aws/aws-sdk-pandas) as our own layer using Wayne's Lambda layer module.

This new PR installs such a layer for use with Lambda.