### PR TITLE
delete non current versions and imcomplete multipart uploads

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -390,6 +390,8 @@ module "lambda_artefact_storage" {
   bucket_identifier = "dp-lambda-artefact-storage"
   versioning_enabled = false
   expire_objects_days = 60  
+  expire_noncurrent_objects_days = 30
+  abort_multipart_days = 30  
 }
 
 module "spark_ui_output_storage" {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -402,6 +402,8 @@ module "spark_ui_output_storage" {
   bucket_identifier = "spark-ui-output-storage"
   versioning_enabled = false
   expire_objects_days = 60
+  expire_noncurrent_objects_days = 30
+  abort_multipart_days = 30
 }
 
 # This bucket is used for storing certificates used in Looker Studio connections.

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -389,9 +389,6 @@ module "lambda_artefact_storage" {
   bucket_name       = "Lambda Artefact Storage"
   bucket_identifier = "dp-lambda-artefact-storage"
   versioning_enabled = false
-  expire_objects_days = 60  
-  expire_noncurrent_objects_days = 30
-  abort_multipart_days = 30  
 }
 
 module "spark_ui_output_storage" {

--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -137,3 +137,17 @@ variable "expire_objects_days" {
   type        = number
   default     = null
 }
+
+
+variable "expire_noncurrent_objects_days" {
+  description = "Number of days after which to permanently delete noncurrent versions of objects, set to null to disable by default"
+  type        = number
+  default     = null
+}
+
+variable "abort_multipart_days" {
+  description = "Number of days after which to abort incomplete multipart uploads, set to null to disable by default"
+  type        = number
+  default     = null
+}
+

--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -140,6 +140,15 @@ resource "aws_s3_bucket_lifecycle_configuration" "bucket" {
     expiration {
       days = var.expire_objects_days
     }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.expire_noncurrent_objects_days
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.abort_multipart_days
+    }
+
   }
 }
 


### PR DESCRIPTION
Added `expire_noncurrent_objects_days `to delete the noncurrent versions of objects. The previous PR (https://github.com/LBHackney-IT/Data-Platform/pull/1750) created `expire_objects_days`, which only takes effect on the current version.

`abort_multipart_days `is for deleting some incomplete uploaded files, which are uncommon, but it is beneficial to have this variable here.

So, with these four variables, we can now completely manage the versioning and deletion of any S3 bucket.