### PR TITLE
add some reading permissions back for Sandrine's fme user

### DIFF
--- a/terraform/core/23-FME-iam.tf
+++ b/terraform/core/23-FME-iam.tf
@@ -133,8 +133,8 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
           "${module.raw_zone.bucket_arn}/${folder}/*",
           "${module.refined_zone.bucket_arn}/${folder}/*",
           "${module.trusted_zone.bucket_arn}/${folder}/*"
-        ]...
-      ]
+        ]
+      ]...
     )
   }
 


### PR DESCRIPTION
Over last [pr ](https://github.com/LBHackney-IT/Data-Platform/pull/1963/files) - I've removed many permission for fme user

Based on Sandrine's new message, she needs reading permission in the below folders in all zones
`data-and-insight, env-enforcement, env-services, housing, parking, planning, streetscene, unrestricted`


Now works fine.
![image](https://github.com/user-attachments/assets/68f30f50-04b4-4b90-af43-9405c8cc5853)
