### PR TITLE
disable cloudwatch metrics for Glue jobs

### DIFF
--- a/terraform/modules/aws-glue-job/10-aws-glue-job.tf
+++ b/terraform/modules/aws-glue-job/10-aws-glue-job.tf
@@ -58,7 +58,7 @@ resource "aws_glue_job" "job" {
       "--extra-py-files"                   = "s3://${local.scripts_bucket_id}/${var.helper_module_key},s3://${local.scripts_bucket_id}/${var.pydeequ_zip_key}"
       "--extra-jars"                       = local.extra_jars
       "--enable-continuous-cloudwatch-log" = "true"
-      "--enable-metrics"                   = "true"
+      "--enable-metrics"                   = "false"
       "--enable-spark-ui"                  = "true"
       "--spark-event-logs-path"            = local.spark_ui_storage
       "--enable-auto-scaling"              = "true"


### PR DESCRIPTION
Changes the default argument for `--enable-metrics` to `false` in the Glue job module. 

The CE team have helped identify the current configuration as causing significant cloudwatch costs and I don't think there's much benefit to keeping them across the board - this can be overridden if there's a need to do so for particular jobs in the future. 