### PR TITLE
change some configurations

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -183,4 +183,11 @@ resource "aws_mwaa_environment" "mwaa" {
   schedulers            = 2             # Must be between 2 and 5
   kms_key               = aws_kms_key.mwaa_key.arn
   tags                  = module.tags.values
+
+  airflow_configuration_options = {
+    "core.default_timezone"               = "utc"
+    "webserver.warn_deployment_exposure"  = "False"
+    "webserver.auto_refresh"              = "True"
+    "scheduler.min_file_process_interval" = "180"
+  }
 }


### PR DESCRIPTION
1. Specify UTC - there is currently a one-hour difference with UK summer time. - Hey @timburke-hackit how's the scheduler timezone used in other services - want to keep it the same? Do we use London time somewhere?
2. Disable the warning message on the banner of Airflow UI - the cloud engineering team will manage traffic (Matt and Wayne have noted the security group config).
![image](https://github.com/LBHackney-IT/Data-Platform/assets/38001883/2f2c60ab-f0b0-4ae5-a02e-8356c871ebfa)
4. Enable auto-refresh - to avoid the need for manual refreshing.
5. Reduce the min_file_process_interval to 3 minutes - this will reduce our waiting time for testing new DAGs.