### PR TITLE
fix taxcomi create daily snapshot by changing push_down_predicate

### DIFF
--- a/scripts/jobs/planning/tascomi_create_daily_snapshot.py
+++ b/scripts/jobs/planning/tascomi_create_daily_snapshot.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
                 glueContext, snapshot_table_name, source_catalog_database
             ):
                 logger.info(
-                    f"Couldn't find table {snapshot_table_name} in database {source_catalog_database}, creating a snapshot from all the increments, starting from 30 days ago"
+                    f"Couldn't find table {snapshot_table_name} in database {source_catalog_database}, creating a snapshot from all the increments, starting from 20210101"
                 )
                 # Increment table does not exist in glue catalogue
                 if not table_exists_in_catalog(
@@ -190,6 +190,8 @@ if __name__ == "__main__":
                         f"No snapshot and no increment for {increment_table_name}, going to the next table"
                     )
                     continue
+
+                # Load increments from default date
                 increment_df = loadIncrementsSinceDate(
                     increment_table_name=increment_table_name,
                     name_space=source_catalog_database,


### PR DESCRIPTION
Change the push_down_predicate to 30 days ago instead of using "`20210101`"

Fix the timeout issue – it was using 20210101 as the push_down_predicate. After reading the [playbook](https://playbook.hackney.gov.uk/Data-Platform-Playbook/docs/tascomi-ingestion), which mentions that it only needs to get the latest records compared to the last snapshot and then Creation of a full snapshot by applying the daily increment to the previous snapshot; Therefore, there's no need to use `20210101 `as the push_down_predicate when deriving the new records.