### PR TITLE
Update 24-aws-glue-tascomi-data.tf

### DIFF
--- a/terraform/etl/24-aws-glue-tascomi-data.tf
+++ b/terraform/etl/24-aws-glue-tascomi-data.tf
@@ -142,7 +142,7 @@ resource "aws_glue_trigger" "tascomi_tables_weekly_ingestion_triggers" {
 
   name     = "${local.short_identifier_prefix}Tascomi ${title(replace(each.value, "_", " "))} Ingestion Trigger"
   type     = "SCHEDULED"
-  schedule = "cron(0 22 ? * SUN *)"
+  schedule = "cron(0 10 ? * SUN *)"
   enabled  = local.is_production_environment
 
   actions {


### PR DESCRIPTION
Change time of Sunday's ingestions as we currently seem to be operating during an API maintenece window. We are trying 10am instead of 10pm (Idox has not replied with a suitable time).