### PR TITLE
roll back putobject permission in landing zone

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "s3_department_access" {
     ]
     resources = [
       var.landing_zone_bucket.bucket_arn,
-      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/*",
+      "${var.landing_zone_bucket.bucket_arn}/${local.department_identifier}/manual/*",
       "${var.landing_zone_bucket.bucket_arn}/unrestricted/*",
 
       var.raw_zone_bucket.bucket_arn,


### PR DESCRIPTION
Tim explained the purpose of the landing zone, so I am rolling back the previous PR.
https://github.com/LBHackney-IT/Data-Platform/pull/1883