### PR TITLE
add AllowSSLRequestsOnly statement

### DIFF
--- a/terraform/modules/sql-to-rds-snapshot/20-cloudtrail.tf
+++ b/terraform/modules/sql-to-rds-snapshot/20-cloudtrail.tf
@@ -152,4 +152,25 @@ data "aws_iam_policy_document" "cloudtrail_bucket_policy" {
       values   = ["bucket-owner-full-control"]
     }
   }
+
+  statement {
+    sid     = "AllowSSLRequestsOnly"
+    effect  = "Deny"
+    actions = ["s3:*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    resources = [
+      aws_s3_bucket.cloudtrail.arn,
+      "${aws_s3_bucket.cloudtrail.arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
This bucket doesn't have a `AllowSSLRequestsOnly` policy statement as required by the Cloud Custodian rule, so it gets removed and reapplied on every terraform apply. 

https://github.com/LBHackney-IT/ce-cloud-custodian/blob/ffd7d2a5fb896d3a2321a861822899d56038404b/custodian/policies/global/s3-set-ssl-policy.yaml

```
filters:
      - type: missing-statement
        statement_ids:
          - AllowSSLRequestsOnly
      - type: value
        key: Name  
        op: regex 
        value: '^((?!document-evidence-store).)*$'
    actions:
      - type: set-statements
        statements:
          - Sid: "AllowSSLRequestsOnly"
            Effect: "Deny"
            Action: "s3:*"
            Principal:
              AWS: "*"
            Resource: [
              "arn:aws:s3:::{bucket_name}",
              "arn:aws:s3:::{bucket_name}/*"
            ]  
            Condition:
              Bool:
                "aws:SecureTransport": false 
```
Similar to https://github.com/LBHackney-IT/Data-Platform/pull/2167