### PR TITLE
create a parking airflow user

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -68,6 +68,7 @@ module "department_parking" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
+  departmental_airflow_user       = true
 }
 
 module "department_finance" {


### PR DESCRIPTION
A while ago, I created a departmental_airflow_user flag so that the Airflow user for parking can be enabled directly. It seems no extra code is needed.