### PR TITLE
set default maintenance window for Redshift

### DIFF
--- a/terraform/modules/redshift/02-inputs-optional.tf
+++ b/terraform/modules/redshift/02-inputs-optional.tf
@@ -3,3 +3,9 @@ variable "additional_iam_roles" {
   type        = list(string)
   default     = []
 }
+
+variable "preferred_maintenance_window" {
+  description = "The weekly time range (in UTC) during which automated cluster maintenance can occur"
+  type        = string
+  default     = "sun:02:00-sun:03:00"
+}

--- a/terraform/modules/redshift/10-redshift.tf
+++ b/terraform/modules/redshift/10-redshift.tf
@@ -101,6 +101,7 @@ resource "aws_redshift_cluster" "redshift_cluster" {
   publicly_accessible          = false
   final_snapshot_identifier    = "${var.identifier_prefix}-redshift-cluster-final"
   vpc_security_group_ids       = [aws_security_group.redshift_cluster_security_group.id]
+  preferred_maintenance_window = var.preferred_maintenance_window
   tags                         = var.tags
 }
 


### PR DESCRIPTION
Sets a default value for the maintenance window of the Redshift clusters for Sundays 2-3am (UTC). Was previously Thursday 6.30pm. 