### PR TITLE
Feature/ce 2567 update qlik tags

### DIFF
--- a/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
@@ -6,6 +6,7 @@ locals {
     Name         = "${var.identifier_prefix}-qlik-sense-restore"
   }
   ec2_tags_prod_restore = {
+    Application = "Qlik"
     BackupPolicy = title(var.environment)
     Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
   }

--- a/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
@@ -1,6 +1,7 @@
 locals {
   backup_ami_id_prod = "ami-0a9bac68a32217ec9"
   ec2_tags_prod = {
+    Application = "Qlik"
     BackupPolicy = title(var.environment)
     Name         = "${var.identifier_prefix}-qlik-sense-restore"
   }


### PR DESCRIPTION
This PR adds a new tag in order to facilitate accessing the Qlik servers. It does by adding a new, overriding 'Application=Qlik' tag on the primary Qlik(sense) server in Prod. 

Adds:
- tags to the local values in terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf

Intended change as in the below screenshot:
![image](https://github.com/user-attachments/assets/88da3576-9ed3-4627-9e43-3c104ec32495)

