### PR TITLE
upgrade lambda python version to 3.9

### DIFF
--- a/lambdas/g_drive_folder_to_s3/Dockerfile
+++ b/lambdas/g_drive_folder_to_s3/Dockerfile
@@ -18,7 +18,7 @@ COPY Pipfile Pipfile.lock /app/
 COPY main.py ./source/
 
 # Install Python dependencies using pipenv
-RUN pipenv install 
+RUN pipenv install
 RUN pipenv requirements > requirements.txt
 RUN pip install -t ./source/lib -r requirements.txt
 
@@ -27,7 +27,3 @@ WORKDIR /app/source
 RUN zip -r g_drive_folder_to_s3.zip .
 
 CMD "pyhon3", "main.py"
-
-
-
-

--- a/lambdas/kafka_test/Makefile
+++ b/lambdas/kafka_test/Makefile
@@ -7,6 +7,6 @@ install-requirements:
 
 	. venv/bin/activate && sudo pipenv lock --requirements > requirements.txt
 	#. venv/bin/activate && sudo pip install --target ./lib -r requirements.txt
-	. venv/bin/activate && sudo docker run -v $(PWD):/var/task "lambci/lambda:build-python3.11" /bin/sh -c "pip install --target ./lib -r requirements.txt; exit"
+	. venv/bin/activate && sudo docker run -v $(PWD):/var/task "lambci/lambda:build-python3.9" /bin/sh -c "pip install --target ./lib -r requirements.txt; exit"
 	sudo cp ../../terraform/modules/kafka-schema-registry/schemas/* ./lib/
 	rm -rf venv/

--- a/terraform/core/13-mssql-ingestion.tf
+++ b/terraform/core/13-mssql-ingestion.tf
@@ -190,7 +190,7 @@ module "max_concurrency_lambda" {
   s3_key                         = "academy-revs-and-bens-housing-needs-database-ingestion-max-concurrency.zip"
   lambda_source_dir              = "../../lambdas/calculate_max_concurrency"
   lambda_output_path             = "../../lambdas/calculate_max_concurrency/max-concurrency.zip"
-  runtime                        = "python3.11"
+  runtime                        = "python3.9"
 }
 
 resource "aws_iam_role" "academy_step_functions_role" {

--- a/terraform/core/22-sagemaker.tf
+++ b/terraform/core/22-sagemaker.tf
@@ -138,7 +138,7 @@ resource "aws_lambda_function" "shutdown_notebooks" {
 
   role             = aws_iam_role.shutdown_notebooks[0].arn
   handler          = "main.shutdown_notebooks"
-  runtime          = "python3.11"
+  runtime          = "python3.9"
   function_name    = "${local.short_identifier_prefix}shutdown-notebooks"
   s3_bucket        = module.lambda_artefact_storage.bucket_id
   s3_key           = aws_s3_object.shutdown_notebooks.key

--- a/terraform/core/38-api-ingestion.tf
+++ b/terraform/core/38-api-ingestion.tf
@@ -16,7 +16,7 @@ module "icaseworks_api_ingestion" {
   lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
   lambda_name                    = "icaseworks-api-ingestion"
   lambda_handler                 = "main.lambda_handler"
-  runtime_language               = "python3.11"
+  runtime_language               = "python3.9"
   secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
   s3_target_bucket_arn           = module.landing_zone.bucket_arn
   s3_target_bucket_name          = local.s3_target_bucket_name
@@ -44,7 +44,7 @@ module "vonage_api_ingestion" {
   lambda_artefact_storage_bucket = module.lambda_artefact_storage.bucket_id
   lambda_name                    = "vonage-api-ingestion"
   lambda_handler                 = "main.lambda_handler"
-  runtime_language               = "python3.11"
+  runtime_language               = "python3.9"
   secrets_manager_kms_key        = aws_kms_key.secrets_manager_key
   s3_target_bucket_arn           = module.landing_zone.bucket_arn
   s3_target_bucket_name          = local.s3_target_bucket_name

--- a/terraform/modules/api-ingestion-lambda/01-inputs-required.tf
+++ b/terraform/modules/api-ingestion-lambda/01-inputs-required.tf
@@ -65,11 +65,11 @@ variable "runtime_language" {
   validation {
     condition = (
       contains([
-        "python3.11",
+        "python3.9",
         "nodejs14.x"
       ], var.runtime_language)
     )
-    error_message = "The value cannot be a blank string, and must be one of the following: 'python3.11' or 'nodejs14.x'"
+    error_message = "The value cannot be a blank string, and must be one of the following: 'python3.9' or 'nodejs14.x'"
   }
 }
 

--- a/terraform/modules/api-ingestion-lambda/10-lambda.tf
+++ b/terraform/modules/api-ingestion-lambda/10-lambda.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 locals {
-  command = var.runtime_language == "python3.11" ? "make install-requirements" : (var.runtime_language == "nodejs14.x" ? "npm install" : 0)
+  command = var.runtime_language == "python3.9" ? "make install-requirements" : (var.runtime_language == "nodejs14.x" ? "npm install" : 0)
   # This ensures that this data resource will not be evaluated until
   # after the null_resource has been created.
   lambda_exporter_id = null_resource.run_install_requirements.id

--- a/terraform/modules/aws-lambda-folder-ingestion/02-inputs-optional.tf
+++ b/terraform/modules/aws-lambda-folder-ingestion/02-inputs-optional.tf
@@ -19,7 +19,7 @@ variable "tags" {
 variable "runtime" {
   type        = string
   description = "Runtime to use for the Lambda Function"
-  default     = "python3.11"
+  default     = "python3.9"
   validation {
     condition = contains(["python3.9", "python3.10", "python3.11"], var.runtime)
     error_message = "Runtime must be a valid Python runtime"

--- a/terraform/modules/aws-lambda/02-inputs-optional.tf
+++ b/terraform/modules/aws-lambda/02-inputs-optional.tf
@@ -19,7 +19,7 @@ variable "tags" {
 variable "runtime" {
   type        = string
   description = "Runtime to use for the Lambda Function"
-  default     = "python3.11"
+  default     = "python3.9"
   validation {
     condition     = can(regex("python3[.]([7-9]|10)", var.runtime))
     error_message = "Runtime must be a valid Python runtime"

--- a/terraform/modules/g-drive-to-s3/10-lambda.tf
+++ b/terraform/modules/g-drive-to-s3/10-lambda.tf
@@ -133,7 +133,7 @@ resource "aws_lambda_function" "g_drive_to_s3_copier_lambda" {
 
   role             = aws_iam_role.g_drive_to_s3_copier_lambda.arn
   handler          = "main.lambda_handler"
-  runtime          = "python3.11"
+  runtime          = "python3.9"
   function_name    = lower("${var.identifier_prefix}g-drive-${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.g_drive_to_s3_copier_lambda.key

--- a/terraform/modules/glue-failure-alert-notifications/10-main.tf
+++ b/terraform/modules/glue-failure-alert-notifications/10-main.tf
@@ -89,7 +89,7 @@ resource "aws_lambda_function" "lambda" {
   function_name     = lower("${var.identifier_prefix}${var.lambda_name}")
   role              = aws_iam_role.lambda.arn
   handler           = "main.lambda_handler"
-  runtime           = "python3.11"
+  runtime           = "python3.9"
   source_code_hash  = filebase64sha256(data.archive_file.lambda.output_path)
   s3_bucket         = var.lambda_artefact_storage_bucket
   s3_key            = "${local.lambda_name_underscore}.zip"

--- a/terraform/modules/kafka-test-lambda/10-lambda.tf
+++ b/terraform/modules/kafka-test-lambda/10-lambda.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 
 locals {
   command                 = "make install-requirements"
-  confluent_kafka_command = "docker run -v \"$PWD\":/var/task \"lambci/lambda:build-python3.11\" /bin/sh -c \"pip install -r requirements.txt -t python/lib/python3.11/site-packages/; exit\""
+  confluent_kafka_command = "docker run -v \"$PWD\":/var/task \"lambci/lambda:build-python3.9\" /bin/sh -c \"pip install -r requirements.txt -t python/lib/python3.9/site-packages/; exit\""
   # This ensures that this data resource will not be evaluated until
   # after the null_resource has been created.
   lambda_exporter_id = null_resource.run_install_requirements.id
@@ -151,7 +151,7 @@ resource "aws_lambda_function" "lambda" {
 
   role             = aws_iam_role.lambda.arn
   handler          = "main.lambda_handler"
-  runtime          = "python3.11"
+  runtime          = "python3.9"
   function_name    = lower("${var.identifier_prefix}${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.lambda.key

--- a/terraform/modules/lambda-alarms-handler/10-aws-lambda.tf
+++ b/terraform/modules/lambda-alarms-handler/10-aws-lambda.tf
@@ -110,7 +110,7 @@ resource "aws_lambda_function" "lambda" {
 
   role             = aws_iam_role.lambda.arn
   handler          = "main.lambda_handler"
-  runtime          = "python3.11"
+  runtime          = "python3.9"
   function_name    = lower("${var.identifier_prefix}${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.lambda.key


### PR DESCRIPTION
AWS stopped maintaining Lambda Python version 3.8 from October 2024. Thanks, Stuart, for the information.

I tried upgrading it to Python 3.11, but the current AWS provider (4.0) doesn’t support this Lambda Python version (mentioned via this [release note](it is mentioned here:
https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md)), which requires version above` 5.11.0`

Therefore, I have only upgraded it to Python 3.9