### PR TITLE
DPP-682 fix the compatibility issue of pandas layer

### DIFF
--- a/terraform/etl/49-lambda-streetscene-ingestion.tf
+++ b/terraform/etl/49-lambda-streetscene-ingestion.tf
@@ -124,9 +124,10 @@ module "street_systems_api_ingestion" {
   }
   layers = [
     # No where in the etl directory reference aws-lambda-layers module, so can't use layer ARNs from its output
-    # "strcontains" checks if the string layer contains the substring "arn:aws:". It returns true if the substring is found, and false otherwise
+    # "strcontains" doesn't support for current version Terraform, so use regex to checks if the string layer contains the substring "arn:aws:".
+    # It returns true if the substring is found, and false otherwise
     for layer in local.lambda_layers: 
-      strcontains(layer, "arn:aws:") ? 
+      can(regex("arn:aws:", layer)) ?
         layer : 
         "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.data_platform.account_id}:layer:${layer}:1"
   ]

--- a/terraform/etl/49-lambda-streetscene-ingestion.tf
+++ b/terraform/etl/49-lambda-streetscene-ingestion.tf
@@ -3,7 +3,8 @@ locals {
   traffic_counters_tables                = ["street-systems"] # more table names can be added here
   lambda_layers = [
   "requests-2-31-0-and-httplib-0-22-0-layer",
-  "panas-2-1-4-layer",
+  # AWS self-managed Pandas layer (aka awswrangler)
+  "arn:aws:lambda:eu-west-2:336392948345:layer:AWSSDKPandas-Python39:12",
   "s3fs-2023-12-2-layer",
   "urllib3-1-26-18-layer"
   ]
@@ -122,8 +123,12 @@ module "street_systems_api_ingestion" {
     CRAWLER_NAME     = "${local.short_identifier_prefix}Streetscene Street Systems Raw Zone"
   }
   layers = [
-    # no where in the etl directory reference aws-lambda-layers module, so can't use layer ARNs from its output
-    for layer in local.lambda_layers: "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.data_platform.account_id}:layer:${layer}:1"
+    # No where in the etl directory reference aws-lambda-layers module, so can't use layer ARNs from its output
+    # "contains" checks if the string layer contains the substring "arn:aws:". It returns true if the substring is found, and false otherwise
+    for layer in local.lambda_layers: 
+      contains(layer, "arn:aws:") ? 
+        layer : 
+        "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.data_platform.account_id}:layer:${layer}:1"
   ]
 }
 

--- a/terraform/etl/49-lambda-streetscene-ingestion.tf
+++ b/terraform/etl/49-lambda-streetscene-ingestion.tf
@@ -124,9 +124,9 @@ module "street_systems_api_ingestion" {
   }
   layers = [
     # No where in the etl directory reference aws-lambda-layers module, so can't use layer ARNs from its output
-    # "contains" checks if the string layer contains the substring "arn:aws:". It returns true if the substring is found, and false otherwise
+    # "strcontains" checks if the string layer contains the substring "arn:aws:". It returns true if the substring is found, and false otherwise
     for layer in local.lambda_layers: 
-      contains(layer, "arn:aws:") ? 
+      strcontains(layer, "arn:aws:") ? 
         layer : 
         "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.data_platform.account_id}:layer:${layer}:1"
   ]


### PR DESCRIPTION
The current pandas layer has compatibility issue with other layers. After discussion with Marta, we've realised we need to use the the AWS self-managed pandas layer called `arn:aws:lambda:eu-west-2:336392948345:layer:AWSSDKPandas-Python39:12 `(AWSSDKPandas).

I've tried to install it using our lambda module but it's too large, so I reference the AWS self-managed pandas directly in the terrafrom file.

Some merged PR related to this
https://github.com/LBHackney-IT/Data-Platform/pull/1695
https://github.com/LBHackney-IT/Data-Platform/pull/1694
https://github.com/LBHackney-IT/Data-Platform/pull/1686