### PR TITLE
limit the fme permission but add unrestricted access in raw zone

### DIFF
--- a/terraform/core/23-FME-iam.tf
+++ b/terraform/core/23-FME-iam.tf
@@ -115,9 +115,7 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
       "s3:GetObjectVersion",
     ]
     resources = [
-      "${module.raw_zone.bucket_arn}/*",
-      "${module.refined_zone.bucket_arn}/*",
-      "${module.trusted_zone.bucket_arn}/*",
+      "${module.raw_zone.bucket_arn}/unrestricted/*",
       "${module.athena_storage.bucket_arn}/primary/*"
     ]
   }
@@ -128,8 +126,7 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
       "s3:PutObject"
     ]
     resources = [
-      "${module.refined_zone.bucket_arn}/*",
-      "${module.trusted_zone.bucket_arn}/*",
+      "${module.raw_zone.bucket_arn}/unrestricted/*",
       "${module.athena_storage.bucket_arn}/primary/*"
     ]
   }
@@ -144,8 +141,6 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
     resources = [
       module.athena_storage.kms_key_arn,
       module.raw_zone.kms_key_arn,
-      module.refined_zone.kms_key_arn,
-      module.trusted_zone.kms_key_arn
     ]
   }
 }


### PR DESCRIPTION
Based on Sandrine's requirements of fme permission ([URL](https://hackit-lbh.slack.com/archives/C0599P86MBK/p1730723823509509)):

- Data needs to be written to an unrestricted folder in the raw zone.
- Access to the refined and trust zones is not required for this FME user.

I’ve made the necessary modifications accordingly.
