### PR TITLE
fix tascomi create daily snapshot

### DIFF
--- a/scripts/jobs/planning/tascomi_create_daily_snapshot.py
+++ b/scripts/jobs/planning/tascomi_create_daily_snapshot.py
@@ -1,7 +1,6 @@
 import sys
 from datetime import datetime
 
-import pydeequ
 import pyspark.sql.functions as F
 from awsglue.context import GlueContext
 from awsglue.dynamicframe import DynamicFrame
@@ -306,7 +305,7 @@ if __name__ == "__main__":
 
             except Exception as verificationError:
                 logger.info(
-                    f"Job cancelled due to data quality test failure, continuing to next table."
+                    "Job cancelled due to data quality test failure, continuing to next table."
                 )
                 message = verificationError.args
                 logger.info(f"{message[0]}")
@@ -317,7 +316,7 @@ if __name__ == "__main__":
 
             else:
                 logger.info(
-                    f"Data quality tests passed, appending data quality results to JSON and moving on to writing data"
+                    "Data quality tests passed, appending data quality results to JSON and moving on to writing data"
                 )
                 verificationSuite.saveOrAppendResult(resultKey).run()
 


### PR DESCRIPTION
I made two main changes; the rest are just formatting.
The changes are:
- Function `get_latest_snapshot`: If snapshot_date does not exist, add the column.
- Function `loadIncrementsSinceDate`: Added a default date — 20210101 (the one used multiple times as the date in the original script).

It’s working fine now. The data has been loaded to the latest partition, for example
> s3://dataplatform-stg-refined-zone/planning/tascomi/snapshot/appeal_decision/snapshot_year=2025/snapshot_month=03/snapshot_day=10/snapshot_date=20250310/


