### PR TITLE
chore: add S3Backup tag

### DIFF
--- a/terraform/backend-setup/10-aws-s3-buckets.tf
+++ b/terraform/backend-setup/10-aws-s3-buckets.tf
@@ -7,7 +7,7 @@ resource "aws_kms_key" "kms_key" {
 }
 
 resource "aws_s3_bucket" "terraform_state_storage" {
-  tags = module.tags.values
+  tags = merge(module.tags.values, { S3Backup = true })
 
   bucket = lower("${var.project}-terraform-state")
 


### PR DESCRIPTION
This PR adds the S3Backup = true tag set to any terraform state buckets created via this repo. 

Adds:
- S3backup = true to terraform/backend-setup/10-aws-s3-buckets.tf