### PR TITLE
add MWAA requirements to source control

### DIFF
--- a/mwaa/requirements.txt
+++ b/mwaa/requirements.txt
@@ -1,0 +1,12 @@
+# It is essential to maintain the constraint for our version.
+# If the specified version conflicts with the constrained one, it will automatically replace it with the constrained version.
+--constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.8.1/constraints-3.11.txt"
+
+apache-airflow-providers-amazon==8.20.0
+apache-airflow-providers-mysql==5.6.0
+boto3==1.34.69
+redshift-connector==2.1.0
+requests==2.27.1
+pandas==2.0.3 #latest which can be found
+scikit-learn==1.3.2 # latest
+pysftp==0.2.8

--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -132,10 +132,11 @@ resource "aws_s3_bucket_object" "dags_placeholder" {
   content = ""
 }
 
-resource "aws_s3_bucket_object" "requirements_placeholder" {
-  bucket  = aws_s3_bucket.mwaa_bucket.bucket
-  key     = "requirements/.placeholder"
-  content = ""
+resource "aws_s3_object" "requirements" {
+  bucket      = aws_s3_bucket.mwaa_bucket.bucket
+  key         = "requirements/requirements.txt"
+  source      = "${path.module}/../../mwaa/requirements.txt"
+  source_hash = filebase64sha256("${path.module}/../../mwaa/requirements.txt")
 }
 
 resource "aws_mwaa_environment" "mwaa" {


### PR DESCRIPTION
Adds the requirements file to the repository. This is the same as was in s3 with the addition of the mysql provider.

Includes terraform to create the object in s3. 