### PR TITLE
 edge case - correct Parking_Persistent_Evaders

### DIFF
--- a/scripts/jobs/parking/parking_persistent_evaders.py
+++ b/scripts/jobs/parking/parking_persistent_evaders.py
@@ -156,10 +156,10 @@ PCases AS
 
           ROW_NUMBER() OVER (PARTITION BY ticketserialnumber ORDER BY ticketserialnumber DESC) as Rn,
 
-          cast(current_date as string) as import_date,
-
-          Year(current_date) as import_year, month(current_date) as import_month,
-          day(current_date) as import_day
+        date_format(current_date, 'yyyy') AS import_year,
+        date_format(current_date, 'MM') AS import_month,
+        date_format(current_date, 'dd') AS import_day,
+        date_format(current_date, 'yyyyMMdd') AS import_date
 
 FROM (SELECT * FROM liberator_pcn_tickets
       WHERE import_date = (SELECT MAX(import_date)


### PR DESCRIPTION
it has hyphones in import_date like below and and single digit month and day.

parking/liberator/Parking_Persistent_Evaders/import_year=2022/import_month=3/import_day=5/import_date=2022-03-05