### PR TITLE
allow_major_version_upgrade

### DIFF
--- a/terraform/modules/datahub/10-rds.tf
+++ b/terraform/modules/datahub/10-rds.tf
@@ -1,20 +1,21 @@
 resource "aws_db_instance" "datahub" {
-  allocated_storage       = 15
-  engine                  = "mysql"
-  engine_version          = "8.0"
-  instance_class          = "db.t3.micro"
-  username                = "datahub"
-  identifier              = replace("${var.short_identifier_prefix}datahub", "-", "")
-  password                = random_password.datahub_secret.result
-  db_subnet_group_name    = aws_db_subnet_group.datahub.name
-  vpc_security_group_ids  = [aws_security_group.datahub.id]
-  skip_final_snapshot     = false
-  deletion_protection     = var.is_live_environment
-  backup_retention_period = 14
-  backup_window           = "22:00-22:31"
-  maintenance_window      = "Wed:23:13-Wed:23:43"
-  ca_cert_identifier      = "rds-ca-rsa2048-g1"
-  tags                    = var.tags
+  allocated_storage           = 15
+  engine                      = "mysql"
+  engine_version              = "8.0"
+  instance_class              = "db.t3.micro"
+  username                    = "datahub"
+  identifier                  = replace("${var.short_identifier_prefix}datahub", "-", "")
+  password                    = random_password.datahub_secret.result
+  db_subnet_group_name        = aws_db_subnet_group.datahub.name
+  vpc_security_group_ids      = [aws_security_group.datahub.id]
+  skip_final_snapshot         = false
+  deletion_protection         = var.is_live_environment
+  backup_retention_period     = 14
+  backup_window               = "22:00-22:31"
+  maintenance_window          = "Wed:23:13-Wed:23:43"
+  ca_cert_identifier          = "rds-ca-rsa2048-g1"
+  allow_major_version_upgrade = true
+  tags                        = var.tags
 }
 
 resource "aws_db_subnet_group" "datahub" {


### PR DESCRIPTION
Get an error after running terraform apply. When upgrading the major version of an engine, allow_major_version_upgrade must be set to true.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance