### PR TITLE
skip make dependency jar if no changes

### DIFF
--- a/.github/workflows/deploy_terraform.yml
+++ b/.github/workflows/deploy_terraform.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Set Github Auth
         run: git config --global url."https://oauth2:${{ secrets.TERRAFORM_SECRET_TOKEN}}@github.com".insteadOf https://github.com
         shell: bash
-      
+
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2.0.3
         with:
@@ -125,7 +125,16 @@ jobs:
       #   working-directory: "./lambdas/g_drive_to_s3"
       #   run: make install-requirements
 
-      - name: Download External Python Dependencies
+      - name: Check for changes in external-lib
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            external-lib/**/*.xml
+            external-lib/Makefile
+
+      - name: Download external dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: "./external-lib"
         run: make all
 

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -72,11 +72,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
-      
+
       - name: Set Github Auth
         run: git config --global url."https://oauth2:${{ secrets.TERRAFORM_SECRET_TOKEN}}@github.com".insteadOf https://github.com
         shell: bash
-      
+
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2.0.3
         with:
@@ -96,7 +96,16 @@ jobs:
         env:
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
 
+      - name: Check for changes in external-lib
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files: |
+            external-lib/**/*.xml
+            external-lib/Makefile
+
       - name: Download external dependencies
+        if: steps.changed-files.outputs.any_changed == 'true'
         working-directory: "./external-lib"
         run: make all
 


### PR DESCRIPTION
Introduces a step in the workflow to check if files relating to the packaging of the dependencies jar have changed. 

I don't think there's a reason to rebuild this jar every time if the config hasn't changed. 