### PR TITLE
fix failed glue jobs

### DIFF
--- a/scripts/jobs/parking/parking_cycle_hangars_denormalised_inservice_live_gds.py
+++ b/scripts/jobs/parking/parking_cycle_hangars_denormalised_inservice_live_gds.py
@@ -227,27 +227,22 @@ to_date(cycle_den.import_date, 'yyyyMMdd') as importdate
 
 /*for partiion*/
 
-,replace(cast(current_date() as string),'-','') as import_date
-,cast(Year(current_date) as string)    as import_year
-,cast(month(current_date) as string)   as import_month
-,cast(day(current_date) as string)     as import_day
-
-
+,date_format(current_date, 'yyyy') AS import_year
+,date_format(current_date, 'MM') AS import_month
+,date_format(current_date, 'dd') AS import_day
+,date_format(current_date, 'yyyyMMdd') AS import_date
 
  from cycle_den
  where cycle_den.import_day = '01' or  cycle_den.import_day = '1'
  and upper(cycle_den.in_service) like 'Y'
  and cycle_den.allocation_status like 'live'
 
-group by to_date(cycle_den.import_date, 'yyyymmdd') --as importdate
-,cycle_den.import_date
+group by
+cycle_den.import_date
 ,cycle_den.hanger_id
 ,cycle_den.hangar_type
 ,cycle_den.hangar_location
-,date_format(current_date, 'yyyy') AS import_year
-,date_format(current_date, 'MM') AS import_month
-,date_format(current_date, 'dd') AS import_day
-,date_format(current_date, 'yyyyMMdd') AS import_date
+,date_format(current_date, 'yyyyMMdd')
 """
 SQLQuery_node1705433170442 = sparkSqlQuery(
     glueContext,

--- a/scripts/jobs/parking/parking_cycle_hangars_waiting_list.py
+++ b/scripts/jobs/parking/parking_cycle_hangars_waiting_list.py
@@ -163,7 +163,7 @@ Count_Hangar_Details as (
 
 SELECT A.*, B.Estate_Count, B.Newonly_Count, B.Resident_Count,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS importdatetime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_persistent_evaders.py
+++ b/scripts/jobs/parking/parking_persistent_evaders.py
@@ -156,9 +156,10 @@ PCases AS
 
           ROW_NUMBER() OVER (PARTITION BY ticketserialnumber ORDER BY ticketserialnumber DESC) as Rn,
 
-        date_format(current_date, 'MM') AS import_month,
-        date_format(current_date, 'dd') AS import_day,
-        date_format(current_date, 'yyyyMMdd') AS import_date
+          cast(current_date as string) as import_date,
+
+          Year(current_date) as import_year, month(current_date) as import_month,
+          day(current_date) as import_day
 
 FROM (SELECT * FROM liberator_pcn_tickets
       WHERE import_date = (SELECT MAX(import_date)


### PR DESCRIPTION
- Revert parking_persistent_evaders. The historical data uses the wrong `import_date `format, with hyphens, which is causing the issue. I'll leave this one to be corrected along with the other tables that need the import_date format updated. s3://dataplatform-prod-refined-zone/parking/liberator/Parking_Persistent_Evaders/import_year=2022/import_month=1/import_day=6/import_date=2022-01-06/
- Fix denormalised_inservice_live_dgs: avoid using "`AS`" in the GROUP BY clause (The `AS `was commented out in original script), and since import_date already includes year, month, and day information, there’s no need to include them separately in the GROUP BY.
- Revert the name of `ImportDateTime `in table `parking_cycle_hangars_waiting_list`. This table uses importdatetime, but other tables use ImportDateTime.