### PR TITLE
let airflow parse connection id from secrete manager

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -82,6 +82,13 @@ resource "aws_iam_role_policy" "mwaa_role_policy" {
           "kms:Encrypt"
         ],
         Resource = aws_kms_key.mwaa_key.arn
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Resource = ["arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/connections/*"]
       }
     ]
   })
@@ -190,5 +197,11 @@ resource "aws_mwaa_environment" "mwaa" {
     "webserver.warn_deployment_exposure"  = "False"
     "webserver.auto_refresh"              = "True"
     "scheduler.min_file_process_interval" = "180"
+    "secrets.backend"                     = "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend"
+    "secrets.backend_kwargs" = jsonencode({
+      "connections_prefix" : "airflow/connections",
+      "variables_prefix" : "airflow/variables",
+      "config_prefix" : "airflow/config"
+    })
   }
 }


### PR DESCRIPTION
1) The prefix in the secret manager starts with "`airflow/connections`". For example, it must be "airflow/connections/dataplatform_aws_default". No additional prefix is allowed between "dataplatform_aws_default" and "airflow/connections". "dataplatform_aws_default" will be used as the aws_conn_id for Airflow operators, e.g. `aws_conn_id='dataplatform_aws_default'`. The dag will use this "dataplatform_aws_default" to perform additional tasks.

2) Add permission for MWAA to access the credentials in the secret manager with the prefix "airflow/connections", (Not strictly followed the permissions [recommended ](https://docs.aws.amazon.com/mwaa/latest/userguide/connections-secrets-manager.html)by AWS, but it works fine over my test)

The main logic can be found in this [doc](https://airflow.apache.org/docs/apache-airflow-providers-amazon/7.4.0/secrets-backends/aws-secrets-manager.html).