### PR TITLE
allow users to create and delete table and view

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -401,9 +401,13 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:UpdateDevEndpoint",
       "glue:UpdateJob",
       "glue:UpdateTable",
+      "glue:CreateTable",
+      "glue:DeleteTable",
       "glue:GetTableVersions",
       "glue:GetTable",
       "glue:GetTables",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
       "glue:Query*",
     ]
     resources = ["*"]


### PR DESCRIPTION
Arda hopes to have permission to build views on the raw zone via the Athena UI.

He mentioned reason below

> need to create some mapping tables to map a group of values into a single value.

Tim and Tian think it's okay to grant users this permission, so I submit this PR