### PR TITLE
allow access to airflow env stg or prod in all containers

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -434,7 +434,8 @@ data "aws_iam_policy_document" "secrets_manager_read_only" {
       module.google_service_account.credentials_secret.arn,
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:${var.identifier_prefix}/${local.department_identifier}/*",
       "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:${var.short_identifier_prefix}/${local.department_identifier}*",
-      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:airflow/variables/env-fxe5CD"
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:airflow/variables/env-fxe5CD",
+      "arn:aws:secretsmanager:eu-west-2:${data.aws_caller_identity.current.account_id}:secret:airflow/variables/env-jeCYYl",
     ]
   }
 


### PR DESCRIPTION
These keywords "stg" and "prod" are stored in the Secrets Manager under `airflow/variables/env` to allow access by containers.

The ARN of `airflow/variables/env` in 'prod' and 'stg' differs because AWS attaches a unique string to each. If there is a better way to manage access to airflow/variables/env, please let me know. Thanks

I know we can pass it from the Airflow DAG to the container, but reading it from Secrets Manager seems more straightforward