### PR TITLE
use different config for airflow stg and prod

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -170,7 +170,7 @@ resource "aws_mwaa_environment" "mwaa" {
   count                = local.is_live_environment ? 1 : 0
   name                 = "${local.identifier_prefix}-mwaa-environment"
   airflow_version      = "2.10.3" # Latest MWAA on 2025-01-13, preinstall python 3.11
-  environment_class    = "mw1.medium"
+  environment_class    = local.is_production_environment ? "mw1.medium" : "mw1.small"
   execution_role_arn   = aws_iam_role.mwaa_role.arn
   source_bucket_arn    = aws_s3_bucket.mwaa_bucket.arn
   dag_s3_path          = "dags"
@@ -205,10 +205,10 @@ resource "aws_mwaa_environment" "mwaa" {
 
   # To view the Airflow UI, set this to PUBLIC_ONLY or create a mechanism to access the VPC endpoint
   # https://docs.aws.amazon.com/mwaa/latest/userguide/t-create-update-environment.html#t-network-failure
-  webserver_access_mode           = "PUBLIC_ONLY" # Default is PRIVATE_ONLY
-  max_workers                     = 10            # The default for mw1.medium is 10 for mw1.samll is 5
-  min_workers                     = 1             # Default 1
-  schedulers                      = 2             # Must be between 2 and 5
+  webserver_access_mode           = "PUBLIC_ONLY"                             # Default is PRIVATE_ONLY
+  max_workers                     = local.is_production_environment ? 20 : 10 # The default for mw1.medium is 10 for mw1.samll is 5
+  min_workers                     = 1                                         # Default 1
+  schedulers                      = 2                                         # Must be between 2 and 5
   kms_key                         = aws_kms_key.mwaa_key.arn
   tags                            = module.tags.values
   weekly_maintenance_window_start = "SUN:03:30"


### PR DESCRIPTION
- In stg, change the instance to mw1.small to reduce costs.
- In prod, keep it the same, but change max_workers to 20. This is because I noticed that there were Airflow DAGs waiting to start when multiple DAGs were executing