### PR TITLE
change the cron to 8.00 - parking cycle hagar allocation update

### DIFF
--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1345,7 +1345,7 @@ module "parking_cycle_hangar_allocation_update" {
   script_name                    = "parking_cycle_hangar_allocation_update"
   job_description                = "Rewrite of cycle hangar allocation using new denormalisation code"
   trigger_enabled                = local.is_production_environment
-  schedule                       = "cron(0 9 * * ? *)"
+  schedule                       = "cron(0 8 * * ? *)"
   number_of_workers_for_glue_job = 2
   glue_job_worker_type           = "G.1X"
   glue_version                   = "4.0"


### PR DESCRIPTION
Mike needs to use the parking_cycle_hangar_allocation_update_`latest`, which is scheduled in Airflow at 8:30. Therefore, we need to move this glue job "parking_cycle_hangar_allocation_update' to an earlier timeslot. So I've changed it to 8.00 am