### PR TITLE
add glue:GetTables permission to airflow users

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -850,6 +850,7 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "glue:StartCrawler",
       "glue:ListCrawlers",
       "glue:GetTable",
+      "glue:GetTables",
       "glue:GetPartitions",
       "glue:GetDatabase",
       "glue:GetDatabases",


### PR DESCRIPTION
This is used to read all tables in one go and filter out those with an "import_day" or "import_date" suffix in the parking refined zone.