### PR TITLE
allow the airflow user to update and create partitions

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -915,7 +915,7 @@ data "aws_iam_policy_document" "airflow_base_policy" {
 resource "aws_iam_policy" "airflow_base_policy" {
   tags = var.tags
 
-  name   = lower("${var.identifier_prefix}-${local.department_identifier}-ariflow-base-policy")
+  name   = lower("${var.identifier_prefix}-${local.department_identifier}-airflow-base-policy")
   policy = data.aws_iam_policy_document.airflow_base_policy.json
 }
 


### PR DESCRIPTION
`Exception: Query failed with state: FAILED, reason: Insufficient permissions to execute the query. User is not authorized to create partitions on Glue catalog . You may need to manually clean the data at location 's3://dataplatform-stg-athena-storage/parking/temp/tables/94ee04d0-5656-4a39-9c97-e37c0ad77aa4' before retrying. Athena will not delete data in your account.`

Attach permissions to the Airflow user to allow for partition creation and updates.