### PR TITLE
Add output for lambda IAM role ARN in 99-outputs.tf

### DIFF
--- a/terraform/modules/aws-lambda/99-outputs.tf
+++ b/terraform/modules/aws-lambda/99-outputs.tf
@@ -8,6 +8,11 @@ output "lambda_iam_role" {
   value       = aws_iam_role.lambda_role.name
 }
 
+output "lambda_iam_role_arn" {
+  description = "arn of the lambda function iam role"
+  value       = aws_iam_role.lambda_role.arn
+}
+
 output "lambda_name" {
   description = "name of the lambda function"
   value       = aws_lambda_function.lambda.function_name


### PR DESCRIPTION
Outputs the ARN for the IAM role associated with the lambda