### PR TITLE
Chore/trigger rebuild of lambda zips

### DIFF
--- a/lambdas/icaseworks_api_ingestion/main.py
+++ b/lambdas/icaseworks_api_ingestion/main.py
@@ -1,14 +1,10 @@
-import sys
-
-
-sys.path.append("./lib/")
-
 import datetime
 import hashlib
 import hmac
 import json
 import logging
 import re
+import sys
 import time
 from os import getenv
 
@@ -17,6 +13,8 @@ import pybase64
 import requests
 from dotenv import load_dotenv
 
+
+sys.path.append("./lib/")
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)

--- a/lambdas/icaseworks_api_ingestion/main.py
+++ b/lambdas/icaseworks_api_ingestion/main.py
@@ -1,19 +1,22 @@
 import sys
 
-sys.path.append('./lib/')
 
-import pybase64
-import json
+sys.path.append("./lib/")
+
+import datetime
 import hashlib
 import hmac
-import re
-import requests
-import time
-import boto3
-from dotenv import load_dotenv
-from os import getenv
-import datetime
+import json
 import logging
+import re
+import time
+from os import getenv
+
+import boto3
+import pybase64
+import requests
+from dotenv import load_dotenv
+
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -21,11 +24,9 @@ logger.setLevel(logging.INFO)
 
 def remove_illegal_characters(string):
     """Removes illegal characters from string"""
-    regex_list = [['=', ""], ['\/', "_"], ['+', "-"]]
+    regex_list = [["=", ""], ["\/", "_"], ["+", "-"]]
     for r in regex_list:
-        string = re.sub(string=string,
-                        pattern="[{}]".format(r[0]),
-                        repl=r[1])
+        string = re.sub(string=string, pattern="[{}]".format(r[0]), repl=r[1])
     return string
 
 
@@ -44,12 +45,14 @@ def dictionary_to_string(dictionary):
 def create_signature(header, payload, secret):
     """Encode JSON string"""
     # hashed header, hashed payload, string secret
-    unsigned_token = header + '.' + payload
-    key_bytes = bytes(secret, 'utf-8')
-    string_to_sign_bytes = bytes(unsigned_token, 'utf-8')
-    signature_hash = hmac.new(key_bytes, string_to_sign_bytes, digestmod=hashlib.sha256).digest()
+    unsigned_token = header + "." + payload
+    key_bytes = bytes(secret, "utf-8")
+    string_to_sign_bytes = bytes(unsigned_token, "utf-8")
+    signature_hash = hmac.new(
+        key_bytes, string_to_sign_bytes, digestmod=hashlib.sha256
+    ).digest()
     encoded_signature = pybase64.b64encode(signature_hash)
-    encoded_signature = encoded_signature.decode('utf-8')
+    encoded_signature = encoded_signature.decode("utf-8")
     encoded_signature = remove_illegal_characters(encoded_signature)
     return encoded_signature
 
@@ -57,24 +60,24 @@ def create_signature(header, payload, secret):
 def get_token(url, encoded_header, encoded_payload, signature, headers):
     """Get token"""
     assertion = encoded_header + "." + encoded_payload + "." + signature
-    data = f'assertion={assertion}&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer'
+    data = f"assertion={assertion}&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer"
     response = requests.post(url, headers=headers, data=data)
     response_json = response.json()
-    auth_token = response_json.get('access_token')
+    auth_token = response_json.get("access_token")
     return auth_token
 
 
 def get_icaseworks_report_from(report_id, from_date, auth_headers, auth_payload):
     report_url = "https://hackneyreports.icasework.com/getreport?"
-    request_url = f'{report_url}ReportId={report_id}&Format=json&From={from_date}'
-    logger.info(f'Request url: {request_url}')
+    request_url = f"{report_url}ReportId={report_id}&Format=json&From={from_date}"
+    logger.info(f"Request url: {request_url}")
     response = requests.get(request_url, headers=auth_headers, data=auth_payload)
-    logger.info(f'Status Code: {response.status_code}')
+    logger.info(f"Status Code: {response.status_code}")
     return response.content
 
 
 def write_dataframe_to_s3(s3_client, data, s3_bucket, output_folder, filename):
-    filename = re.sub('[^a-zA-Z0-9]+', '-', filename).lower()
+    filename = re.sub("[^a-zA-Z0-9]+", "-", filename).lower()
     current_date = datetime.datetime.now()
     day = single_digit_to_zero_prefixed_string(current_date.day)
     month = single_digit_to_zero_prefixed_string(current_date.month)
@@ -83,7 +86,7 @@ def write_dataframe_to_s3(s3_client, data, s3_bucket, output_folder, filename):
     return s3_client.put_object(
         Bucket=s3_bucket,
         Body=data,
-        Key=f"{output_folder}/import_year={year}/import_month={month}/import_day={day}/import_date={date}/{filename}.json"
+        Key=f"{output_folder}/import_year={year}/import_month={month}/import_day={day}/import_date={date}/{filename}.json",
     )
 
 
@@ -102,14 +105,16 @@ def lambda_handler(event, lambda_context):
     url = "https://hackney.icasework.com/token"
 
     headers = {
-        'Content-Type': 'application/x-www-form-urlencoded',
+        "Content-Type": "application/x-www-form-urlencoded",
     }
 
     # Get api api credentials from secrets manager
     secret_name = getenv("SECRET_NAME")
-    secrets_manager_client = boto3.client('secretsmanager')
-    api_credentials_response = retrieve_credentials_from_secrets_manager(secrets_manager_client, secret_name)
-    api_credentials = json.loads(api_credentials_response['SecretString'])
+    secrets_manager_client = boto3.client("secretsmanager")
+    api_credentials_response = retrieve_credentials_from_secrets_manager(
+        secrets_manager_client, secret_name
+    )
+    api_credentials = json.loads(api_credentials_response["SecretString"])
     api_key = api_credentials.get("api_key")
     secret = api_credentials.get("secret")
 
@@ -122,11 +127,7 @@ def lambda_handler(event, lambda_context):
     # Create payload
     current_unix_time = int(time.time())
     str_time = str(current_unix_time)
-    payload_object = {
-        "iss": api_key,
-        "aud": url,
-        "iat": str_time
-    }
+    payload_object = {"iss": api_key, "aud": url, "iat": str_time}
 
     payload_object = dictionary_to_string(payload_object)
 
@@ -136,16 +137,21 @@ def lambda_handler(event, lambda_context):
     signature = create_signature(header, payload, secret)
 
     # Get token from response
-    auth_token = get_token(url=url, encoded_header=header, encoded_payload=payload, signature=signature,
-                           headers=headers)
+    auth_token = get_token(
+        url=url,
+        encoded_header=header,
+        encoded_payload=payload,
+        signature=signature,
+        headers=headers,
+    )
 
     # Create auth header for API Calls and auth payload
-    authorization = f'Bearer {auth_token}'
+    authorization = f"Bearer {auth_token}"
 
     auth_payload = {}
 
     auth_headers = {
-        'Authorization': authorization,
+        "Authorization": authorization,
     }
 
     report_tables = [
@@ -164,22 +170,32 @@ def lambda_handler(event, lambda_context):
     date_to_track_from = today - datetime.timedelta(days=1)
     logger.info(f"Date to track from: {date_to_track_from}")
 
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
 
     for report_details in report_tables:
-        logger.info(f'Pulling report for {report_details["name"]}')
+        logger.info(f"Pulling report for {report_details['name']}")
         case_id_report_id = report_details["id"]
-        case_id_list = get_icaseworks_report_from(case_id_report_id, date_to_track_from, auth_headers, auth_payload)
+        case_id_list = get_icaseworks_report_from(
+            case_id_report_id, date_to_track_from, auth_headers, auth_payload
+        )
         report_details["data"] = case_id_list
-        write_dataframe_to_s3(s3_client, report_details["data"], s3_bucket, output_folder_name, report_details["name"])
-        logger.info(f'Finished writing report for {report_details["name"]} to S3')
+        write_dataframe_to_s3(
+            s3_client,
+            report_details["data"],
+            s3_bucket,
+            output_folder_name,
+            report_details["name"],
+        )
+        logger.info(f"Finished writing report for {report_details['name']} to S3")
 
     # Trigger glue job to copy from landing to raw and convert to parquet
-    glue_client = boto3.client('glue')
+    glue_client = boto3.client("glue")
     start_glue_trigger(glue_client, glue_trigger_name)
 
+
 def single_digit_to_zero_prefixed_string(value):
-    return str(value) if value > 9 else '0' + str(value)
+    return str(value) if value > 9 else "0" + str(value)
+
 
 def start_glue_trigger(glue_client, trigger_name):
     trigger_details = glue_client.start_trigger(Name=trigger_name)

--- a/lambdas/icaseworks_api_ingestion/main.py
+++ b/lambdas/icaseworks_api_ingestion/main.py
@@ -22,7 +22,7 @@ logger.setLevel(logging.INFO)
 
 def remove_illegal_characters(string):
     """Removes illegal characters from string"""
-    regex_list = [["=", ""], ["\/", "_"], ["+", "-"]]
+    regex_list = [["=", ""], ["\/", "_"], ["+", "-"]]  # noqa: W605
     for r in regex_list:
         string = re.sub(string=string, pattern="[{}]".format(r[0]), repl=r[1])
     return string

--- a/terraform/modules/api-ingestion-lambda/10-lambda.tf
+++ b/terraform/modules/api-ingestion-lambda/10-lambda.tf
@@ -129,7 +129,7 @@ resource "aws_s3_object" "lambda" {
   source_hash = null_resource.run_install_requirements.triggers["dir_sha1"]
   depends_on  = [data.archive_file.lambda]
   metadata = {
-    last_updated = data.archive_file.lambda.output_base64sha256
+    last_updated = null_resource.run_install_requirements.triggers.dir_sha1
   }
 }
 


### PR DESCRIPTION
Includes formatting changes to the scripts to trigger the null_resource - they remain functionally identical.

First run scenario:

- Source files are changed, so null_resource triggers
- Dependencies get installed 
- Zip file is created with both source files _and_ dependencies
- This complete zip file gets uploaded to S3


Subsequent runs (no source changes):

- Same source files produce the same dir_sha1 hash
- null_resource doesn't trigger (since the hash is unchanged)
- A local zip gets created with only source files (no dependencies)
  - this is what was being uploaded and resulting in failures
- Terraform sees that source_hash hasn't changed in the state, so it won't update the S3 object
- Lambda continues using the original, complete zip from S3