### PR TITLE
rename sid for qlik log bucket policy statement

### DIFF
--- a/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
+++ b/terraform/modules/qlik-sense-server/04-aws-s3-alb-logs.tf
@@ -117,23 +117,21 @@ data "aws_iam_policy_document" "write_access_for_aws_loggers" {
   }
 
   statement {
-    sid    = "HTTPSOnly"
-    effect = "Deny"
-
-    resources = [aws_s3_bucket.qlik_alb_logs[0].arn,
-    "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"]
-
+    sid     = "AllowSSLRequestsOnly"
+    effect  = "Deny"
     actions = ["s3:*"]
-
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.qlik_alb_logs[0].arn,
+      "${aws_s3_bucket.qlik_alb_logs[0].arn}/*"
+    ]
     condition {
       test     = "Bool"
       variable = "aws:SecureTransport"
       values   = ["false"]
-    }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
     }
   }
 }


### PR DESCRIPTION
This Cloud Custodian policy is adding an identical policy with a different SID so they get over-written on every apply.

https://github.com/LBHackney-IT/ce-cloud-custodian/blob/ffd7d2a5fb896d3a2321a861822899d56038404b/custodian/policies/global/s3-set-ssl-policy.yaml

```
filters:
      - type: missing-statement
        statement_ids:
          - AllowSSLRequestsOnly
      - type: value
        key: Name  
        op: regex 
        value: '^((?!document-evidence-store).)*$'
    actions:
      - type: set-statements
        statements:
          - Sid: "AllowSSLRequestsOnly"
            Effect: "Deny"
            Action: "s3:*"
            Principal:
              AWS: "*"
            Resource: [
              "arn:aws:s3:::{bucket_name}",
              "arn:aws:s3:::{bucket_name}/*"
            ]  
            Condition:
              Bool:
                "aws:SecureTransport": false 
```