### PR TITLE
Department ecs passrole

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -932,7 +932,7 @@ data "aws_iam_policy_document" "department_ecs_passrole" {
 
 resource "aws_iam_policy" "department_ecs_passrole" {
   name   = lower("${var.identifier_prefix}-${local.department_identifier}-department-ecs-passrole")
-  policy = data.aws_iam_policy_document.airflow_base_policy.json
+  policy = data.aws_iam_policy_document.department_ecs_passrole.json
   tags   = var.tags
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -900,27 +900,6 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:cluster/*"
     ]
   }
-
-  statement {
-    sid    = "AirflowPassRolePolicy"
-    effect = "Allow"
-    actions = [
-      "iam:PassRole"
-    ]
-    resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/parking-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-ecs-parking",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/housing-ecs-execution-role",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.identifier_prefix}-ecs-housing",
-    ]
-    condition {
-      test     = "StringEquals"
-      variable = "iam:PassedToService"
-      values   = ["ecs-tasks.amazonaws.com"]
-    }
-  }
 }
 
 resource "aws_iam_policy" "airflow_base_policy" {
@@ -929,6 +908,29 @@ resource "aws_iam_policy" "airflow_base_policy" {
   name   = lower("${var.identifier_prefix}-${local.department_identifier}-ariflow-base-policy")
   policy = data.aws_iam_policy_document.airflow_base_policy.json
 }
+
+data "aws_iam_policy_document" "department_ecs_passrole" {
+  statement {
+    sid    = "AirflowDepartmentECSPassrolePolicy"
+    effect = "Allow"
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = [
+      aws_iam_role.department_ecs_role.arn,
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.department_identifier}-ecs-execution-role",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-execution-role",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "department_ecs_passrole" {
+  name   = lower("${var.identifier_prefix}-${local.department_identifier}-department-ecs-passrole")
+  policy = data.aws_iam_policy_document.airflow_base_policy.json
+  tags   = var.tags
+}
+
 
 # ECS Department task role policy
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -922,6 +922,11 @@ data "aws_iam_policy_document" "department_ecs_passrole" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-execution-role",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/dap-ecs-task-role"
     ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -102,6 +102,7 @@ locals {
     s3_access                 = aws_iam_policy.s3_access.arn,
     secrets_manager_read_only = aws_iam_policy.secrets_manager_read_only.arn,
     airflow_base_policy       = aws_iam_policy.airflow_base_policy.arn,
+    department_ecs_passrole   = aws_iam_policy.department_ecs_policy.arn
   }
 }
 


### PR DESCRIPTION

The previous implementation would allow a department to pass the ecs task role of another department. For example the finance department was able to pass the parking and housing ecs task roles:
![image](https://github.com/user-attachments/assets/7a015080-f32f-4564-a2d4-353fc3911300)