### PR TITLE
Dpf 220/ecs department roles

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -947,11 +947,11 @@ data "aws_iam_policy_document" "ecs_cloudwatch" {
 
 data "aws_iam_policy_document" "ecs_department_policy" {
   source_policy_documents = [
-    data.aws_iam_policy_document.s3_department_access,
-    data.aws_iam_policy_document.secrets_manager_read_only,
-    data.aws_iam_policy_document.read_glue_scripts_and_mwaa_and_athena,
-    data.aws_iam_policy_document.ecs_cloudwatch,
-    data.aws_iam_policy_document.crawler_can_access_jdbc_connection
+    data.aws_iam_policy_document.s3_department_access.json,
+    data.aws_iam_policy_document.secrets_manager_read_only.json,
+    data.aws_iam_policy_document.read_glue_scripts_and_mwaa_and_athena.json,
+    data.aws_iam_policy_document.ecs_cloudwatch.json,
+    data.aws_iam_policy_document.crawler_can_access_jdbc_connection.json
   ]
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -955,7 +955,7 @@ data "aws_iam_policy_document" "ecs_department_policy" {
   ]
 }
 
-resource "aws_iam_policy_document" "department_ecs_policy" {
+resource "aws_iam_policy" "department_ecs_policy" {
   name   = lower("${var.identifier_prefix}${local.department_identifier}-ecs-base-policy")
   policy = data.aws_iam_policy_document.department_ecs.json
   tags   = var.tags

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -953,11 +953,10 @@ data "aws_iam_policy_document" "ecs_department_policy" {
     data.aws_iam_policy_document.ecs_cloudwatch,
     data.aws_iam_policy_document.crawler_can_access_jdbc_connection
   ]
-
 }
 
-resource "aws_iam_policy" "ecs_department_task_policy" {
-  name = lower("${var.identifier_prefix}-${local.department_identifier}-ecs-policy")
-
-
+resource "aws_iam_policy_document" "department_ecs_policy" {
+  name   = lower("${var.identifier_prefix}${local.department_identifier}-ecs-base-policy")
+  policy = data.aws_iam_policy_document.department_ecs.json
+  tags   = var.tags
 }

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -925,3 +925,39 @@ resource "aws_iam_policy" "airflow_base_policy" {
   name   = lower("${var.identifier_prefix}-${local.department_identifier}-ariflow-base-policy")
   policy = data.aws_iam_policy_document.airflow_base_policy.json
 }
+
+# ECS Department task role policy
+
+# Todo: departments should probably have their own log groups
+# but this is equivalent to the existing Glue set up
+data "aws_iam_policy_document" "ecs_cloudwatch" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "logs:CreateLogGroup",
+      "logs:AssociateKmsKey"
+    ]
+    resources = [
+      "arn:aws:logs:*:*:/ecs/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "ecs_department_policy" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.s3_department_access,
+    data.aws_iam_policy_document.secrets_manager_read_only,
+    data.aws_iam_policy_document.read_glue_scripts_and_mwaa_and_athena,
+    data.aws_iam_policy_document.ecs_cloudwatch,
+    data.aws_iam_policy_document.crawler_can_access_jdbc_connection
+  ]
+
+}
+
+resource "aws_iam_policy" "ecs_department_task_policy" {
+  name = lower("${var.identifier_prefix}-${local.department_identifier}-ecs-policy")
+
+
+}

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -960,3 +960,14 @@ resource "aws_iam_policy_document" "department_ecs_policy" {
   policy = data.aws_iam_policy_document.department_ecs.json
   tags   = var.tags
 }
+
+data "aws_iam_policy_document" "ecs_assume_role_policy" {
+  statement {
+    effect = "allow"
+    principals {
+      identifiers = ["ecs-tasks.amazonaws.com"]
+      type        = "Service"
+    }
+    actions = "sts:AssumeRole"
+  }
+}

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -968,6 +968,6 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"
     }
-    actions = "sts:AssumeRole"
+    actions = ["sts:AssumeRole"]
   }
 }

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -963,7 +963,7 @@ resource "aws_iam_policy_document" "department_ecs_policy" {
 
 data "aws_iam_policy_document" "ecs_assume_role_policy" {
   statement {
-    effect = "allow"
+    effect = "Allow"
     principals {
       identifiers = ["ecs-tasks.amazonaws.com"]
       type        = "Service"

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -957,7 +957,7 @@ data "aws_iam_policy_document" "ecs_department_policy" {
 
 resource "aws_iam_policy" "department_ecs_policy" {
   name   = lower("${var.identifier_prefix}${local.department_identifier}-ecs-base-policy")
-  policy = data.aws_iam_policy_document.department_ecs.json
+  policy = data.aws_iam_policy_document.ecs_department_policy.json
   tags   = var.tags
 }
 

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -143,7 +143,7 @@ resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {
 # Department ECS
 resource "aws_iam_role" "department_ecs_role" {
   name               = lower("${var.identifier_prefix}-glue-${local.department_identifier}")
-  assume_role_policy = data.aws_iam_policy_document.department
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
   tags               = var.tags
 }
 

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -139,3 +139,15 @@ resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {
     extra     = jsonencode({ region_name = var.region })
   })
 }
+
+# Department ECS
+resource "aws_iam_role" "department_ecs_role" {
+  name               = lower("${var.identifier_prefix}-glue-${local.department_identifier}")
+  assume_role_policy = data.aws_iam_policy_document.department
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "department_ecs_policy" {
+  role       = aws_iam_role.department_ecs_role.name
+  policy_arn = aws_iam_policy_document.department_ecs_policy.arn
+}

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -149,5 +149,5 @@ resource "aws_iam_role" "department_ecs_role" {
 
 resource "aws_iam_role_policy_attachment" "department_ecs_policy" {
   role       = aws_iam_role.department_ecs_role.name
-  policy_arn = aws_iam_policy_document.department_ecs_policy.arn
+  policy_arn = aws_iam_policy.department_ecs_policy.arn
 }


### PR DESCRIPTION
Creates base department roles for running ECS tasks that are broadly equivalent to the existing Glue roles.