### PR TITLE
roll back the version to 3.8 for kafka test lambda module

### DIFF
--- a/terraform/modules/kafka-test-lambda/10-lambda.tf
+++ b/terraform/modules/kafka-test-lambda/10-lambda.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 
 locals {
   command                 = "make install-requirements"
-  confluent_kafka_command = "docker run -v \"$PWD\":/var/task \"lambci/lambda:build-python3.9\" /bin/sh -c \"pip install -r requirements.txt -t python/lib/python3.9/site-packages/; exit\""
+  confluent_kafka_command = "docker run -v \"$PWD\":/var/task \"lambci/lambda:build-python3.8\" /bin/sh -c \"pip install -r requirements.txt -t python/lib/python3.8/site-packages/; exit\""
   # This ensures that this data resource will not be evaluated until
   # after the null_resource has been created.
   lambda_exporter_id = null_resource.run_install_requirements.id
@@ -151,7 +151,7 @@ resource "aws_lambda_function" "lambda" {
 
   role             = aws_iam_role.lambda.arn
   handler          = "main.lambda_handler"
-  runtime          = "python3.9"
+  runtime          = "python3.8"
   function_name    = lower("${var.identifier_prefix}${var.lambda_name}")
   s3_bucket        = var.lambda_artefact_storage_bucket
   s3_key           = aws_s3_object.lambda.key


### PR DESCRIPTION
│ docker: Error response from daemon: manifest for
│ lambci/lambda:build-python3.9 not found: manifest unknown: manifest
│ unknown.

lambda:build-python3.9 doen't exist, need to roll back to 3.8

The last [PR ](https://github.com/LBHackney-IT/Data-Platform/pull/2061)updated the Lambda Python version to 3.9, but one of then changes failed and needs to be rolled back.