### PR TITLE
ignore parking file changes when linting

### DIFF
--- a/.github/workflows/flake8_linter_python_files.yml
+++ b/.github/workflows/flake8_linter_python_files.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         files: |
           **.py
+        files_ignore: |
+          scripts/jobs/parking/**/*.py
 
     - name: Lint Changed Python Files
       if: steps.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
supersedes #1734 

**copied from previous PR:**
The linter will flag many minor errors in scripts created using the Glue console, generally whitespace and unused imports.

Parking users do not use a local IDE for python development so are unlikely to rectify these themselves and as a result will receive failure notifications whenever they make minor changes to old scripts.

Although this can be done at the script level by including the flag # flake8: noqa, this would disable any local linter for a user who was using an IDE with linting functionality who might want to make these corrections.

This is an example output which fails the linting because of unused imports present in the boilerplate code and other formatting errors from the Glue Studio console created script:

![image](https://github.com/LBHackney-IT/Data-Platform/assets/61045197/ccaf571c-dce1-4429-9d1c-1afa21bbda57)

After some quick changes and using the Black formatter the linter will still fail because of these whitespace errors that exist in the generated SQL string:
![image](https://github.com/LBHackney-IT/Data-Platform/assets/61045197/c9258253-65dd-4ade-aaa1-e5f803fbbf99)
