### PR TITLE
add airflow alert mapping variable

### DIFF
--- a/terraform/etl/60-airflow-variables-and-connnections.tf
+++ b/terraform/etl/60-airflow-variables-and-connnections.tf
@@ -1,3 +1,25 @@
+### Airflow Alerts
+
+resource "aws_secretsmanager_secret" "google_chat_webhook_mapping" {
+  name        = "airflow/variables/google_chat_webhook_mapping"
+  description = "Mapping of department DAG tags to Google Spaces webhooks for failure alerts."
+  tags        = module.tags.values
+}
+
+resource "aws_secretsmanager_secret_version" "google_chat_webhook_mapping" {
+  secret_id = aws_secretsmanager_secret.google_chat_webhook_mapping.id
+  secret_string = jsonencode({
+    lower_department_name = "UPDATE_WITH_WEBHOOK_IN_CONSOLE"
+  })
+
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+
+
 ### Alloy
 
 resource "aws_secretsmanager_secret" "alloy_api_key" {


### PR DESCRIPTION
Adds a secret to provide a mapping table of departments to alert webhooks in Airflow.

Used in https://github.com/LBHackney-IT/dap-airflow/pull/343