### PR TITLE
remove the env_services_geospatial_enrichment glue job

### DIFF
--- a/terraform/etl/24-aws-glue-spatial.tf
+++ b/terraform/etl/24-aws-glue-spatial.tf
@@ -64,7 +64,6 @@ resource "aws_s3_object" "parking_spatial_enrichment_dictionary" {
   source_hash = filemd5("../../scripts/jobs/parking/spatial-enrichment-dictionary.json")
 }
 
-
 # Job using the script and dictionary above for the parking dept
 module "parking_geospatial_enrichment" {
   source                    = "../modules/aws-glue-job"


### PR DESCRIPTION
No longer in use and currently has bugs.

An Airflow job using the refactored ETL script is already handling the same process.