### PR TITLE
Update SSL and RDS MySQL engine

### DIFF
--- a/terraform/modules/datahub/10-rds.tf
+++ b/terraform/modules/datahub/10-rds.tf
@@ -13,6 +13,7 @@ resource "aws_db_instance" "datahub" {
   backup_retention_period = 14
   backup_window           = "22:00-22:31"
   maintenance_window      = "Wed:23:13-Wed:23:43"
+  ca_cert_identifier      = "rds-ca-rsa2048-g1"
   tags                    = var.tags
 }
 

--- a/terraform/modules/datahub/10-rds.tf
+++ b/terraform/modules/datahub/10-rds.tf
@@ -1,7 +1,7 @@
 resource "aws_db_instance" "datahub" {
   allocated_storage       = 15
   engine                  = "mysql"
-  engine_version          = "5.7"
+  engine_version          = "8.0"
   instance_class          = "db.t3.micro"
   username                = "datahub"
   identifier              = replace("${var.short_identifier_prefix}datahub", "-", "")

--- a/terraform/modules/sql-to-rds-snapshot/30-rds.tf
+++ b/terraform/modules/sql-to-rds-snapshot/30-rds.tf
@@ -17,6 +17,7 @@ resource "aws_db_instance" "ingestion_db" {
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.snapshot_db.id]
   apply_immediately      = false
+  ca_cert_identifier     = "rds-ca-rsa2048-g1"
 }
 
 resource "random_password" "rds_password" {


### PR DESCRIPTION
This is a response to ticket [DPF-187](https://hackney.atlassian.net/browse/DPF-187): 1) The old RDS instance certificate `rds-ca-2019` will expire in 22 August 2024, and 2) Selwyn hopes we can upgrade the `MySQL `version since the old version we used in DataHub is no longer supported (stopped at 29 February 2024).

**1.Update SSL**
Based on the latest [documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html), we can change the Certificate Authority (CA) to `rds-ca-rsa2048-g1`, which offers broader compatibility and support for automatic certificate rotation.
Both `Datahub `and `Liberator-to-RDS-snapshot` use RDS, and this PR will change both their certificates.

**2.Upgrade the MySQL version of DataHub**
I checked the latest `DataHub `is compatible with MySQL `8.2` ([URL](https://datahubproject.io/docs/how/updating-datahub/)). However, the latest version of MySQL supported by AWS RDS is `8.0.37`, so I am upgrading it to `8.0. `in this PR. This will allow Amazon RDS to handle minor version updates automatically ([URL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/MySQL.Concepts.VersionMgmt.html))

**If it is not compatible with our current version of DataHub, then we will upgrade Datahub or roll back the MySQL version.**

[DPF-187]: https://hackney.atlassian.net/browse/DPF-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ