### PR TITLE
fix the kms key encryption on query results

### DIFF
--- a/scripts/helpers/athena_helpers.py
+++ b/scripts/helpers/athena_helpers.py
@@ -78,7 +78,7 @@ def run_query_on_athena(
     response = client.start_query_execution(
         QueryString=query,
         QueryExecutionContext={"Database": database_name},
-        ResultConfiguration={"OutputLocation": output_location},
+        ResultConfiguration=result_configuration,
     )
 
     query_execution_id = response["QueryExecutionId"]


### PR DESCRIPTION
Did not pass the `result_configuration `dict correctly, which causes the encryption still using the default kms key.