### PR TITLE
reduce the size of department ecs base policy

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -959,7 +959,6 @@ resource "aws_iam_policy" "department_ecs_passrole" {
 
 data "aws_iam_policy_document" "ecs_department_policy" {
   source_policy_documents = [
-    data.aws_iam_policy_document.s3_department_access.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
     data.aws_iam_policy_document.read_glue_scripts_and_mwaa_and_athena.json,
     data.aws_iam_policy_document.crawler_can_access_jdbc_connection.json

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -157,3 +157,8 @@ resource "aws_iam_role_policy_attachment" "glue_access_attachment_to_ecs_role" {
   role       = aws_iam_role.department_ecs_role.name
   policy_arn = aws_iam_policy.glue_access.arn
 }
+
+resource "aws_iam_role_policy" "grant_s3_access_to_ecs_role" {
+  role   = aws_iam_role.department_ecs_role.name
+  policy = data.aws_iam_policy_document.s3_department_access.json
+}


### PR DESCRIPTION
Encountered this error in last [PR](https://github.com/LBHackney-IT/Data-Platform/pull/2115):

> Error: Updating IAM Policy (arn:aws:iam:::policy/-env-enforcement-ecs-base-policy) failed due to LimitExceeded: Cannot exceed the quota for PolicySize: 6144.
> Status code: 409
> Request ID: 981c6e38-621a-4552-a74e-79045260ea63

To resolve this, I split the S3 access from the big base policy.