### PR TITLE
allow putobjects in departmental folder

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "s3_department_access" {
     ]
     resources = [
       var.landing_zone_bucket.bucket_arn,
-      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/manual/*",
+      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/*",
       "${var.landing_zone_bucket.bucket_arn}/unrestricted/*",
 
       var.raw_zone_bucket.bucket_arn,


### PR DESCRIPTION
> botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:iam::120038763019:user/streetscene-airflow-user is not authorized to perform: s3:PutObject on resource: "arn:aws:s3:::dataplatform-stg-landing-zone/streetscene/traffic-counters/street-systems/

I am replacing the Marta's dag permission from our `DataPlatform `connection to `streetscene`, but it has the above error.

Files should be allowed to be placed in the 'streetscene/traffic-counters/' prefix. Originally, only the 'streetscene/manual' prefix was permitted. I have allowed files to be uploaded to prefix 'streetscene/traffic-counters/', don't see any risk associated with the PutObject permission.

Hi @timburke-hackit since, it's increasing the permission. Could you help review it? Thanks.

