### PR TITLE
Allow airflow user (parking and housing) one to pass the ecs-execution-role

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -909,7 +909,9 @@ data "aws_iam_policy_document" "airflow_base_policy" {
     ]
     resources = [
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/parking-ecs-execution-role",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/housing-ecs-execution-role"
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
> botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the RunTask operation: User: arn:aws:iam::120038763019:user/parking-airflow-user is not authorized to perform: iam:PassRole on resource: arn:aws:iam::120038763019:role/parking-ecs-execution-role because no identity-based policy allows the iam:PassRole action


Same as before, need to allow passrole permission here.