### PR TITLE
add existing glue access and athena access to ecs task role

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -475,7 +475,8 @@ data "aws_iam_policy_document" "read_glue_scripts_and_mwaa_and_athena" {
       "athena:GetQueryResults",
       "athena:ListDatabases",
       "athena:ListTableMetadata",
-      "athena:GetTableMetadata"
+      "athena:GetTableMetadata",
+      "athena:GetWorkGroup",
     ]
     resources = ["*"]
   }

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -152,3 +152,8 @@ resource "aws_iam_role_policy_attachment" "department_ecs_policy" {
   role       = aws_iam_role.department_ecs_role.name
   policy_arn = aws_iam_policy.department_ecs_policy.arn
 }
+
+resource "aws_iam_role_policy_attachment" "glue_access_attachment_to_ecs_role" {
+  role       = aws_iam_role.department_ecs_role.name
+  policy_arn = aws_iam_policy.glue_access.arn
+}


### PR DESCRIPTION
> botocore.errorfactory.AccessDeniedException: An error occurred (AccessDeniedException) when calling the DeleteTable operation: User: arn:aws:sts::120038763019:assumed-role/dataplatform-stg-ecs-parking/0eb3c2d72ff34a2495af6aec696bdf69 is not authorized to perform: glue:DeleteTable on resource: arn:aws:glue:eu-west-2:120038763019:catalog because no identity-based policy allows the glue:DeleteTable action
> 
> botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the GetWorkGroup operation: You are not authorized to perform: athena:GetWorkGroup on the resource. After your AWS administrator or you have updated your permissions, please try again.

The above is an error message shared from Sandrine’s ECS task:

- execute Athena queries to get the data, which requires `athena:GetWorkGroup`
- overwrite table and partition via Athena CTAS (Create Table As Select) queries method, which requires `glue:DeleteTable`

I have attached the existing Glue access to the ECS task role instead of adding it to the `ecs_department_policy`, as it exceeds the length of a single policy.

