### PR TITLE
grant department write to landing g-drive paths

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -191,7 +191,7 @@ data "aws_iam_policy_document" "s3_department_access" {
     resources = [
       var.landing_zone_bucket.bucket_arn,
       "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/manual/*",
-      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/g-drive/*"
+      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/g-drive/*",
       "${var.landing_zone_bucket.bucket_arn}/unrestricted/*",
 
       var.raw_zone_bucket.bucket_arn,

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -191,6 +191,7 @@ data "aws_iam_policy_document" "s3_department_access" {
     resources = [
       var.landing_zone_bucket.bucket_arn,
       "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/manual/*",
+      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/g-drive/*"
       "${var.landing_zone_bucket.bucket_arn}/unrestricted/*",
 
       var.raw_zone_bucket.bucket_arn,


### PR DESCRIPTION
This will allow department users access to the g-drive path in landing zone so that they can manually upload files that were previously being retrieved from Google Drive. 

Needed to facilitate #1716 
