### PR TITLE
allow airflow dept user to pass role to dept glue agent

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -831,6 +831,17 @@ data "aws_iam_policy_document" "airflow_base_policy" {
     # This can be refined later but not urgent
     resources = ["*"]
   }
+
+  statement {
+    sid    = "DepartmentPassRole"
+    effect = "Allow"
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = [
+      aws_iam_role.glue_agent.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "airflow_base_policy" {


### PR DESCRIPTION
The airflow department user needs to be able to pass the equivalent department Glue role so that it can invoke resources like Glue Crawlers.

This PR allows, for example, the housing airflow user to pass the housing glue role when invoking a Glue crawler. 