### PR TITLE
upgrade airflow to 2.10.3

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -169,7 +169,7 @@ resource "aws_s3_object" "requirements_placeholder" {
 resource "aws_mwaa_environment" "mwaa" {
   count                = local.is_live_environment ? 1 : 0
   name                 = "${local.identifier_prefix}-mwaa-environment"
-  airflow_version      = "2.10.3" # Latest MWAA on 2024-01-13, preinstall python 3.11
+  airflow_version      = "2.10.3" # Latest MWAA on 2025-01-13, preinstall python 3.11
   environment_class    = "mw1.medium"
   execution_role_arn   = aws_iam_role.mwaa_role.arn
   source_bucket_arn    = aws_s3_bucket.mwaa_bucket.arn


### PR DESCRIPTION
This is the latest version of MWAA based on the AWS doc below:
https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html

The upgrade requires updating the Python package version to align with Airflow 2.10.3 and Python 3.11. This has been addressed in the following PR within the Airflow repo:
https://github.com/LBHackney-IT/dap-airflow/pull/270

The reason for upgrading the version of MWAA is that, from Airflow 2.10 onwards, there have been big changes to the UI, making it more user-friendly (see [URL](https://airflow.apache.org/blog/airflow-2.10.0/)).