### PR TITLE
Add createpartition permission for ecs

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -380,7 +380,6 @@ data "aws_iam_policy_document" "glue_access" {
     actions = [
       "glue:Batch*",
       "glue:CheckSchemaVersionValidity",
-      "glue:CreateDag",
       "glue:CreateDevEndpoint",
       "glue:CreateJob",
       "glue:CreateScript",
@@ -403,7 +402,6 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:StopTrigger",
       "glue:StopWorkflowRun",
       "glue:TagResource",
-      "glue:UpdateDag",
       "glue:UpdateDevEndpoint",
       "glue:UpdateJob",
       "glue:UpdateTable",

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -384,6 +384,7 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:CreateJob",
       "glue:CreateScript",
       "glue:CreateSession",
+      "glue:CreatePartition",
       "glue:DeleteDevEndpoint",
       "glue:DeleteJob",
       "glue:DeleteTrigger",


### PR DESCRIPTION
Allows the CreatePartition action in Glue. This is needed for the ECS tasks to update tables in the catalog with new partitions. 

Also removes two actions that don't exist in the glue service:
      "glue:UpdateDag",
      "glue:CreateDag",

![image](https://github.com/user-attachments/assets/c7fc9970-e816-46c5-a0fa-bfbb28a89fac)

