### PR TITLE
add read access to mtfh in landing  for d and i ecs tasks

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -979,3 +979,31 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
     actions = ["sts:AssumeRole"]
   }
 }
+
+// s3 access for mtfh data in landing zone
+data "aws_iam_policy_document" "mtfh_access" {
+  count = local.department_identifier == "data-and-insight" ? 1 : 0
+
+  statement {
+    sid    = "S3ReadMtfhDirectory"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+    ]
+    resources = [
+      "${var.landing_zone_bucket.bucket_arn}/mtfh/*",
+      var.landing_zone_bucket.bucket_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "mtfh_access_policy" {
+  count       = local.department_identifier == "data-and-insight" ? 1 : 0
+  name        = lower("${var.identifier_prefix}-${local.department_identifier}-mtfh-landing-access-policy")
+  description = "Allows data-and-insight department access  for ecs tasks to mtfh/ subdirectory in landing zone"
+  policy      = data.aws_iam_policy_document.mtfh_access[0].json
+}
+
+

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -162,3 +162,9 @@ resource "aws_iam_role_policy" "grant_s3_access_to_ecs_role" {
   role   = aws_iam_role.department_ecs_role.name
   policy = data.aws_iam_policy_document.s3_department_access.json
 }
+
+resource "aws_iam_role_policy_attachment" "mtfh_access_attachment" {
+  count      = local.department_identifier == "data-and-insight" ? 1 : 0
+  role       = aws_iam_role.department_ecs_role.name
+  policy_arn = aws_iam_policy.mtfh_access_policy[0].arn
+}


### PR DESCRIPTION
Allows read access to the MTFH exports in Landing for the Data and Insight ECS task role.

By design the landing zone is generally only accessible to data platform engineers. This data is needed for implementation of the housing data pipeline which is currently in development and will require access for other members of data and insight. 