### PR TITLE
remove cloudwatch permission from task role

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -943,27 +943,12 @@ resource "aws_iam_policy" "department_ecs_passrole" {
 
 # Todo: departments should probably have their own log groups
 # but this is equivalent to the existing Glue set up
-data "aws_iam_policy_document" "ecs_cloudwatch" {
-  statement {
-    effect = "Allow"
-    actions = [
-      "logs:PutLogEvents",
-      "logs:CreateLogStream",
-      "logs:CreateLogGroup",
-      "logs:AssociateKmsKey"
-    ]
-    resources = [
-      "arn:aws:logs:*:*:/ecs/*"
-    ]
-  }
-}
 
 data "aws_iam_policy_document" "ecs_department_policy" {
   source_policy_documents = [
     data.aws_iam_policy_document.s3_department_access.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
     data.aws_iam_policy_document.read_glue_scripts_and_mwaa_and_athena.json,
-    data.aws_iam_policy_document.ecs_cloudwatch.json,
     data.aws_iam_policy_document.crawler_can_access_jdbc_connection.json
   ]
 }


### PR DESCRIPTION
I am removing it from task role. The execution role created in Wayne's ecs module includes two permission: read from ECR and read/write to cloudwatch permission. The python script in containers can write to CloudWatch ECS group via it.

And this will fix the error LimitExceeded: Cannot exceed quota for PolicySize: 6144
https://github.com/LBHackney-IT/Data-Platform/actions/runs/12029136720/job/33534177911