### PR TITLE
allow access a shared folder in the ecs bucket

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -221,7 +221,8 @@ data "aws_iam_policy_document" "s3_department_access" {
 
       var.mwaa_etl_scripts_bucket_arn,
       "${var.mwaa_etl_scripts_bucket_arn}/${local.department_identifier}/*",
-      "${var.mwaa_etl_scripts_bucket_arn}/${local.department_identifier}/unrestricted/*",
+      "${var.mwaa_etl_scripts_bucket_arn}/unrestricted/*",
+      "${var.mwaa_etl_scripts_bucket_arn}/shared/*",
     ]
   }
 


### PR DESCRIPTION
- This is for a stored shared project used by multiple departments, including Google Sheet ingestion and some helper functions at the moment.
- Remove the departmental prefix before restricted - was a typo.