### PR TITLE
revert the ImportDateTime type to default

### DIFF
--- a/scripts/jobs/parking/parking_bailiff_allocation.py
+++ b/scripts/jobs/parking/parking_bailiff_allocation.py
@@ -266,7 +266,7 @@ SELECT
        Else 0
     End as Percentage_Excluded_by_EA,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_bailiff_return.py
+++ b/scripts/jobs/parking/parking_bailiff_return.py
@@ -251,7 +251,7 @@ Order by EA, MonthYear)
 
 /*** Output the Bailiff Return ***/
 SELECT *,
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_bailiff_warrant_figures.py
+++ b/scripts/jobs/parking/parking_bailiff_warrant_figures.py
@@ -178,7 +178,7 @@ SELECT
    round((cast(Part_Paid_Total as double)/Total_No_PCN)*100,2) as Part_Paid_Total_Percentage,
    round((cast(Not_Paid_Total as double)/Total_No_PCN)*100,2)  as Not_Paid_Total_Percentage,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_cedar_backing_data_summary.py
+++ b/scripts/jobs/parking/parking_cedar_backing_data_summary.py
@@ -111,7 +111,7 @@ SELECT A.*,
          END
     END as Year_Type,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
+++ b/scripts/jobs/parking/parking_cedar_fulling_total_summary.py
@@ -324,7 +324,7 @@ SELECT
     CAST((Previous_Monthly_Total/Current_Monthly_Total)*100  as decimal(10,2)) as PercentageDiff,
 
     Pay_Year,
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_cedar_payments.py
+++ b/scripts/jobs/parking/parking_cedar_payments.py
@@ -117,7 +117,7 @@ SELECT A.*,
          END
     END as Year_Type,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_ceo_average_on_street.py
+++ b/scripts/jobs/parking/parking_ceo_average_on_street.py
@@ -144,7 +144,7 @@ SELECT
    CAST(Format_Break_Avg as string)   as Avg_Break,
    CAST(C.Format_Total_Avg as string) as Avg_Time_to_Beat,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
+++ b/scripts/jobs/parking/parking_ceo_average_on_street_hrs_mins_secs.py
@@ -176,7 +176,7 @@ SELECT
    CAST(Format_Break_Avg as string)   as Avg_Break,
    CAST(C.Format_Total_Avg as string) as Avg_Time_to_Beat,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_ceo_on_street.py
+++ b/scripts/jobs/parking/parking_ceo_on_street.py
@@ -159,7 +159,7 @@ Display_Data as (
 
 SELECT A.*, B.TimeOnStreet_Secs,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_ceo_summary.py
+++ b/scripts/jobs/parking/parking_ceo_summary.py
@@ -99,7 +99,7 @@ SELECT
    C.shift_start_time,
    C.shift_end_time,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_deployment_target_details.py
+++ b/scripts/jobs/parking/parking_deployment_target_details.py
@@ -285,7 +285,7 @@ SELECT
    SATEV,
    Act_MFAM, Act_MFPM, Act_MFEV, Act_MFAT, Act_SATAM, Act_SATPM, Act_SATEV,
 
-   date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+   current_timestamp() as ImportDateTime,
    date_format(current_date, 'yyyy') AS import_year,
    date_format(current_date, 'MM') AS import_month,
    date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_market_licence_totals.py
+++ b/scripts/jobs/parking/parking_market_licence_totals.py
@@ -171,7 +171,7 @@ SELECT
    No_Temp_Licences,
    No_Perm_Licences,
 
-   date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+   current_timestamp() as ImportDateTime,
    date_format(current_date, 'yyyy') AS import_year,
    date_format(current_date, 'MM') AS import_month,
    date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_markets_denormalisation.py
+++ b/scripts/jobs/parking/parking_markets_denormalisation.py
@@ -221,7 +221,7 @@ SELECT
    INSP_area_width_3,INSP_area_depth_3,
    INSP_total_area, INSP_total_area, bplu_class, Total_Payment,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_pcn_ltn_report_summary.py
+++ b/scripts/jobs/parking/parking_pcn_ltn_report_summary.py
@@ -47,7 +47,7 @@ SELECT concat(substr(Cast(pcnissuedate as varchar(10)),1, 7), '-01')    AS Issue
        COUNT(distinct pcn)                                              AS PCNs_Issued,
        CAST(SUM(cast(lib_payment_received as double)) as decimal(11,2)) AS Total_Amount_Paid,
 
-        date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+        current_timestamp() as ImportDateTime,
         date_format(current_date, 'yyyy') AS import_year,
         date_format(current_date, 'MM') AS import_month,
         date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_pcn_report_summary.py
+++ b/scripts/jobs/parking/parking_pcn_report_summary.py
@@ -35,7 +35,7 @@ SELECT concat(substr(Cast(pcnissuedate as varchar(10)),1, 7), '-01') as IssueMon
        CASE When Lib_Payment_Received != '0' Then 1 Else 0 END as Payment_Flag,
        count(*) as PCNs_Issued,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_percent_street_coverage.py
+++ b/scripts/jobs/parking/parking_percent_street_coverage.py
@@ -69,7 +69,7 @@ SELECT
    zone_actual as Monthly_NoStreets_Actual,
    round(((zone_actual - zone_target) / zone_target)*100, 2)+100 as Percentage_Coverage,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_percent_street_coverage_cpz.py
+++ b/scripts/jobs/parking/parking_percent_street_coverage_cpz.py
@@ -72,7 +72,7 @@ SELECT
       ELSE round(((zone_actual - zone_target) / zone_target)*100, 2)+100
    END, 2) as Percentage_Coverage,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_permit_de_normalisation.py
+++ b/scripts/jobs/parking/parking_permit_de_normalisation.py
@@ -563,7 +563,7 @@ SELECT
 
    cast(0 as decimal) as usrn,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_shop_front_licence_totals.py
+++ b/scripts/jobs/parking/parking_shop_front_licence_totals.py
@@ -149,7 +149,7 @@ SELECT
    No_Temp_Licences,
    No_Perm_Licences,
 
-   date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+   current_timestamp as ImportDateTime,
    date_format(current_date, 'yyyy') AS import_year,
    date_format(current_date, 'MM') AS import_month,
    date_format(current_date, 'dd') AS import_day,

--- a/scripts/jobs/parking/parking_suspension_de-normalised_data.py
+++ b/scripts/jobs/parking/parking_suspension_de-normalised_data.py
@@ -225,7 +225,7 @@ SELECT A.*,
        K.status                                        as App_Reject_status,
        L.status_date                                   as Cancel_Date,
 
-    date_format(CAST(CURRENT_TIMESTAMP AS timestamp), 'yyyy-MM-dd HH:mm:ss') AS ImportDateTime,
+    current_timestamp() as ImportDateTime,
     date_format(current_date, 'yyyy') AS import_year,
     date_format(current_date, 'MM') AS import_month,
     date_format(current_date, 'dd') AS import_day,


### PR DESCRIPTION
All the failed jobs are related to several tables, which have a column ImportDateTime that was changed to a string instead of a timestamp.

I am reverting all my changes to this column back to its original format.