### PR TITLE
enable key rotation for MWAA kms key

### DIFF
--- a/terraform/core/46-mwaa-bucket-kms.tf
+++ b/terraform/core/46-mwaa-bucket-kms.tf
@@ -51,9 +51,10 @@ locals {
 
 # Create the KMS key with the custom key policy
 resource "aws_kms_key" "mwaa_key" {
-  description = "KMS key for MWAA"
-  policy      = local.custom_key_policy
-  tags        = module.tags.values
+  description         = "KMS key for MWAA"
+  policy              = local.custom_key_policy
+  enable_key_rotation = true
+  tags                = module.tags.values
 }
 
 # Create an alias for the KMS key for better readability in the console


### PR DESCRIPTION
More conforming with cloud custodian. The default value is false so this needs to be set as true explicitly.
https://github.com/LBHackney-IT/ce-cloud-custodian/blob/main/custodian/policies/global/enable-kms-key-rotation.yaml

```
policies:
  - name: enable-cmk-rotation
    comment: Enables the 'Automatically rotate this KMS key every year' check box for customer managed keys.
    resource: kms-key
    mode:
      type: periodic
      schedule: "rate(1 day)"
      role: CloudCustodian/CE_Cloud_Custodian_Policy_Execution_Role
      memory: 128
    filters:
      - type: key-rotation-status
        key: KeyRotationEnabled
        value: False
      - type: value
        key: KeyState
        value: Enabled  
    actions:
      - type: set-rotation
        state: True
```