### PR TITLE
enable airflow user for env services department

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -345,6 +345,7 @@ module "department_environmental_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
+  departmental_airflow_user       = true
 }
 
 module "department_housing" {


### PR DESCRIPTION
Enable the Airflow user for department_environmental_services - this will create the departmental AWS connection in secrete manager.

Cliff wants to schedule one of his tasks under department_environmental_services, which primarily calls the Alloy API and then uses Alloy server to perform some work.