### PR TITLE
pin alpine version to 3.19

### DIFF
--- a/docker/pre-production-data-cleanup/Dockerfile
+++ b/docker/pre-production-data-cleanup/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.19
 
 RUN apk add --update --no-cache \
     bash \


### PR DESCRIPTION
Alpine 3.20 removed the aws-cli tool because of incompatibility with python version 3.12

See issue: https://github.com/alpinelinux/docker-alpine/issues/396