### PR TITLE
add variable to allow for not including BackupPolicy tag

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -419,7 +419,10 @@ resource "aws_s3_bucket" "ssl_connection_resources" {
   count = local.is_live_environment ? 1 : 0
 
   bucket = "${local.identifier_prefix}-ssl-connection-resources"
-  tags   = module.tags.values
+  tags = {
+    for key, value in module.tags.values :
+    key => value if key != "BackupPolicy"
+  }
 }
 
 resource "aws_s3_bucket_acl" "ssl_connection_resources" {

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -304,6 +304,7 @@ module "landing_zone" {
   bucket_identifier            = "landing-zone"
   bucket_policy_statements     = local.is_production_environment ? [local.allow_housing_reporting_role_access_to_landing_zone_path] : (local.is_live_environment ? [local.allow_housing_reporting_role_access_to_landing_zone_path_pre_prod] : [])
   bucket_key_policy_statements = [local.share_kms_key_with_housing_reporting_role]
+  include_backup_policy_tags   = false
 }
 
 module "raw_zone" {
@@ -316,7 +317,7 @@ module "raw_zone" {
   bucket_identifier            = "raw-zone"
   bucket_policy_statements     = local.is_production_environment ? [local.s3_to_s3_copier_for_addresses_api_write_access_to_raw_zone_statement] : (local.is_live_environment ? [local.prod_to_pre_prod_raw_zone_data_sync_statement_for_pre_prod] : [])
   bucket_key_policy_statements = local.is_production_environment ? [local.s3_to_s3_copier_for_addresses_api_raw_zone_key_statement] : (local.is_live_environment ? [local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod] : [])
-
+  include_backup_policy_tags   = false
 }
 
 module "refined_zone" {
@@ -335,6 +336,7 @@ module "refined_zone" {
   bucket_key_policy_statements = concat(
     [local.rentsense_refined_zone_key_statement],
   local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod] : [])
+  include_backup_policy_tags = false
 }
 
 module "trusted_zone" {
@@ -348,47 +350,52 @@ module "trusted_zone" {
 
   bucket_policy_statements     = local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_trusted_zone_data_sync_statement_for_pre_prod] : []
   bucket_key_policy_statements = local.is_live_environment && !local.is_production_environment ? [local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod] : []
+  include_backup_policy_tags   = false
 }
 
 module "glue_scripts" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Glue Scripts"
-  bucket_identifier = "glue-scripts"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Glue Scripts"
+  bucket_identifier          = "glue-scripts"
+  include_backup_policy_tags = false
 }
 
 module "glue_temp_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Glue Temp Storage"
-  bucket_identifier = "glue-temp-storage"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Glue Temp Storage"
+  bucket_identifier          = "glue-temp-storage"
+  include_backup_policy_tags = false
 }
 
 module "athena_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Athena Storage"
-  bucket_identifier = "athena-storage"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Athena Storage"
+  bucket_identifier          = "athena-storage"
+  include_backup_policy_tags = false
 }
 
 module "lambda_artefact_storage" {
-  source             = "../modules/s3-bucket"
-  tags               = module.tags.values
-  project            = var.project
-  environment        = var.environment
-  identifier_prefix  = local.identifier_prefix
-  bucket_name        = "Lambda Artefact Storage"
-  bucket_identifier  = "dp-lambda-artefact-storage"
-  versioning_enabled = false
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Lambda Artefact Storage"
+  bucket_identifier          = "dp-lambda-artefact-storage"
+  versioning_enabled         = false
+  include_backup_policy_tags = false
 }
 
 module "spark_ui_output_storage" {
@@ -403,6 +410,7 @@ module "spark_ui_output_storage" {
   expire_objects_days            = 60
   expire_noncurrent_objects_days = 30
   abort_multipart_days           = 30
+  include_backup_policy_tags     = false
 }
 
 # This bucket is used for storing certificates used in Looker Studio connections.
@@ -434,23 +442,25 @@ resource "aws_s3_bucket_versioning" "ssl_connection_resources" {
 module "rds_export_storage" {
   source = "../modules/s3-bucket"
 
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "RDS Export Storage"
-  bucket_identifier = "rds-shapshot-export-storage"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "RDS Export Storage"
+  bucket_identifier          = "rds-shapshot-export-storage"
+  include_backup_policy_tags = false
 }
 
 module "deprecated_rds_export_storage" {
   source = "../modules/s3-bucket"
 
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = "${local.identifier_prefix}-dp"
-  bucket_name       = "RDS Export Storage"
-  bucket_identifier = "rds-export-storage"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = "${local.identifier_prefix}-dp"
+  bucket_name                = "RDS Export Storage"
+  bucket_identifier          = "rds-export-storage"
+  include_backup_policy_tags = false
 }
 
 module "addresses_api_rds_export_storage" {
@@ -467,6 +477,7 @@ module "addresses_api_rds_export_storage" {
   providers = {
     aws = aws.aws_api_account
   }
+  include_backup_policy_tags = false
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "addresses_api_rds_export_storage" {

--- a/terraform/core/20-noiseworks-import-s3.tf
+++ b/terraform/core/20-noiseworks-import-s3.tf
@@ -1,11 +1,12 @@
 module "noiseworks_data_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Noiseworks Data Storage"
-  bucket_identifier = "noiseworks-data-storage"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Noiseworks Data Storage"
+  bucket_identifier          = "noiseworks-data-storage"
+  include_backup_policy_tags = false
 }
 
 # Noiseworks User

--- a/terraform/core/29-db-snapshot-to-s3.tf
+++ b/terraform/core/29-db-snapshot-to-s3.tf
@@ -1,11 +1,12 @@
 module "lambda_artefact_storage_for_api_account" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Lambda Artefact Storage"
-  bucket_identifier = "api-lambda-artefact-storage"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Lambda Artefact Storage"
+  bucket_identifier          = "api-lambda-artefact-storage"
+  include_backup_policy_tags = false
 
   providers = {
     aws = aws.aws_api_account

--- a/terraform/core/36-liberator-import.tf
+++ b/terraform/core/36-liberator-import.tf
@@ -1,12 +1,13 @@
 
 module "liberator_data_storage" {
-  source            = "../modules/s3-bucket"
-  tags              = module.tags.values
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = local.identifier_prefix
-  bucket_name       = "Liberator Data Storage"
-  bucket_identifier = "liberator-data-storage"
+  source                     = "../modules/s3-bucket"
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Liberator Data Storage"
+  bucket_identifier          = "liberator-data-storage"
+  include_backup_policy_tags = false
 }
 
 module "liberator_dump_to_rds_snapshot" {

--- a/terraform/core/46-mwaa-bucket-kms.tf
+++ b/terraform/core/46-mwaa-bucket-kms.tf
@@ -95,8 +95,10 @@ resource "aws_s3_bucket_public_access_block" "mwaa_bucket_block" {
 
 resource "aws_s3_bucket" "mwaa_etl_scripts_bucket" {
   bucket = "${local.identifier_prefix}-mwaa-etl-scripts-bucket"
-
-  tags = module.tags.values
+  tags = {
+    for key, value in module.tags.values :
+    key => value if key != "BackupPolicy"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "mwaa_etl_scripts_bucket_encryption" {

--- a/terraform/core/46-mwaa-bucket-kms.tf
+++ b/terraform/core/46-mwaa-bucket-kms.tf
@@ -66,7 +66,10 @@ resource "aws_kms_alias" "mwaa_key_alias" {
 resource "aws_s3_bucket" "mwaa_bucket" {
   bucket = "${local.identifier_prefix}-mwaa-bucket"
 
-  tags = module.tags.values
+  tags = {
+    for key, value in module.tags.values :
+    key => value if key != "BackupPolicy"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "mwaa_bucket_encryption" {
@@ -116,3 +119,4 @@ resource "aws_s3_bucket_public_access_block" "mwaa_etl_scripts_bucket_block" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+

--- a/terraform/modules/kafka-event-streaming/10-dependencies.tf
+++ b/terraform/modules/kafka-event-streaming/10-dependencies.tf
@@ -1,11 +1,12 @@
 module "kafka_dependency_storage" {
-  source            = "../s3-bucket"
-  tags              = var.tags
-  project           = var.project
-  environment       = var.environment
-  identifier_prefix = var.identifier_prefix
-  bucket_name       = "Kafka Dependency Storage"
-  bucket_identifier = "kafka-dependency-storage"
+  source                     = "../s3-bucket"
+  tags                       = var.tags
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = var.identifier_prefix
+  bucket_name                = "Kafka Dependency Storage"
+  bucket_identifier          = "kafka-dependency-storage"
+  include_backup_policy_tags = false
 }
 
 resource "aws_s3_object" "kafka_connector_s3" {

--- a/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
+++ b/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
@@ -1,6 +1,9 @@
 resource "aws_s3_bucket" "qlik_alb_logs" {
-  count  = var.is_live_environment ? 1 : 0
-  tags   = var.tags
+  count = var.is_live_environment ? 1 : 0
+  tags = {
+    for key, value in var.tags :
+    key => value if key != "BackupPolicy"
+  }
   bucket = "${var.identifier_prefix}-qlik-alb-logs"
 }
 
@@ -42,8 +45,8 @@ resource "aws_s3_bucket_versioning" "qlik_alb_logs_versioning" {
 }
 
 data "aws_iam_policy_document" "write_access_for_aws_loggers" {
-  count  = var.is_live_environment ? 1 : 0
-  
+  count = var.is_live_environment ? 1 : 0
+
   statement {
     sid    = "AWSLogDeliveryAclCheck"
     effect = "Allow"
@@ -118,7 +121,7 @@ data "aws_iam_policy_document" "write_access_for_aws_loggers" {
     effect = "Deny"
 
     resources = [aws_s3_bucket.qlik_alb_logs[0].arn,
-                "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"]
+    "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"]
 
     actions = ["s3:*"]
 
@@ -136,7 +139,7 @@ data "aws_iam_policy_document" "write_access_for_aws_loggers" {
 }
 
 resource "aws_s3_bucket_policy" "write_access_for_aws_loggers" {
-  count  = var.is_live_environment ? 1 : 0
+  count = var.is_live_environment ? 1 : 0
 
   bucket = aws_s3_bucket.qlik_alb_logs[0].id
   policy = data.aws_iam_policy_document.write_access_for_aws_loggers[0].json

--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -60,7 +60,7 @@ variable "bucket_policy_statements" {
   validation {
     condition = length([
       for o in var.bucket_policy_statements : true
-       if o.principals.type != null && o.principals.type != ""
+      if o.principals.type != null && o.principals.type != ""
     ]) == length(var.bucket_policy_statements)
     error_message = "Principal type must be provided"
   }
@@ -72,9 +72,9 @@ variable "bucket_policy_statements" {
 variable "bucket_key_policy_statements" {
   description = "A list of statements to be added to the bucket policy"
   type = list(object({
-    sid       = string
-    effect    = string
-    actions   = list(string)
+    sid     = string
+    effect  = string
+    actions = list(string)
     principals = object({
       type        = string
       identifiers = list(string)
@@ -116,7 +116,7 @@ variable "bucket_key_policy_statements" {
   validation {
     condition = length([
       for o in var.bucket_key_policy_statements : true
-       if o.principals.type != null && o.principals.type != ""
+      if o.principals.type != null && o.principals.type != ""
     ]) == length(var.bucket_key_policy_statements)
     error_message = "Principal type must be provided"
   }
@@ -151,3 +151,8 @@ variable "abort_multipart_days" {
   default     = null
 }
 
+variable "include_backup_policy_tags" {
+  description = "Whether to apply the backup policy tags provided by the tagging module"
+  type        = bool
+  default     = true
+}

--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -130,13 +130,18 @@ data "aws_iam_policy_document" "bucket" {
   ]
 }
 
+locals {
+  standard_s3_tags = var.tags
+
+  filtered_s3_tags = {
+    for key, value in local.standard_s3_tags :
+    key => value if key != "BackupPolicy" || var.include_backup_policy_tags
+  }
+}
 resource "aws_s3_bucket" "bucket" {
-  tags = var.tags
-
-  bucket = lower("${var.identifier_prefix}-${var.bucket_identifier}")
-
+  tags          = local.filtered_s3_tags
+  bucket        = lower("${var.identifier_prefix}-${var.bucket_identifier}")
   force_destroy = (var.environment == "dev")
-
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {


### PR DESCRIPTION
This cloud custodian module will automatically remove BackupPolicy tags from buckets when they're applied. 
[https://github.com/LBHackney-IT/ce-cloud-custodian/blob/ffd7d2a5fb896d3a2321a86182[…]custodian/policies/global/remove-backup-policy-tag-from-s3.yaml](https://github.com/LBHackney-IT/ce-cloud-custodian/blob/ffd7d2a5fb896d3a2321a861822899d56038404b/custodian/policies/global/remove-backup-policy-tag-from-s3.yaml#L3)

Our terraform plans are then very noisy because these tags will be re-applied as well as needing to recreate any dependent resources. 

This PR:

- Adds a variable  `include_backup_policy_tags` to the s3_bucket module
- sets that variable to true by default
- explicitly sets the value to false on modules across the repository
- where bucket resources have been created without this module removed the BackupPolicy tag by filtering the applied tags