### PR TITLE
allow passrole on task role too

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -911,9 +911,9 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-execution-role",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/parking-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-${var.environment}-ecs-parking",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-ecs-parking",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/housing-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-${var.environment}-ecs-housing",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-ecs-housing",
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
> botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the RunTask operation: User: arn:aws:iam::120038763019:user/parking-airflow-user is not authorized to perform: iam:PassRole on resource: arn:aws:iam::120038763019:role/dataplatform-stg-ecs-parking because no identity-based policy allows the iam:PassRole action


Get the error which requires passrole on task role. We added this before for mosaic, but I forgot it this morning's [PR](https://github.com/LBHackney-IT/Data-Platform/pull/1990).