### PR TITLE
Add runtime variable

### DIFF
--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -33,7 +33,7 @@ module "copy_from_s3_to_s3_ft" {
   identifier_prefix              = local.identifier_prefix
   short_identifier_prefix        = local.short_identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage
-  runtime                        = "nodejs20.x"
+  runtime                        = "nodejs18.x"
   lambda_execution_cron_schedule = "cron(0 8 * * ? *)"
   origin_bucket                  = module.refined_zone
   origin_path                    = "housing/rentsense-ft/export/"

--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -33,6 +33,7 @@ module "copy_from_s3_to_s3_ft" {
   identifier_prefix              = local.identifier_prefix
   short_identifier_prefix        = local.short_identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage
+  runtime                        = "nodejs20.x"
   lambda_execution_cron_schedule = "cron(0 8 * * ? *)"
   origin_bucket                  = module.refined_zone
   origin_path                    = "housing/rentsense-ft/export/"

--- a/terraform/core/81-sync-rentsense-files.tf
+++ b/terraform/core/81-sync-rentsense-files.tf
@@ -33,7 +33,7 @@ module "copy_from_s3_to_s3_ft" {
   identifier_prefix              = local.identifier_prefix
   short_identifier_prefix        = local.short_identifier_prefix
   lambda_artefact_storage_bucket = module.lambda_artefact_storage
-  runtime                        = "nodejs18.x"
+  runtime                        = "nodejs16.x"
   lambda_execution_cron_schedule = "cron(0 8 * * ? *)"
   origin_bucket                  = module.refined_zone
   origin_path                    = "housing/rentsense-ft/export/"

--- a/terraform/modules/copy-from-s3-to-s3/00-init.tf
+++ b/terraform/modules/copy-from-s3-to-s3/00-init.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform/modules/copy-from-s3-to-s3/00-init.tf
+++ b/terraform/modules/copy-from-s3-to-s3/00-init.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.11"
+      version = "~> 5.11"
     }
   }
 }

--- a/terraform/modules/copy-from-s3-to-s3/00-init.tf
+++ b/terraform/modules/copy-from-s3-to-s3/00-init.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 4.11"
     }
   }
 }

--- a/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
+++ b/terraform/modules/copy-from-s3-to-s3/02-inputs-optional.tf
@@ -10,3 +10,8 @@ variable "lambda_execution_cron_schedule" {
   default     = "cron(0 9 * * ? *)"
 }
 
+variable "runtime" {
+  description = "The runtime to use for the Lambda"
+  type        = string
+  default     = "nodejs14.x"
+}

--- a/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
+++ b/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
@@ -87,7 +87,7 @@ data "aws_iam_policy_document" "copy_from_s3_to_s3_lambda" {
 resource "aws_iam_policy" "copy_from_s3_to_s3_lambda" {
   tags = var.tags
 
-  name   = lower("${var.identifier_prefix}-copy-from-s3-to-s3-lambda")
+  name   = lower("${var.identifier_prefix}-${var.lambda_name}-lambda")
   policy = data.aws_iam_policy_document.copy_from_s3_to_s3_lambda.json
 }
 
@@ -122,12 +122,12 @@ locals {
 data "archive_file" "lambda_source_code" {
   type        = "zip"
   source_dir  = local.source_dir
-  output_path = "${path.module}/copy-from-s3-to-s3.zip"
+  output_path = "${path.module}/${var.lambda_name}.zip"
 }
 
 resource "aws_s3_object" "copy_from_s3_to_s3_lambda" {
   bucket      = var.lambda_artefact_storage_bucket.bucket_id
-  key         = "copy-from-s3-to-s3.zip"
+  key         = "${var}.zip"
   source      = data.archive_file.lambda_source_code.output_path
   acl         = "private"
   source_hash = data.archive_file.lambda_source_code.output_md5
@@ -141,7 +141,7 @@ resource "aws_lambda_function" "copy_from_s3_to_s3_lambda" {
 
   role             = aws_iam_role.copy_from_s3_to_s3.arn
   handler          = "index.handler"
-  runtime          = "nodejs14.x"
+  runtime          = var.runtime
   function_name    = "${var.identifier_prefix}-${var.lambda_name}"
   s3_bucket        = var.lambda_artefact_storage_bucket.bucket_id
   s3_key           = aws_s3_object.copy_from_s3_to_s3_lambda.key


### PR DESCRIPTION
The module hardcoded a deprecated version of nodejs. This PR allows an optional variable that keeps the existing Lambda as is but allows the new lambda to be deployed with the recommended version of nodejs.

Includes name dedupe changes from #1735 