### PR TITLE
change role name for ECS department roles

### DIFF
--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -142,7 +142,7 @@ resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {
 
 # Department ECS
 resource "aws_iam_role" "department_ecs_role" {
-  name               = lower("${var.identifier_prefix}-glue-${local.department_identifier}")
+  name               = lower("${var.identifier_prefix}-ecs-${local.department_identifier}")
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
   tags               = var.tags
 }


### PR DESCRIPTION
I'd left the Glue reference in the role name when I copied the block so this change simply replaces that with ecs.