### PR TITLE
Retrieve SSL Cert Bundle for Liberator ECS task

### DIFF
--- a/docker/sql-to-parquet/entrypoint.sh
+++ b/docker/sql-to-parquet/entrypoint.sh
@@ -19,10 +19,13 @@ echo "Snapshot Id - $SNAPSHOT_ID"
 FILENAME="liberator_dump_${DATE}"
 DBNAME="liberator"
 
-MYSQL_CONN_PARAMS="--user=${MYSQL_USER} --password=${MYSQL_PASS} --host=${MYSQL_HOST}"
+wget -O /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem
+
+MYSQL_CONN_PARAMS="--user=${MYSQL_USER} --password=${MYSQL_PASS} --host=${MYSQL_HOST} --ssl-ca=/tmp/rds-combined-ca-bundle.pem"
 
 SSL_MODE=${MYSQL_SSL_MODE:-""}  
 OTHER_FLAGS=${MYSQL_OTHER_FLAGS:-""}  
+
 
 if [ -n "$SSL_MODE" ]; then
   MYSQL_CONN_PARAMS="$MYSQL_CONN_PARAMS --ssl-mode=$SSL_MODE"

--- a/docker/sql-to-parquet/entrypoint.sh
+++ b/docker/sql-to-parquet/entrypoint.sh
@@ -23,14 +23,7 @@ wget -O /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com
 
 MYSQL_CONN_PARAMS="--user=${MYSQL_USER} --password=${MYSQL_PASS} --host=${MYSQL_HOST} --ssl-ca=/tmp/rds-combined-ca-bundle.pem"
 
-SSL_MODE=${MYSQL_SSL_MODE:-""}  
 OTHER_FLAGS=${MYSQL_OTHER_FLAGS:-""}  
-
-
-if [ -n "$SSL_MODE" ]; then
-  MYSQL_CONN_PARAMS="$MYSQL_CONN_PARAMS --ssl-mode=$SSL_MODE"
-  echo "SSL Mode set to $SSL_MODE"
-fi
 
 if [ -n "$OTHER_FLAGS" ]; then
   MYSQL_CONN_PARAMS="$MYSQL_CONN_PARAMS $OTHER_FLAGS"

--- a/docker/sql-to-parquet/entrypoint.sh
+++ b/docker/sql-to-parquet/entrypoint.sh
@@ -19,6 +19,7 @@ echo "Snapshot Id - $SNAPSHOT_ID"
 FILENAME="liberator_dump_${DATE}"
 DBNAME="liberator"
 
+echo "Retrieving pem file..."
 wget -O /tmp/rds-combined-ca-bundle.pem https://truststore.pki.rds.amazonaws.com/eu-west-2/eu-west-2-bundle.pem
 
 MYSQL_CONN_PARAMS="--user=${MYSQL_USER} --password=${MYSQL_PASS} --host=${MYSQL_HOST} --ssl-ca=/tmp/rds-combined-ca-bundle.pem"
@@ -29,8 +30,6 @@ if [ -n "$OTHER_FLAGS" ]; then
   MYSQL_CONN_PARAMS="$MYSQL_CONN_PARAMS $OTHER_FLAGS"
   echo "Additional MySQL flags: $OTHER_FLAGS"
 fi
-
-echo "MYSQL connection params: $MYSQL_CONN_PARAMS"
 
 echo "Deleting old snapshots in database..."
 python3 delete_db_snapshots_in_db.py


### PR DESCRIPTION
Retrieves the pem files and passes it to allow the task to connect to the database in RDS. 

Additionally removes SSL_MODE handling, this can be passed as the more generic "OTHER_FLAGS" if necessary.