### PR TITLE
disable spark and lambda artefact buckets versioning and expire in 60 days

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -388,6 +388,8 @@ module "lambda_artefact_storage" {
   identifier_prefix = local.identifier_prefix
   bucket_name       = "Lambda Artefact Storage"
   bucket_identifier = "dp-lambda-artefact-storage"
+  versioning_enabled = false
+  expire_objects_days = 60  
 }
 
 module "spark_ui_output_storage" {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -398,6 +398,8 @@ module "spark_ui_output_storage" {
   identifier_prefix = local.identifier_prefix
   bucket_name       = "Spark UI Storage"
   bucket_identifier = "spark-ui-output-storage"
+  versioning_enabled = false
+  expire_objects_days = 60
 }
 
 # This bucket is used for storing certificates used in Looker Studio connections.

--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -124,3 +124,16 @@ variable "bucket_key_policy_statements" {
 
   default = []
 }
+
+
+variable "versioning_enabled" {
+  description = "Enable versioning for the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "expire_objects_days" {
+  description = "Number of days after which to expire objects. Set to null to disable."
+  type        = number
+  default     = null
+}

--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -124,8 +124,22 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
 resource "aws_s3_bucket_versioning" "bucket" {
   bucket = aws_s3_bucket.bucket.id
   versioning_configuration {
-    status     = "Enabled"
+    status = var.versioning_enabled ? "Enabled" : "Suspended"
     mfa_delete = "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
+  count  = var.expire_objects_days != null ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    id     = "expire-older-objects"
+    status = "Enabled"
+
+    expiration {
+      days = var.expire_objects_days
+    }
   }
 }
 


### PR DESCRIPTION
Create two variables to allow a bucket enable (as default) or disable versioning. Also, allow data older than certain days to be deleted.

> [Disabled ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning#:~:text=should%20only%20be%20used%20when%20creating%20or%20importing%20resources%20that%20correspond%20to%20unversioned%20S3%20buckets.)should only be used when creating or importing resources that correspond to unversioned S3 buckets.

So the "Disabled" is replaced by "Suspended" for an existing versioning bucket.

Using bucket "Spark UI Storage" and "lambda artefact" as the use case.