### PR TITLE
allow mwaa to acess variables and config

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -88,7 +88,11 @@ resource "aws_iam_role_policy" "mwaa_role_policy" {
         Action = [
           "secretsmanager:GetSecretValue"
         ],
-        Resource = ["arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/connections/*"]
+        Resource = [
+          "arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/connections/*",
+          "arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/variables/*",
+          "arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/config/*"
+        ]
       }
     ]
   })


### PR DESCRIPTION
I spent about 2 hour debugging why MWAA could not use -Variable I stored in secret manager, regardless of whether I used `Variable.get("env")` or `Variable.get("airflow/variables/env")`. I thought it's the configure of MWAA - After extensive searching on it, I finally discovered it's not. Only because MWAA does not permit access to the secrets manager under the prefix "airflow/variables". As simple as this :face_with_spiral_eyes:!