### PR TITLE
removes HTTP and HTTPS traffic from coming in via the internet, as custodian removes these rules any way

### DIFF
--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -75,32 +75,14 @@ resource "aws_security_group" "qlik_sense" {
     from_port   = 139
     to_port     = 139
     protocol    = "tcp"
-    cidr_blocks = ["10.151.11.27/32"]  # Replace with specific IP ranges for better security
+    cidr_blocks = ["10.151.11.27/32"] # Replace with specific IP ranges for better security
   }
 
   ingress {
     from_port   = 445
     to_port     = 445
     protocol    = "tcp"
-    cidr_blocks = ["10.151.11.27/32"]  # Replace with specific IP ranges for better security
-  }
-
-  ingress {
-    description      = "Allow inbound HTTP traffic"
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
-  ingress {
-    description      = "Allow inbound HTTPS traffic"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    cidr_blocks = ["10.151.11.27/32"] # Replace with specific IP ranges for better security
   }
 
   ingress {


### PR DESCRIPTION
Removes two security group rules from the Qliksense server that allow traffic from the open internet to port 80 and 443.

Note these rules wouldn't work anyway since all traffic is routed through the hub IP addresses and there isn't a route for the open internet to access these instances.