### PR TITLE
add additional Glue actions

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -800,6 +800,8 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "glue:GetCrawlerMetrics",
       "glue:GetCrawlers",
       "glue:GetDatabase",
+      "glue:GetTable",
+      "glue:GetPartitions",
       "glue:ListCrawlers",
       "glue:StartCrawler",
       "glue:StopCrawler",


### PR DESCRIPTION
Grants Airflow users the ability to get tables and partitions from the Glue data catalog.