### PR TITLE
refine the permission of mwaa and department user

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -96,6 +96,17 @@ resource "aws_iam_role_policy" "mwaa_role_policy" {
           "arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/variables/*",
           "arn:aws:secretsmanager:${var.aws_deploy_region}:${var.aws_deploy_account_id}:secret:airflow/config/*"
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ecs:*"
+        ],
+        Resource = [
+          "arn:aws:ecs:${var.aws_deploy_region}:${var.aws_deploy_account_id}:task/*",
+          "arn:aws:ecs:${var.aws_deploy_region}:${var.aws_deploy_account_id}:task-definition/*",
+          "arn:aws:ecs:${var.aws_deploy_region}:${var.aws_deploy_account_id}:cluster/*"
+        ]
       }
     ]
   })

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -805,24 +805,26 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "logs:GetQueryResults",
       "logs:DescribeLogGroups"
     ]
-    resources = ["arn:aws:logs:*"]
+    resources = ["*"]
   }
 
   statement {
     sid    = "AirflowGluePolicy"
     effect = "Allow"
     actions = [
-      "glue:GetCrawler",
-      "glue:GetCrawlerMetrics",
-      "glue:GetCrawlers",
-      "glue:GetDatabase",
+      "glue:UpdateCrawlerSchedule",
+      "glue:UpdateCrawler",
+      "glue:StopCrawler",
+      "glue:StartCrawler",
+      "glue:ListCrawlers",
       "glue:GetTable",
       "glue:GetPartitions",
-      "glue:ListCrawlers",
-      "glue:StartCrawler",
-      "glue:StopCrawler",
-      "glue:UpdateCrawler",
-      "glue:UpdateCrawlerSchedule",
+      "glue:GetDatabase",
+      "glue:GetCrawlers",
+      "glue:GetCrawlerMetrics",
+      "glue:GetCrawler",
+      "glue:CreateTable",
+      "glue:DeleteTable"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This PR is related to https://github.com/LBHackney-IT/dap-airflow/pull/64, mainly to add:
- permission to the departmental user to drop tables 
- permission to manage ecs jobs via mwaa


 btw, revised "arn:aws:logs:*" which reminds a syntax error on the console


