### PR TITLE
add passrole policy

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -865,6 +865,17 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/*"
     ]
   }
+
+  statement {
+    sid    = "AirflowPassRolePolicy"
+    effect = "Allow"
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "airflow_base_policy" {

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -873,8 +873,14 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "iam:PassRole"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
+      # A temporary solution (using mannually created role - test_hackney_ecs), we should replace with the actual terrafomed ecs task role
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/test_hackney_ecs"
     ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 


### PR DESCRIPTION
> botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the RunTask operation: User: arn:aws:iam::120038763019:user/child-fam-services-airflow-user is not authorized to perform: iam:PassRole on resource: arn:aws:iam::120038763019:role/test_hackney_ecs because no identity-based policy allows the iam:PassRole action

A passrole error to run the ingestion in ecs, after I've manually added below permission (see screenshot) and test it again, the ingestion task works well now. No more issue. I am sorry for changing a few times.

![image](https://github.com/LBHackney-IT/Data-Platform/assets/38001883/9c6dbdff-5850-4bfd-9f8f-586d17e10148)
