### PR TITLE
nas_live_manual_updates_data_load - change to 8.00am

### DIFF
--- a/terraform/etl/08-google-sheets-imports.tf
+++ b/terraform/etl/08-google-sheets-imports.tf
@@ -568,7 +568,7 @@ module "nas_live_manual_updates_data_load" {
   google_sheets_worksheet_name    = "nas_live_manual_updates_data_load"
   department                      = module.department_parking_data_source
   dataset_name                    = "nas_live_manual_updates_data_load"
-  google_sheet_import_schedule    = "cron(0 4 ? * * *)"
+  google_sheet_import_schedule    = "cron(0 8 ? * * *)"
   spark_ui_output_storage_id      = module.spark_ui_output_storage_data_source.bucket_id
 }
 


### PR DESCRIPTION
Davina hopes this can be changed to 8:00.

For other downstream jobs impacted by this one, we are migrating them to airflow in recent two days. The crawler behind this sheet will also be managed by Airflow.