### PR TITLE
add data and insight as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file specifies owners for pull request approval
 # See https://help.github.com/articles/about-code-owners/
 
-* @LBHackney-IT/data-analytics-platform
+* @LBHackney-IT/data-analytics-platform @LBHackney-IT/data-insight


### PR DESCRIPTION
Even after approval by Data & Insight, the PRs still cannot be merged. Daro and I discussed granting Data & Insight permission to approve and merge PRs. This is especially important on Fridays when there may be only one DAP member available, which could cause delays.