### PR TITLE
attach passrole to airflow user - correct a typo

### DIFF
--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -102,7 +102,7 @@ locals {
     s3_access                 = aws_iam_policy.s3_access.arn,
     secrets_manager_read_only = aws_iam_policy.secrets_manager_read_only.arn,
     airflow_base_policy       = aws_iam_policy.airflow_base_policy.arn,
-    department_ecs_passrole   = aws_iam_policy.department_ecs_policy.arn
+    department_ecs_passrole   = aws_iam_policy.department_ecs_passrole.arn
   }
 }
 


### PR DESCRIPTION
I think there’s a typo from last [pr](https://github.com/LBHackney-IT/Data-Platform/pull/1993/files). not found passrole in department_ecs_policy, department_ecs_passrole is the right one.