### PR TITLE
new - create mwaa

### DIFF
--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -3,6 +3,7 @@ Feature: S3
   @exclude_aws_s3_bucket.ssl_connection_resources\[0\]
   @exclude_module.qlik_server\[0\].aws_s3_bucket.qlik_alb_logs\[0\]
   @exclude_module.airflow.aws_s3_bucket.bucket
+  @exclude_module.mwaa_bucket.aws_s3_bucket.bucket
   Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource
     Given I have aws_s3_bucket defined
     Then it must have server_side_encryption_configuration
@@ -23,7 +24,7 @@ Feature: S3
   @exclude_module.kafka_event_streaming\[0\].module.kafka_dependency_storage.aws_s3_bucket.bucket
   @exclude_module.db_snapshot_to_s3\[0\].module.rds_export_storage.aws_s3_bucket.bucket
   @exclude_module.liberator_dump_to_rds_snapshot\[0\].aws_s3_bucket.cloudtrail
-  @exclude_module.liberator_db_snapshot_to_s3\[0\].module.rds_export_storage.aws_s3_bucket.bucket 
+  @exclude_module.liberator_db_snapshot_to_s3\[0\].module.rds_export_storage.aws_s3_bucket.bucket
   Scenario: Data must be encrypted at rest for buckets created using separate server side configuration resource
     Given I have aws_s3_bucket defined
     Then it must have aws_s3_bucket_server_side_encryption_configuration

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -381,39 +381,50 @@ module "athena_storage" {
 }
 
 module "lambda_artefact_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Lambda Artefact Storage"
-  bucket_identifier = "dp-lambda-artefact-storage"
+  source             = "../modules/s3-bucket"
+  tags               = module.tags.values
+  project            = var.project
+  environment        = var.environment
+  identifier_prefix  = local.identifier_prefix
+  bucket_name        = "Lambda Artefact Storage"
+  bucket_identifier  = "dp-lambda-artefact-storage"
   versioning_enabled = false
 }
 
 module "airflow" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "airflow"
-  bucket_identifier = "airflow"
+  source             = "../modules/s3-bucket"
+  tags               = module.tags.values
+  project            = var.project
+  environment        = var.environment
+  identifier_prefix  = local.identifier_prefix
+  bucket_name        = "airflow"
+  bucket_identifier  = "airflow"
+  versioning_enabled = false
+}
+
+module "mwaa_bucket" {
+  source             = "../modules/s3-bucket"
+  tags               = module.tags.values
+  project            = var.project
+  environment        = var.environment
+  identifier_prefix  = local.identifier_prefix
+  bucket_name        = "mwaa"
+  bucket_identifier  = "mwaa"
   versioning_enabled = false
 }
 
 module "spark_ui_output_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Spark UI Storage"
-  bucket_identifier = "spark-ui-output-storage"
-  versioning_enabled = false
-  expire_objects_days = 60
+  source                         = "../modules/s3-bucket"
+  tags                           = module.tags.values
+  project                        = var.project
+  environment                    = var.environment
+  identifier_prefix              = local.identifier_prefix
+  bucket_name                    = "Spark UI Storage"
+  bucket_identifier              = "spark-ui-output-storage"
+  versioning_enabled             = false
+  expire_objects_days            = 60
   expire_noncurrent_objects_days = 30
-  abort_multipart_days = 30
+  abort_multipart_days           = 30
 }
 
 # This bucket is used for storing certificates used in Looker Studio connections.

--- a/terraform/core/42-mwaa.tf
+++ b/terraform/core/42-mwaa.tf
@@ -59,7 +59,10 @@ resource "aws_iam_role_policy" "mwaa_role_policy" {
           "s3:GetBucketPublicAccessBlock"
         ],
         Effect   = "Allow",
-        Resource = "*"
+        Resource = [
+          module.mwaa_bucket.bucket_arn,
+          "${module.mwaa_bucket.bucket_arn}/*"
+        ]
       }
     ]
   })

--- a/terraform/core/42-mwaa.tf
+++ b/terraform/core/42-mwaa.tf
@@ -1,0 +1,155 @@
+resource "aws_iam_role" "mwaa_role" {
+  name = "mwaa_execution_role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "airflow-env.amazonaws.com"
+        }
+      }
+    ]
+  })
+  tags = module.tags.values
+}
+
+resource "aws_iam_role_policy" "mwaa_role_policy" {
+  name = "mwaa_role_policy"
+  role = aws_iam_role.mwaa_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:PutObject"
+        ],
+        Effect = "Allow",
+        Resource = [
+          module.mwaa_bucket.bucket_arn,
+          "${module.mwaa_bucket.bucket_arn}/*"
+        ]
+      },
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Effect   = "Allow",
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Action = [
+          "iam:PassRole"
+        ],
+        Effect   = "Allow",
+        Resource = aws_iam_role.mwaa_role.arn
+      },
+      {
+        Action = [
+          "s3:GetAccountPublicAccessBlock",
+          "s3:PutAccountPublicAccessBlock",
+          "s3:PutBucketPublicAccessBlock",
+          "s3:GetBucketPublicAccessBlock"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Security group for MWAA to allow HTTPS traffic on port 443 and all outbound traffic
+# We definate refine it to limit the traffic later (let's keep it simple for now)
+resource "aws_security_group" "mwaa_sg" {
+  name        = "mwaa_sg"
+  description = "Security group for MWAA"
+  vpc_id      = data.aws_vpc.network.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  #   egress {
+  #     from_port   = 0
+  #     to_port     = 0
+  #     protocol    = "-1"
+  #     cidr_blocks = ["0.0.0.0/0"]
+  #   }
+  tags = module.tags.values
+}
+
+
+# Create a placeholder file in the S3 bucket, S3 does not support the creation of empty folders
+# To ensure the folders are created otherwise the MWAA environment will fail to create
+resource "aws_s3_bucket_object" "plugins_placeholder" {
+  bucket  = module.mwaa_bucket.bucket_id
+  key     = "plugins/.placeholder"
+  content = ""
+}
+
+resource "aws_s3_bucket_object" "dags_placeholder" {
+  bucket  = module.mwaa_bucket.bucket_id
+  key     = "dags/.placeholder"
+  content = ""
+}
+
+resource "aws_s3_bucket_object" "requirements_placeholder" {
+  bucket  = module.mwaa_bucket.bucket_id
+  key     = "requirements/requirements.txt"
+  content = ""
+}
+
+resource "aws_mwaa_environment" "mwaa" {
+  name               = "data_platform_mwaa_environment"
+  airflow_version    = "2.8.1" # Preinstall python 3.11
+  environment_class  = "mw1.small"
+  execution_role_arn = aws_iam_role.mwaa_role.arn
+  source_bucket_arn  = module.mwaa_bucket.bucket_arn
+  dag_s3_path        = "dags"
+  #   plugins_s3_path      = "plugins"
+  requirements_s3_path = "requirements/requirements.txt"
+  network_configuration {
+    security_group_ids = [aws_security_group.mwaa_sg.id]
+    subnet_ids         = slice(data.aws_subnets.network.ids, 0, 2) # Must contain no more than 2 subnet IDs.
+  }
+  logging_configuration {
+    dag_processing_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+    scheduler_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+    task_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+    webserver_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+    worker_logs {
+      enabled   = true
+      log_level = "INFO"
+    }
+  }
+  # default is PRIVATE_ONLY
+  # to view the Airflow UI, set this to PUBLIC_ONLY or create a mechanism to access the VPC endpoint
+  # https://docs.aws.amazon.com/mwaa/latest/userguide/t-create-update-environment.html#t-network-failure
+  webserver_access_mode = "PUBLIC_ONLY"
+  max_workers           = 5
+  min_workers           = 1
+  kms_key               = module.mwaa_bucket.kms_key_arn
+  tags                  = module.tags.values
+}


### PR DESCRIPTION
An official PR has been submitted. The same code, when I tested it on the `DataPlatform-Development` account through my local development AWS profile, failed with the following error (details see the [draft PR](https://github.com/LBHackney-IT/Data-Platform/pull/1762)):

> Error: waiting for MWAA Environment (data_platform_mwaa_environment) create: unexpected state 'CREATE_FAILED', wanted target 'AVAILABLE'. last error: INCORRECT_CONFIGURATION: You may need to check the execution role permissions policy for your environment, and that each of the VPC networking components required by the environment are configured to allow traffic. Troubleshooting: https://docs.aws.amazon.com/mwaa/latest/userguide/troubleshooting.html

However, as you can see, it works well through our repo, so let me deploy it through our GitHub action.

