### PR TITLE
ecs permission to departmental base policy

### DIFF
--- a/terraform/modules/department/03-input-derived.tf
+++ b/terraform/modules/department/03-input-derived.tf
@@ -4,3 +4,5 @@ locals {
 }
 
 data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -852,6 +852,19 @@ data "aws_iam_policy_document" "airflow_base_policy" {
     # This can be refined later but not urgent
     resources = ["*"]
   }
+
+  statement {
+    sid    = "AirflowEcsPolicy"
+    effect = "Allow"
+    actions = [
+      "ecs:*"
+    ]
+    resources = [
+      "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task/*",
+      "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:task-definition/*",
+      "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "airflow_base_policy" {


### PR DESCRIPTION
> An error occurred (AccessDeniedException) when calling the RunTask operation: User: arn:aws:iam::120038763019:user/child-fam-services-airflow-user is not authorized to perform: ecs:RunTask on resource: arn:aws:ecs:eu-west-2:120038763019:task-definition/a_test_task:9 because no identity-based policy allows the ecs:RunTask action

a... Receiving an error without granting the departmental base policy with the ECS permission. (not sure how it works when I tested yesterday)

Adding the permission to departmental user
