### PR TITLE
Maven assembly plugin

### DIFF
--- a/external-lib/Makefile
+++ b/external-lib/Makefile
@@ -3,7 +3,7 @@
 all: target/java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar target/deequ-1.0.3.jar target/pydeequ-1.0.1.zip
 
 target/java-lib-1.0-SNAPSHOT-jar-with-dependencies.jar: pom.xml
-	mvn assembly:single -DdescriptorId=jar-with-dependencies
+	mvn package
 
 target/deequ-1.0.3.jar:
 	wget https://repo1.maven.org/maven2/com/amazon/deequ/deequ/1.0.3/deequ-1.0.3.jar -O target/deequ-1.0.3.jar

--- a/external-lib/pom.xml
+++ b/external-lib/pom.xml
@@ -5,13 +5,14 @@
   <artifactId>java-lib</artifactId>
   <version>1.0-SNAPSHOT</version>
   <name>java-lib</name>
-  <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -25,41 +26,40 @@
       <version>0.13.7</version>
     </dependency>
   </dependencies>
+
   <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.7.1</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+            </manifest>
+          </archive>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
     <pluginManagement>
-      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
-          <executions>
-            <execution>
-              <phase>package</phase>
-              <goals>
-                <goal>shade</goal>
-              </goals>
-              <configuration>
-                <artifactSet>
-                  <excludes>
-                    <exclude>classworlds:classworlds</exclude>
-                    <exclude>junit:junit</exclude>
-                    <exclude>jmock:*</exclude>
-                    <exclude>*:xml-apis</exclude>
-                    <exclude>org.apache.maven:lib:tests</exclude>
-                    <exclude>log4j:log4j:jar:</exclude>
-                  </excludes>
-                </artifactSet>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>
@@ -84,7 +84,6 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>

--- a/external-lib/pom.xml
+++ b/external-lib/pom.xml
@@ -31,7 +31,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.3.0</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -41,6 +41,9 @@
               <addClasspath>true</addClasspath>
             </manifest>
           </archive>
+          <appendAssemblyId>true</appendAssemblyId>
+          <ignoreDirFormatExtensions>false</ignoreDirFormatExtensions>
+          <includeProjectArtifact>false</includeProjectArtifact>
         </configuration>
         <executions>
           <execution>

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -1,3 +1,4 @@
+#dummy to trigger workflow
 data "aws_ssoadmin_instances" "sso_instances" {
   count = local.is_live_environment ? 1 : 0
 

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -1,4 +1,3 @@
-#dummy to trigger workflow
 data "aws_ssoadmin_instances" "sso_instances" {
   count = local.is_live_environment ? 1 : 0
 


### PR DESCRIPTION
Removes the shade plugin from pom.xml and replaces it with the assembly plugin.

Pins the version of assembly plugin to be used. 

Uses the package command to recreate the jar. 