### PR TITLE
apply_immediately = true

### DIFF
--- a/terraform/modules/datahub/10-rds.tf
+++ b/terraform/modules/datahub/10-rds.tf
@@ -14,6 +14,7 @@ resource "aws_db_instance" "datahub" {
   backup_window               = "22:00-22:31"
   maintenance_window          = "Wed:23:13-Wed:23:43"
   ca_cert_identifier          = "rds-ca-rsa2048-g1"
+  apply_immediately           = true
   allow_major_version_upgrade = true
   tags                        = var.tags
 }

--- a/terraform/modules/sql-to-rds-snapshot/30-rds.tf
+++ b/terraform/modules/sql-to-rds-snapshot/30-rds.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "ingestion_db" {
   password               = random_password.rds_password.result
   skip_final_snapshot    = true
   vpc_security_group_ids = [aws_security_group.snapshot_db.id]
-  apply_immediately      = false
+  apply_immediately      = true
   ca_cert_identifier     = "rds-ca-rsa2048-g1"
 }
 


### PR DESCRIPTION
MySQL verision has been updated in staging, but the ca_cert_identifier is still the old one.
This [link ](https://github.com/hashicorp/terraform-provider-aws/issues/33546)mentions needs apply_immediately = true