### PR TITLE
removing profile from AUTH_OIDC_SCOPE

### DIFF
--- a/terraform/modules/datahub/03-locals.tf
+++ b/terraform/modules/datahub/03-locals.tf
@@ -24,7 +24,7 @@ locals {
       { name : "AUTH_OIDC_ENABLED", value : var.is_live_environment },
       { name : "AUTH_OIDC_DISCOVERY_URI", value : "https://accounts.google.com/.well-known/openid-configuration" },
       { name : "AUTH_OIDC_BASE_URL", value : var.datahub_url },
-      { name : "AUTH_OIDC_SCOPE", value : "openid profile email" },
+      { name : "AUTH_OIDC_SCOPE", value : "openid email" },
       { name : "AUTH_OIDC_USER_NAME_CLAIM", value : "email" },
       { name : "AUTH_OIDC_USER_NAME_CLAIM_REGEX", value : "([^@]+)" },
       { name : "DATAHUB_ANALYTICS_ENABLED", value : "false" },


### PR DESCRIPTION
Removing "profile" from AUTH_OIDC_SCOPE to test and see if that resolves the issue that some users are not able to access datahub