### PR TITLE
correct script name value

### DIFF
--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1593,7 +1593,7 @@ module "parking_nas_live_manual_updates_with_pcns_box23" {
   helper_module_key              = data.aws_s3_object.helpers.key
   pydeequ_zip_key                = data.aws_s3_object.pydeequ.key
   spark_ui_output_storage_id     = module.spark_ui_output_storage_data_source.bucket_id
-  script_name                    = "parking_nas_live_manual_updates_data_load_with_pcns"
+  script_name                    = "parking_nas_live_manual_updates_with_pcns_box23"
   triggered_by_job               = module.parking_nas_live_manual_updates_data_load_with_pcns.job_name
   job_description                = "Hackney Parking NAS Live ETA data linked lib PCN and box 2 n 3"
   workflow_name                  = "${local.short_identifier_prefix}parking-liberator-data-workflow"


### PR DESCRIPTION
The script for the job `parking_nas_live_manual_updates_with_pcns_box23` was incorrect, this pr sets the value to the expected script. 