### PR TITLE
change the vrm_ceo to vrm

### DIFF
--- a/scripts/jobs/parking/parking_pcn_dvla_response_no_address.py
+++ b/scripts/jobs/parking/parking_pcn_dvla_response_no_address.py
@@ -71,7 +71,7 @@ and upper(nextprogressionstage) not like 'WRITEOFF'
 
 --and cast(pcnissuedate as date) > cast('2019-12-31' as date) and cast(pcnissuedate as date) < cast('2024-01-01' as date)--Parking Tickets issued between 01/01/2020 and 31/12/2023.
 
-group by vrm_ceo
+group by vrm
 order by vrm_ceo
 )
 , no_resp_cctv as (


### PR DESCRIPTION
There is an execution order issue: the `GROUP BY vrm_ceo` is done before the alias (rename vrm to vrm_ceo) (in SQL, group by will be executed earlier than SELECT), so it causes an error in Athena, even though it did not throw an error in Glue.