### PR TITLE
skip linting parking scripts

### DIFF
--- a/.github/workflows/flake8_linter_python_files.yml
+++ b/.github/workflows/flake8_linter_python_files.yml
@@ -32,8 +32,19 @@ jobs:
       run: |
         CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
         IFS=' ' read -r -a FILE_ARRAY <<< "$CHANGED_FILES"
+        IGNORED_PATHS=("scripts/jobs/parking/")
         for FILE in "${FILE_ARRAY[@]}"
         do
-          flake8 $FILE --ignore=E501
+          skip_file=false
+          for IGNORED_PATH in "${IGNORED_PATHS[@]}"
+          do
+            if [[ $FILE == *"$IGNORED_PATH"* ]]; then
+              skip_file=true
+              break
+            fi
+          done
+          if [ "$skip_file" = false ]; then
+            flake8 $FILE --ignore=E501
+          fi
         done
 


### PR DESCRIPTION
The linter will flag many minor errors in scripts created using the Glue console, generally whitespace and unused imports.

Parking users do not use a local IDE for python development so are unlikely to rectify these themselves and as a result will receive failure notifications whenever they make minor changes to old scripts. 

Although this can be done at the script level by including the flag `# flake8: noqa`, this would disable any local linter for a user who was using an IDE with linting functionality who might want to make these corrections. 

This is an example output which fails the linting because of unused imports present in the boilerplate code and other formatting errors from the Glue Studio console created script:
![image](https://github.com/LBHackney-IT/Data-Platform/assets/61045197/4d8f05d8-297c-43a6-b003-de686f69b3a6)

After some quick changes and using the Black formatter the linter will still fail because of these whitespace errors that exist in the generated SQL string:
![image](https://github.com/LBHackney-IT/Data-Platform/assets/61045197/5f6bc081-cfdb-441e-8ec8-39c26130c322)
