### PR TITLE
roll back the change  of new lambda layer AWSSDKPandas

### DIFF
--- a/lambdas/lambda_layers/requirements8.txt
+++ b/lambdas/lambda_layers/requirements8.txt
@@ -1,1 +1,0 @@
-awswrangler==3.7.2

--- a/terraform/core/44-lambda-layers.tf
+++ b/terraform/core/44-lambda-layers.tf
@@ -74,14 +74,3 @@ module "lambda_layer_7" {
   layer_name          = "s3fs-2023-12-2-layer"
   compatible_runtimes = ["python3.9"]
 }
-
-module "lambda_layer_8" {
-  count               = local.is_live_environment ? 1 : 0
-  source              = "../modules/aws-lambda-layers/"
-  lambda_name         = "lambda_layers"
-  tags                = module.tags.values
-  identifier_prefix   = local.short_identifier_prefix
-  layer_zip_file      = "layer8.zip"
-  layer_name          = "awswrangler-3-7-2-layer"
-  compatible_runtimes = ["python3.9"]
-}


### PR DESCRIPTION
I tried to create a new layer called AWSSDKPandas (also known as awswrangler), but its size is too large.


For detailed explanation, please see https://github.com/LBHackney-IT/Data-Platform/pull/1694