### PR TITLE
change the way for encryption

### DIFF
--- a/terraform/core/46-mwaa-bucket-kms.tf
+++ b/terraform/core/46-mwaa-bucket-kms.tf
@@ -66,23 +66,26 @@ resource "aws_kms_alias" "mwaa_key_alias" {
 resource "aws_s3_bucket" "mwaa_bucket" {
   bucket = "${local.identifier_prefix}-mwaa-bucket"
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = aws_kms_key.mwaa_key.arn
-      }
-    }
-  }
-
   tags = module.tags.values
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "mwaa_bucket_encryption" {
+  bucket = aws_s3_bucket.mwaa_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "aws:kms"
+      kms_master_key_id = aws_kms_key.mwaa_key.arn
+    }
+    bucket_key_enabled = true
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "mwaa_bucket_block" {
   bucket = aws_s3_bucket.mwaa_bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
-  ignore_public_acls  = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
   restrict_public_buckets = true
 }


### PR DESCRIPTION
the server_side_encryption_configuration has been deprecated ([URL](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket)) - change to the new way to stop the warning message.
