### PR TITLE
fix iam policy deplicate name s3-to-s3 lambda

### DIFF
--- a/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
+++ b/terraform/modules/copy-from-s3-to-s3/10-lambda.tf
@@ -84,10 +84,12 @@ data "aws_iam_policy_document" "copy_from_s3_to_s3_lambda" {
   }
 }
 
+resource "random_uuid" "lambda_uuid" {}
+
 resource "aws_iam_policy" "copy_from_s3_to_s3_lambda" {
   tags = var.tags
 
-  name   = lower("${var.identifier_prefix}-copy-from-s3-to-s3-lambda")
+  name   = "${lower("${var.identifier_prefix}-copy-from-s3-to-s3-lambda-${random_uuid.lambda_uuid.result}")}"
   policy = data.aws_iam_policy_document.copy_from_s3_to_s3_lambda.json
 }
 


### PR DESCRIPTION
we have this error"│ Error: creating IAM Policy (***-copy-from-s3-to-s3-lambda): EntityAlreadyExists: A policy called ***-copy-from-s3-to-s3-lambda already exists. Duplicate names are not allowed.", which shows up recently.

I am using a UUID to have a quick fix, it will avoid deplicated names. however, it will recreate a new policy each time changes are applied. so it's not the best solution, but it's a quick fix.