### PR TITLE
temp fix on the unrestricted_address_api_dbo_hackney_address

### DIFF
--- a/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
+++ b/scripts/jobs/parking/parking_permit_denormalised_gds_street_llpg.py
@@ -1,17 +1,20 @@
-from calendar import c
 import sys
+from calendar import c
+
+from awsglue import DynamicFrame
+from awsglue.context import GlueContext
+from awsglue.job import Job
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from awsglue.context import GlueContext
-from awsglue.job import Job
-from awsglue import DynamicFrame
+
 from scripts.helpers.helpers import (
-    get_glue_env_var,
-    get_latest_partitions,
     PARTITION_KEYS,
     create_pushdown_predicate,
+    get_glue_env_var,
+    get_latest_partitions,
 )
+
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
@@ -29,20 +32,18 @@ job.init(args["JOB_NAME"], args)
 environment = get_glue_env_var("environment")
 
 # Script generated for node S3 bucket - refined - parking_permit_denormalised_data
-S3bucketrefinedparking_permit_denormalised_data_node1 = (
-    glueContext.create_dynamic_frame.from_catalog(
-        database="dataplatform-"+environment+"-liberator-refined-zone",
-        table_name="parking_permit_denormalised_data",
-        transformation_ctx="S3bucketrefinedparking_permit_denormalised_data_node1",
-        #teporarily removed while table partitions are fixed
-        #push_down_predicate=create_pushdown_predicate("import_date", 7),
-    )
+S3bucketrefinedparking_permit_denormalised_data_node1 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-liberator-refined-zone",
+    table_name="parking_permit_denormalised_data",
+    transformation_ctx="S3bucketrefinedparking_permit_denormalised_data_node1",
+    # teporarily removed while table partitions are fixed
+    # push_down_predicate=create_pushdown_predicate("import_date", 7),
 )
 
 # Script generated for node Amazon S3 - raw - liberator_permit_llpg
 AmazonS3rawliberator_permit_llpg_node1657535904691 = (
     glueContext.create_dynamic_frame.from_catalog(
-        database="dataplatform-"+environment+"-liberator-raw-zone",
+        database="dataplatform-" + environment + "-liberator-raw-zone",
         table_name="liberator_permit_llpg",
         transformation_ctx="AmazonS3rawliberator_permit_llpg_node1657535904691",
         push_down_predicate=create_pushdown_predicate("import_date", 7),
@@ -51,10 +52,10 @@ AmazonS3rawliberator_permit_llpg_node1657535904691 = (
 
 # Script generated for node Amazon S3 - unrestricted_address_api_dbo_hackney_address
 AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004 = glueContext.create_dynamic_frame.from_catalog(
-    database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api",
+    database="dataplatform-" + environment + "-raw-zone-unrestricted-address-api",
     table_name="unrestricted_address_api_dbo_hackney_address",
     transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_address_node1657535910004",
-    push_down_predicate=create_pushdown_predicate("import_date", 7),
+    push_down_predicate=create_pushdown_predicate("import_date", 30),
 )
 
 # Script generated for node Amazon S3 - parking raw - ltn_london_fields
@@ -69,7 +70,7 @@ AmazonS3parkingrawltn_london_fields_node1657536241729 = (
 # Script generated for node Apply Mapping - New
 SqlQuery0 = """
 /*08/04/2022 - added ,case when latest_permit_status in('Approved','Renewed','Created','ORDER_APPROVED','PENDING_VRM_CHANGE','RENEW_EVID','PENDING_ADDR_CHANGE') and live_permit_flag = 1 then 1 else 0 end as live_flag */
-with street as (select  
+with street as (select
     UPRN as SR_UPRN,
 	ADDRESS1 as SR_ADDRESS1,
 	ADDRESS2 as SR_ADDRESS2,
@@ -96,27 +97,27 @@ with street as (select
 	STREET_END_X as SR_STREET_END_X,
 	STREET_END_Y as SR_STREET_END_Y,
 	WARD_CODE as SR_WARD_CODE,
-if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',    
-if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',    
-if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',    
-if(WARD_CODE = 'E05009370',    'DALSTON WARD',    
-if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',    
-if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',    
-if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',    
-if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',    
-if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',    
-if(WARD_CODE = 'E05009376',    'HOMERTON WARD',    
-if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',    
-if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',    
-if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',    
-if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',    
-if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',    
-if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',    
-if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',    
-if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',    
-if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',    
-if(WARD_CODE = 'E05009386',    'VICTORIA WARD',    
-if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name, 	 
+if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',
+if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',
+if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',
+if(WARD_CODE = 'E05009370',    'DALSTON WARD',
+if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',
+if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',
+if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',
+if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',
+if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',
+if(WARD_CODE = 'E05009376',    'HOMERTON WARD',
+if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',
+if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',
+if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',
+if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',
+if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',
+if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',
+if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',
+if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',
+if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',
+if(WARD_CODE = 'E05009386',    'VICTORIA WARD',
+if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name,
 	PARISH_CODE as SR_PARISH_CODE,
 	PARENT_UPRN as SR_PARENT_UPRN,
 	PAO_START as SR_PAO_START,
@@ -142,14 +143,14 @@ where (ADDRESS1 like 'Street Record' or ADDRESS1 like 'STREET RECORD') and liber
   SELECT * FROM unrestricted_address_api_dbo_hackney_address where unrestricted_address_api_dbo_hackney_address.import_date = (SELECT max(unrestricted_address_api_dbo_hackney_address.import_date) FROM unrestricted_address_api_dbo_hackney_address) and lpi_logical_status like 'Approved Preferred'
   )
 SELECT street.usrn as sr_usrn, SR_ADDRESS1, SR_ADDRESS2, llpg.street_description, SR_WARD_CODE, SR_ward_name, llpg.property_shell, llpg.blpu_class, llpg.usage_primary, llpg.usage_description
-,concat(cast(street.usrn as string),' - ', llpg.street_description) as street, concat(cast(llpg.uprn as string),' - ',llpg.usage_description) as add_type , concat(llpg.blpu_class,' - ',llpg.planning_use_class ) as add_class, 
+,concat(cast(street.usrn as string),' - ', llpg.street_description) as street, concat(cast(llpg.uprn as string),' - ',llpg.usage_description) as add_type , concat(llpg.blpu_class,' - ',llpg.planning_use_class ) as add_class,
 
 case when cpz !='' and cpz_name != '' then concat(cpz,' - ', cpz_name)
 when cpz !='' and cpz_name = '' then concat(cpz)
 when cpz ='' and cpz_name != '' then concat(cpz_name)
 else 'NONE'
-end as zone_name, 
-case 
+end as zone_name,
+case
 
 when address_line_2 ='' and business_name ='' and hasc_organisation_name ='' and  doctors_surgery_name ='' then concat(permit_reference,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
 when business_name !='' and hasc_organisation_name !='' and address_line_2 ='' then concat(permit_reference,' - ',business_name,' - ',hasc_organisation_name,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
@@ -167,37 +168,37 @@ when doctors_surgery_name !='' and address_line_3 ='' then concat(permit_referen
 
 
 when business_name !='' then concat(permit_reference,' - ',business_name,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
-when hasc_organisation_name !='' then concat(permit_reference,' - ',hasc_organisation_name,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant) 
+when hasc_organisation_name !='' then concat(permit_reference,' - ',hasc_organisation_name,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
 when doctors_surgery_name !='' then concat(permit_reference,' - ',doctors_surgery_name,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
 
-else concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant) 
+else concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode,' - ',email_address_of_applicant)
 end as permit_summary
 
 
-,case 
+,case
 when address_line_2 ='' then concat(permit_reference,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode)
-when address_line_3 ='' then concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode) 
-else concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode) 
+when address_line_3 ='' then concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode)
+else concat(permit_reference,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode)
 end as permit_full_address
-,case 
+,case
 when address_line_2 ='' then concat(address_line_1,', ',parking_permit_denormalised_data.postcode)
-when address_line_3 ='' then concat(address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode) 
-else concat(address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode) 
+when address_line_3 ='' then concat(address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode)
+else concat(address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode)
 end as full_address
 
-,case 
-when address_line_2 ='' then concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode) 
-when address_line_3 ='' then concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode) 
-else concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode) 
+,case
+when address_line_2 ='' then concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode)
+when address_line_3 ='' then concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode)
+else concat(permit_reference,' - ',usage_primary,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode)
 end as permit_full_address_type
 
-,case 
-when address_line_2 ='' then concat(usage_primary,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode) 
-when address_line_3 ='' then concat(usage_primary,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode) 
-else concat(usage_primary,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode) 
+,case
+when address_line_2 ='' then concat(usage_primary,' - ',address_line_1,', ',parking_permit_denormalised_data.postcode)
+when address_line_3 ='' then concat(usage_primary,' - ',address_line_1,', ',address_line_2,', ',parking_permit_denormalised_data.postcode)
+else concat(usage_primary,' - ',address_line_1,', ',address_line_2,', ',address_line_3,', ',parking_permit_denormalised_data.postcode)
 end as full_address_type
 
-,case when latest_permit_status in('Approved','Renewed','Created','ORDER_APPROVED','PENDING_VRM_CHANGE','RENEW_EVID','PENDING_ADDR_CHANGE') and live_permit_flag = 1 then 1 else 0 end as live_flag 
+,case when latest_permit_status in('Approved','Renewed','Created','ORDER_APPROVED','PENDING_VRM_CHANGE','RENEW_EVID','PENDING_ADDR_CHANGE') and live_permit_flag = 1 then 1 else 0 end as live_flag
 
 ,Case when live_permit_flag = 1 and blue_badge_number !='' and permit_type like 'Estate Resident' and (amount like '0.00' or amount like '0.000'  or amount like '') then 1 else 0 end as flag_lp_est_bb_zero
 ,Case when live_permit_flag = 1 and blue_badge_number !='' and permit_type != 'Estate Resident' then 1 else 0 end as flag_lp_bb_onst
@@ -220,7 +221,7 @@ end as full_address_type
 
 , parking_permit_denormalised_data.*, llpg.planning_use_class, llpg.longitude, llpg.latitude  FROM parking_permit_denormalised_data
 
-left join llpg on cast(llpg.uprn as string) = cast(parking_permit_denormalised_data.uprn as string) /*and 
+left join llpg on cast(llpg.uprn as string) = cast(parking_permit_denormalised_data.uprn as string) /*and
 cast(concat(parking_permit_denormalised_data.import_year,parking_permit_denormalised_data.import_month,parking_permit_denormalised_data.import_day) as string
 ) = llpg.import_date*/
 
@@ -247,7 +248,9 @@ ApplyMappingNew_node1657710041310 = sparkSqlQuery(
 
 # Script generated for node Amazon S3
 AmazonS3_node1657709892303 = glueContext.getSink(
-    path="s3://dataplatform-"+environment+"-refined-zone/parking/liberator/parking_permit_denormalised_gds_street_llpg/",
+    path="s3://dataplatform-"
+    + environment
+    + "-refined-zone/parking/liberator/parking_permit_denormalised_gds_street_llpg/",
     connection_type="s3",
     updateBehavior="UPDATE_IN_DATABASE",
     partitionKeys=["import_year", "import_month", "import_day", "import_date"],
@@ -256,7 +259,7 @@ AmazonS3_node1657709892303 = glueContext.getSink(
     transformation_ctx="AmazonS3_node1657709892303",
 )
 AmazonS3_node1657709892303.setCatalogInfo(
-    catalogDatabase="dataplatform-"+environment+"-liberator-refined-zone",
+    catalogDatabase="dataplatform-" + environment + "-liberator-refined-zone",
     catalogTableName="parking_permit_denormalised_gds_street_llpg",
 )
 AmazonS3_node1657709892303.setFormat("glueparquet")

--- a/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
+++ b/scripts/jobs/parking/parking_vouchers_approved_summary_gds.py
@@ -1,39 +1,68 @@
 import sys
+
+from awsglue import DynamicFrame
+from awsglue.context import GlueContext
+from awsglue.job import Job
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from awsglue.context import GlueContext
-from awsglue.job import Job
-from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS
+
+from scripts.helpers.helpers import (
+    PARTITION_KEYS,
+    get_glue_env_var,
+    get_latest_partitions,
+)
+
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
         frame.toDF().createOrReplaceTempView(alias)
     result = spark.sql(query)
     return DynamicFrame.fromDF(result, glueContext, transformation_ctx)
-args = getResolvedOptions(sys.argv, ['JOB_NAME'])
+
+
+args = getResolvedOptions(sys.argv, ["JOB_NAME"])
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session
 job = Job(glueContext)
-job.init(args['JOB_NAME'], args)
+job.init(args["JOB_NAME"], args)
 environment = get_glue_env_var("environment")
 
 # Script generated for node Amazon S3 liberator-raw-zone - liberator_permit_llpg
-AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-liberator-raw-zone", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="liberator_permit_llpg", transformation_ctx="AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559")
+AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-liberator-raw-zone",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="liberator_permit_llpg",
+    transformation_ctx="AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559",
+)
 
 # Script generated for node Amazon S3 - liberator-refined-zone - parking_voucher_de_normalised
-AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-liberator-refined-zone", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="parking_voucher_de_normalised", transformation_ctx="AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376")
+AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-liberator-refined-zone",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="parking_voucher_de_normalised",
+    transformation_ctx="AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376",
+)
 
 # Script generated for node Amazon S3 - raw-zone-unrestricted-address-api - unrestricted_address_api_dbo_hackney_address
-AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="unrestricted_address_api_dbo_hackney_address", transformation_ctx="AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032")
+AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-raw-zone-unrestricted-address-api",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="unrestricted_address_api_dbo_hackney_address",
+    transformation_ctx="AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032",
+)
 
 # Script generated for node Amazon S3 - unrestricted_address_api_dbo_hackney_xref
-AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="unrestricted_address_api_dbo_hackney_xref", transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086")
+AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-raw-zone-unrestricted-address-api",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 30)",
+    table_name="unrestricted_address_api_dbo_hackney_xref",
+    transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086",
+)
 
 # Script generated for node SQL Query
-SqlQuery0 = '''
+SqlQuery0 = """
 /*
 03/07/2024 - updated vouchers approved version two
 09/07/2024 - breakdown by household, street, zone, lbh versions.  This is the CPZ version
@@ -280,12 +309,12 @@ when parking_voucher_de_normalised.voucher_ref ='HY50300' then 'Dispensation'
 when substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYS' then 'Suspension' else 'Permit'
 end as product_category
 
-,case when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or 
+,case when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or
  substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYF'or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYQ' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYV' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYJ' ) and parking_voucher_de_normalised.e_voucher ='E' then 'eVoucher'
-when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or 
+when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or
  substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYF'or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYQ' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYV' or
@@ -293,7 +322,7 @@ substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYJ' ) and
  parking_voucher_de_normalised.e_voucher <> 'E' then 'Paper Voucher' else 'Not Voucher' end as voucher_type_category
 
 /*Calculation of total vouchers in books*/
-,cast(case 
+,cast(case
 when upper(permit_type) like '2 HOUR VISITORS VOUCHERS' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 20 *  try_cast(quantity as double) --2 hour visitors vouchers x20
 when upper(permit_type) like '1 DAY VISITORS VOUCHERS' and  (quantity is not null or quantity not like '' or quantity not like ' ')  THEN 5 *  try_cast(quantity as double) --1 day visitors vouchers x5
 when upper(permit_type) like 'FILM VOUCHER' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 10 *  try_cast(quantity as double) --Film voucher x10
@@ -301,11 +330,11 @@ when upper(permit_type) like 'ESTATE VISITOR VOUCHERS' and  (quantity is not nul
 when upper(permit_type) like 'HEALTH AND SOCIAL CARE VOUCHER' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 5 *  try_cast(quantity as double) --Health and Social Care Voucher x5
 when upper(permit_type) like 'ALL ZONE BUSINESS VOUCHER' and  (quantity is not null or quantity not like '' or quantity not like ' ')  THEN 10 *  try_cast(quantity as double) --All Zone Business Voucher x10
 end as decimal (10,0)) as total_num_vouchers_in_book
-,* 
+,*
 from parking_voucher_de_normalised where import_date = (Select max(import_date) from parking_voucher_de_normalised ) --544,689
 
 )
-, street as (select  
+, street as (select
     UPRN as SR_UPRN,
 	ADDRESS1 as SR_ADDRESS1,
 	ADDRESS2 as SR_ADDRESS2,
@@ -332,27 +361,27 @@ from parking_voucher_de_normalised where import_date = (Select max(import_date) 
 	STREET_END_X as SR_STREET_END_X,
 	STREET_END_Y as SR_STREET_END_Y,
 	WARD_CODE as SR_WARD_CODE,
-if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',    
-if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',    
-if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',    
-if(WARD_CODE = 'E05009370',    'DALSTON WARD',    
-if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',    
-if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',    
-if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',    
-if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',    
-if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',    
-if(WARD_CODE = 'E05009376',    'HOMERTON WARD',    
-if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',    
-if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',    
-if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',    
-if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',    
-if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',    
-if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',    
-if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',    
-if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',    
-if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',    
-if(WARD_CODE = 'E05009386',    'VICTORIA WARD',    
-if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name, 	 
+if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',
+if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',
+if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',
+if(WARD_CODE = 'E05009370',    'DALSTON WARD',
+if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',
+if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',
+if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',
+if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',
+if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',
+if(WARD_CODE = 'E05009376',    'HOMERTON WARD',
+if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',
+if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',
+if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',
+if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',
+if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',
+if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',
+if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',
+if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',
+if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',
+if(WARD_CODE = 'E05009386',    'VICTORIA WARD',
+if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name,
 	PARISH_CODE as SR_PARISH_CODE,
 	PARENT_UPRN as SR_PARENT_UPRN,
 	PAO_START as SR_PAO_START,
@@ -378,10 +407,10 @@ where (ADDRESS1 like 'Street Record' or ADDRESS1 like 'STREET RECORD') and liber
   SELECT * FROM unrestricted_address_api_dbo_hackney_address where unrestricted_address_api_dbo_hackney_address.import_date = (SELECT max(unrestricted_address_api_dbo_hackney_address.import_date) FROM unrestricted_address_api_dbo_hackney_address) and lpi_logical_status like 'Approved Preferred'
   )
 , cfxref as (
-select * from  unrestricted_address_api_dbo_hackney_xref where import_date = (select max(import_date)  from  unrestricted_address_api_dbo_hackney_xref) and xref_name like 'Parking Blacklisted S106' 
+select * from  unrestricted_address_api_dbo_hackney_xref where import_date = (select max(import_date)  from  unrestricted_address_api_dbo_hackney_xref) and xref_name like 'Parking Blacklisted S106'
 )
 
-select distinct 
+select distinct
 
 vou.fy
 ,vou.cpz
@@ -470,11 +499,11 @@ vou.fy
 
 
 from vou
-left join llpg on cast(llpg.uprn as string) = cast(vou.uprn as string) 
+left join llpg on cast(llpg.uprn as string) = cast(vou.uprn as string)
 left join street on cast(street.usrn as string) = cast(llpg.usrn as string)
-left join cfxref on cast(cfxref.uprn as string) = cast(vou.uprn as string) 
+left join cfxref on cast(cfxref.uprn as string) = cast(vou.uprn as string)
 
-Where 
+Where
 vou.approved_status_flag = 1
 
 group by
@@ -505,12 +534,38 @@ vou.month_year_application_date desc
 ,vou.cpz
 --,vou.cpz_name
 --,vou.zone_name
-'''
-SQLQuery_node1720617258366 = sparkSqlQuery(glueContext, query = SqlQuery0, mapping = {"parking_voucher_de_normalised":AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376, "liberator_permit_llpg":AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559, "unrestricted_address_api_dbo_hackney_address":AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032, "unrestricted_address_api_dbo_hackney_xref":AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086}, transformation_ctx = "SQLQuery_node1720617258366")
+"""
+SQLQuery_node1720617258366 = sparkSqlQuery(
+    glueContext,
+    query=SqlQuery0,
+    mapping={
+        "parking_voucher_de_normalised": AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376,
+        "liberator_permit_llpg": AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559,
+        "unrestricted_address_api_dbo_hackney_address": AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032,
+        "unrestricted_address_api_dbo_hackney_xref": AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724073104086,
+    },
+    transformation_ctx="SQLQuery_node1720617258366",
+)
 
 # Script generated for node Amazon S3 - parking_vouchers_approved_summary_gds
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938 = glueContext.getSink(path="s3://dataplatform-"+environment+"-refined-zone/parking/liberator/parking_vouchers_approved_summary_gds/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=["import_year", "import_month", "import_day", "import_date"], enableUpdateCatalog=True, transformation_ctx="AmazonS3parking_vouchers_approved_summary_gds_node1720617264938")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setCatalogInfo(catalogDatabase="dataplatform-"+environment+"-liberator-refined-zone",catalogTableName="parking_vouchers_approved_summary_gds")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setFormat("glueparquet", compression="snappy")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.writeFrame(SQLQuery_node1720617258366)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938 = glueContext.getSink(
+    path="s3://dataplatform-"
+    + environment
+    + "-refined-zone/parking/liberator/parking_vouchers_approved_summary_gds/",
+    connection_type="s3",
+    updateBehavior="UPDATE_IN_DATABASE",
+    partitionKeys=["import_year", "import_month", "import_day", "import_date"],
+    enableUpdateCatalog=True,
+    transformation_ctx="AmazonS3parking_vouchers_approved_summary_gds_node1720617264938",
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setCatalogInfo(
+    catalogDatabase="dataplatform-" + environment + "-liberator-refined-zone",
+    catalogTableName="parking_vouchers_approved_summary_gds",
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setFormat(
+    "glueparquet", compression="snappy"
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.writeFrame(
+    SQLQuery_node1720617258366
+)
 job.commit()

--- a/scripts/jobs/parking/parking_vouchers_approved_summary_gds_lbh.py
+++ b/scripts/jobs/parking/parking_vouchers_approved_summary_gds_lbh.py
@@ -1,39 +1,68 @@
 import sys
+
+from awsglue import DynamicFrame
+from awsglue.context import GlueContext
+from awsglue.job import Job
 from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
-from awsglue.context import GlueContext
-from awsglue.job import Job
-from awsglue import DynamicFrame
-from scripts.helpers.helpers import get_glue_env_var, get_latest_partitions, PARTITION_KEYS
+
+from scripts.helpers.helpers import (
+    PARTITION_KEYS,
+    get_glue_env_var,
+    get_latest_partitions,
+)
+
 
 def sparkSqlQuery(glueContext, query, mapping, transformation_ctx) -> DynamicFrame:
     for alias, frame in mapping.items():
         frame.toDF().createOrReplaceTempView(alias)
     result = spark.sql(query)
     return DynamicFrame.fromDF(result, glueContext, transformation_ctx)
-args = getResolvedOptions(sys.argv, ['JOB_NAME'])
+
+
+args = getResolvedOptions(sys.argv, ["JOB_NAME"])
 sc = SparkContext()
 glueContext = GlueContext(sc)
 spark = glueContext.spark_session
 job = Job(glueContext)
-job.init(args['JOB_NAME'], args)
+job.init(args["JOB_NAME"], args)
 environment = get_glue_env_var("environment")
 
 # Script generated for node Amazon S3 - unrestricted_address_api_dbo_hackney_xref
-AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="unrestricted_address_api_dbo_hackney_xref", transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047")
+AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-raw-zone-unrestricted-address-api",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="unrestricted_address_api_dbo_hackney_xref",
+    transformation_ctx="AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047",
+)
 
 # Script generated for node Amazon S3 liberator-raw-zone - liberator_permit_llpg
-AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-liberator-raw-zone", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="liberator_permit_llpg", transformation_ctx="AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559")
+AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-liberator-raw-zone",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="liberator_permit_llpg",
+    transformation_ctx="AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559",
+)
 
 # Script generated for node Amazon S3 - liberator-refined-zone - parking_voucher_de_normalised
-AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-liberator-refined-zone", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="parking_voucher_de_normalised", transformation_ctx="AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376")
+AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-liberator-refined-zone",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)",
+    table_name="parking_voucher_de_normalised",
+    transformation_ctx="AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376",
+)
 
 # Script generated for node Amazon S3 - raw-zone-unrestricted-address-api - unrestricted_address_api_dbo_hackney_address
-AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032 = glueContext.create_dynamic_frame.from_catalog(database="dataplatform-"+environment+"-raw-zone-unrestricted-address-api", push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 7)", table_name="unrestricted_address_api_dbo_hackney_address", transformation_ctx="AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032")
+AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032 = glueContext.create_dynamic_frame.from_catalog(
+    database="dataplatform-" + environment + "-raw-zone-unrestricted-address-api",
+    push_down_predicate="to_date(import_date, 'yyyyMMdd') >= date_sub(current_date, 30)",
+    table_name="unrestricted_address_api_dbo_hackney_address",
+    transformation_ctx="AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032",
+)
 
 # Script generated for node SQL Query
-SqlQuery0 = '''
+SqlQuery0 = """
 /*
 03/07/2024 - updated vouchers approved version two
 09/07/2024 - breakdown by household, street, zone, lbh versions.  This is the LBH version
@@ -281,12 +310,12 @@ when parking_voucher_de_normalised.voucher_ref ='HY50300' then 'Dispensation'
 when substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYS' then 'Suspension' else 'Permit'
 end as product_category
 
-,case when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or 
+,case when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or
  substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYF'or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYQ' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYV' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYJ' ) and parking_voucher_de_normalised.e_voucher ='E' then 'eVoucher'
-when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or 
+when (substr(parking_voucher_de_normalised.voucher_ref,1,3) ='HYE' or
  substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYF'or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYQ' or
 substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYV' or
@@ -294,7 +323,7 @@ substr(parking_voucher_de_normalised.voucher_ref,1,3)='HYJ' ) and
  parking_voucher_de_normalised.e_voucher <> 'E' then 'Paper Voucher' else 'Not Voucher' end as voucher_type_category
 
 /*Calculation of total vouchers in books*/
-,cast(case 
+,cast(case
 when upper(permit_type) like '2 HOUR VISITORS VOUCHERS' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 20 *  try_cast(quantity as double) --2 hour visitors vouchers x20
 when upper(permit_type) like '1 DAY VISITORS VOUCHERS' and  (quantity is not null or quantity not like '' or quantity not like ' ')  THEN 5 *  try_cast(quantity as double) --1 day visitors vouchers x5
 when upper(permit_type) like 'FILM VOUCHER' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 10 *  try_cast(quantity as double) --Film voucher x10
@@ -302,11 +331,11 @@ when upper(permit_type) like 'ESTATE VISITOR VOUCHERS' and  (quantity is not nul
 when upper(permit_type) like 'HEALTH AND SOCIAL CARE VOUCHER' and (quantity is not null or quantity not like '' or quantity not like ' ') THEN 5 *  try_cast(quantity as double) --Health and Social Care Voucher x5
 when upper(permit_type) like 'ALL ZONE BUSINESS VOUCHER' and  (quantity is not null or quantity not like '' or quantity not like ' ')  THEN 10 *  try_cast(quantity as double) --All Zone Business Voucher x10
 end as decimal (10,0)) as total_num_vouchers_in_book
-,* 
+,*
 from parking_voucher_de_normalised where import_date = (Select max(import_date) from parking_voucher_de_normalised ) --544,689
 
 )
-, street as (select  
+, street as (select
     UPRN as SR_UPRN,
 	ADDRESS1 as SR_ADDRESS1,
 	ADDRESS2 as SR_ADDRESS2,
@@ -333,27 +362,27 @@ from parking_voucher_de_normalised where import_date = (Select max(import_date) 
 	STREET_END_X as SR_STREET_END_X,
 	STREET_END_Y as SR_STREET_END_Y,
 	WARD_CODE as SR_WARD_CODE,
-if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',    
-if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',    
-if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',    
-if(WARD_CODE = 'E05009370',    'DALSTON WARD',    
-if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',    
-if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',    
-if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',    
-if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',    
-if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',    
-if(WARD_CODE = 'E05009376',    'HOMERTON WARD',    
-if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',    
-if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',    
-if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',    
-if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',    
-if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',    
-if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',    
-if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',    
-if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',    
-if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',    
-if(WARD_CODE = 'E05009386',    'VICTORIA WARD',    
-if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name, 	 
+if(WARD_CODE = 'E05009367',    'BROWNSWOOD WARD',
+if(WARD_CODE = 'E05009368',    'CAZENOVE WARD',
+if(WARD_CODE = 'E05009369',    'CLISSOLD WARD',
+if(WARD_CODE = 'E05009370',    'DALSTON WARD',
+if(WARD_CODE = 'E05009371',    'DE BEAUVOIR WARD',
+if(WARD_CODE = 'E05009372',    'HACKNEY CENTRAL WARD',
+if(WARD_CODE = 'E05009373',    'HACKNEY DOWNS WARD',
+if(WARD_CODE = 'E05009374',    'HACKNEY WICK WARD',
+if(WARD_CODE = 'E05009375',    'HAGGERSTON WARD',
+if(WARD_CODE = 'E05009376',    'HOMERTON WARD',
+if(WARD_CODE = 'E05009377',    'HOXTON EAST AND SHOREDITCH WARD',
+if(WARD_CODE = 'E05009378',    'HOXTON WEST WARD',
+if(WARD_CODE = 'E05009379',    'KINGS PARK WARD',
+if(WARD_CODE = 'E05009380',    'LEA BRIDGE WARD',
+if(WARD_CODE = 'E05009381',    'LONDON FIELDS WARD',
+if(WARD_CODE = 'E05009382',    'SHACKLEWELL WARD',
+if(WARD_CODE = 'E05009383',    'SPRINGFIELD WARD',
+if(WARD_CODE = 'E05009384',    'STAMFORD HILL WEST',
+if(WARD_CODE = 'E05009385',    'STOKE NEWINGTON WARD',
+if(WARD_CODE = 'E05009386',    'VICTORIA WARD',
+if(WARD_CODE = 'E05009387',    'WOODBERRY DOWN WARD',WARD_CODE))))))))))))))))))))) as SR_ward_name,
 	PARISH_CODE as SR_PARISH_CODE,
 	PARENT_UPRN as SR_PARENT_UPRN,
 	PAO_START as SR_PAO_START,
@@ -379,10 +408,10 @@ where (ADDRESS1 like 'Street Record' or ADDRESS1 like 'STREET RECORD') and liber
   SELECT * FROM unrestricted_address_api_dbo_hackney_address where unrestricted_address_api_dbo_hackney_address.import_date = (SELECT max(unrestricted_address_api_dbo_hackney_address.import_date) FROM unrestricted_address_api_dbo_hackney_address) and lpi_logical_status like 'Approved Preferred'
   )
 , cfxref as (
-select * from  unrestricted_address_api_dbo_hackney_xref where import_date = (select max(import_date)  from  unrestricted_address_api_dbo_hackney_xref) and xref_name like 'Parking Blacklisted S106' 
+select * from  unrestricted_address_api_dbo_hackney_xref where import_date = (select max(import_date)  from  unrestricted_address_api_dbo_hackney_xref) and xref_name like 'Parking Blacklisted S106'
 )
 
-select distinct 
+select distinct
 
 vou.fy
 
@@ -470,11 +499,11 @@ vou.fy
 
 
 from vou
-left join llpg on cast(llpg.uprn as string) = cast(vou.uprn as string) 
+left join llpg on cast(llpg.uprn as string) = cast(vou.uprn as string)
 left join street on cast(street.usrn as string) = cast(llpg.usrn as string)
-left join cfxref on cast(cfxref.uprn as string) = cast(vou.uprn as string) 
+left join cfxref on cast(cfxref.uprn as string) = cast(vou.uprn as string)
 
-Where 
+Where
 vou.approved_status_flag = 1
 
 group by
@@ -500,12 +529,38 @@ vou.month_year_application_date desc
 ,vou.PermitType asc --voucherType asc
 ,vou.voucher_period asc
 ,vou.voucher_type_category asc
-'''
-SQLQuery_node1720617258366 = sparkSqlQuery(glueContext, query = SqlQuery0, mapping = {"parking_voucher_de_normalised":AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376, "liberator_permit_llpg":AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559, "unrestricted_address_api_dbo_hackney_address":AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032, "unrestricted_address_api_dbo_hackney_xref":AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047}, transformation_ctx = "SQLQuery_node1720617258366")
+"""
+SQLQuery_node1720617258366 = sparkSqlQuery(
+    glueContext,
+    query=SqlQuery0,
+    mapping={
+        "parking_voucher_de_normalised": AmazonS3liberatorrefinedzoneparking_voucher_de_normalised_node1720617253376,
+        "liberator_permit_llpg": AmazonS3liberatorrawzoneliberator_permit_llpg_node1720617252559,
+        "unrestricted_address_api_dbo_hackney_address": AmazonS3rawzoneunrestrictedaddressapiunrestricted_address_api_dbo_hackney_address_node1720617251032,
+        "unrestricted_address_api_dbo_hackney_xref": AmazonS3unrestricted_address_api_dbo_hackney_xref_node1724077428047,
+    },
+    transformation_ctx="SQLQuery_node1720617258366",
+)
 
 # Script generated for node Amazon S3 - parking_vouchers_approved_summary_gds
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938 = glueContext.getSink(path="s3://dataplatform-"+environment+"-refined-zone/parking/liberator/parking_vouchers_approved_summary_gds_lbh/", connection_type="s3", updateBehavior="UPDATE_IN_DATABASE", partitionKeys=["import_year", "import_month", "import_day", "import_date"], enableUpdateCatalog=True, transformation_ctx="AmazonS3parking_vouchers_approved_summary_gds_node1720617264938")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setCatalogInfo(catalogDatabase="dataplatform-"+environment+"-liberator-refined-zone",catalogTableName="parking_vouchers_approved_summary_gds_lbh")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setFormat("glueparquet", compression="snappy")
-AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.writeFrame(SQLQuery_node1720617258366)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938 = glueContext.getSink(
+    path="s3://dataplatform-"
+    + environment
+    + "-refined-zone/parking/liberator/parking_vouchers_approved_summary_gds_lbh/",
+    connection_type="s3",
+    updateBehavior="UPDATE_IN_DATABASE",
+    partitionKeys=["import_year", "import_month", "import_day", "import_date"],
+    enableUpdateCatalog=True,
+    transformation_ctx="AmazonS3parking_vouchers_approved_summary_gds_node1720617264938",
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setCatalogInfo(
+    catalogDatabase="dataplatform-" + environment + "-liberator-refined-zone",
+    catalogTableName="parking_vouchers_approved_summary_gds_lbh",
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.setFormat(
+    "glueparquet", compression="snappy"
+)
+AmazonS3parking_vouchers_approved_summary_gds_node1720617264938.writeFrame(
+    SQLQuery_node1720617258366
+)
 job.commit()


### PR DESCRIPTION
The address_api data has not been updated for the past seven days (see `s3://dataplatform-prod-raw-zone/unrestricted/addresses_api/dbo.hackney_address/import_year=2025/import_month=01/`).

Sandrine and I are not entirely sure which steps are causing the address_api to fail. We need to review the docs and possibly talk with other colleagues to identify the root causes.

For now, we’ve decided to extend the `push_down_predicate ` of 3 failed parking jobs to 30 days to allow the parking Glue jobs to function.

Looks a lot of changes - sorry it's formatting. Actually only changes the `push_down_predicate ` of table `unrestricted_address_api_dbo_hackney_address `to `30`