### PR TITLE
add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directories:
+      - "*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      groups:
+        straightforward-dependencies:
+          applies-to: version-updates
+          update-types:
+            - minor
+            - patch


### PR DESCRIPTION
This configuration tells Dependabot to group non-major updates into a single PR each week.

There are quite a large amount of outstanding 'moderate' and below dependabot alerts on the repository, I'm hoping this will help us clear those up and stay on top of them going forward without too much noise or the need to review lots of small PRs.

Mimicking the configuration Ryan has implemented for the engineering playbook repo:
https://github.com/LBHackney-IT/lbhackney-it.github.io/pull/19

I waved this at him to sense check earlier here
https://hackit-lbh.slack.com/archives/CKR1DBEQM/p1729612657268829