### PR TITLE
remove Cycle Hangars and Cedar tables from parking transformation glue jobs

### DIFF
--- a/terraform/etl/38-aws-glue-job-parking.tf
+++ b/terraform/etl/38-aws-glue-job-parking.tf
@@ -1021,29 +1021,6 @@ module "parking_pcn_daily_print_monitoring_all" {
   }
 }
 
-module "parking_cycle_hangar_waiting_list" {
-  source                         = "../modules/aws-glue-job"
-  is_live_environment            = local.is_live_environment
-  is_production_environment      = local.is_production_environment
-  department                     = module.department_parking_data_source
-  job_name                       = "${local.short_identifier_prefix}parking_cycle_hangar_waiting_list"
-  helper_module_key              = data.aws_s3_object.helpers.key
-  pydeequ_zip_key                = data.aws_s3_object.pydeequ.key
-  spark_ui_output_storage_id     = module.spark_ui_output_storage_data_source.bucket_id
-  script_name                    = "parking_cycle_hangars_waiting_list"
-  triggered_by_job               = "${local.short_identifier_prefix}Copy parking Liberator landing zone to raw"
-  job_description                = "Takes data from Liberator raw zone and creates a geocoded, duplicate-free version of the cycle hangars waiting list"
-  workflow_name                  = "${local.short_identifier_prefix}parking-liberator-data-workflow"
-  trigger_enabled                = local.is_production_environment
-  glue_job_timeout               = 60
-  number_of_workers_for_glue_job = 10
-  glue_job_worker_type           = "G.1X"
-  glue_version                   = "4.0"
-  job_parameters = {
-    "--job-bookmark-option" = "job-bookmark-disable"
-    "--environment"         = var.environment
-  }
-}
 # MRB 17-07-2023 Job created
 module "parking_permit_street_stress" {
   source                         = "../modules/aws-glue-job"


### PR DESCRIPTION
These tables will be enabled in airflow today, so remove them from the glue jobs.

A total of 12 glue jobs