### PR TITLE
Update 08-google-sheets-imports.tf

### DIFF
--- a/terraform/etl/08-google-sheets-imports.tf
+++ b/terraform/etl/08-google-sheets-imports.tf
@@ -765,6 +765,6 @@ module "nas_live_manual_updates_data_load" {
   google_sheets_worksheet_name    = "nas_live_manual_updates_data_load"
   department                      = module.department_parking_data_source
   dataset_name                    = "nas_live_manual_updates_data_load"
-  google_sheet_import_schedule    = "cron(0 6 ? * * *)"
+  google_sheet_import_schedule    = "cron(0 4 ? * * *)"
   spark_ui_output_storage_id      = module.spark_ui_output_storage_data_source.bucket_id
 }


### PR DESCRIPTION
changed time for job to run for module "nas_live_manual_updates_data_load" as it was affecting dependent job output having been based on two different source import_dates instead of one.  PCN normalised data is starting to run/finish earlier since April 2024 which has impacted when the google import is available after the majority of the time.