### PR TITLE
two new permissons

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -820,10 +820,12 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "glue:GetTable",
       "glue:GetPartitions",
       "glue:GetDatabase",
+      "glue:GetDatabases",
       "glue:GetCrawlers",
       "glue:GetCrawlerMetrics",
       "glue:GetCrawler",
       "glue:CreateTable",
+      "glue:UpdateTable",
       "glue:DeleteTable"
     ]
     resources = ["*"]


### PR DESCRIPTION
> ERROR - Failed to execute job 3161 for task create_views_for_latest_partition (Query failed with state: FAILED, reason: User: arn:aws:iam::120038763019:user/child-fam-services-airflow-user is not authorized to perform: glue:UpdateTable on resource: arn:aws:glue:eu-west-2:120038763019:catalog because no identity-based policy allows the glue:UpdateTable action (Service: AmazonDataCatalog; Status Code: 400; Error Code: AccessDeniedException;

> Exception: Query failed with state: FAILED, reason: User: arn:aws:iam::120038763019:user/child-fam-services-airflow-user is not authorized to perform: glue:GetDatabases on resource: arn:aws:glue:eu-west-2:120038763019:catalog because no identity-based policy allows the glue:GetDatabases action (Service: AmazonDataCatalog; Status Code: 400; Error Code: AccessDeniedException; Request ID: 07741cef-f9e3-4025-aaaf-02f7cdaa958c; Proxy: null)


add two permissions to fix two errors over testing for ticket [183](https://hackney.atlassian.net/browse/DPF-183)
"glue:GetDatabases", - 
"glue:UpdateTable",

We have glue:GetDatabase, but this requires the permission glue:GetDatabases.