### PR TITLE
fix makefile

### DIFF
--- a/lambdas/icaseworks_api_ingestion/Makefile
+++ b/lambdas/icaseworks_api_ingestion/Makefile
@@ -5,6 +5,6 @@ install-requirements:
 	# the requirements are generated so that the packages
 	# could be downloaded and packaged up for the lambda
 
-	. venv/bin/activate && sudo pipenv lock --requirements > requirements.txt
+	. venv/bin/activate && sudo pipenv requirements > requirements.txt
 	. venv/bin/activate && sudo pip install --target ./lib -r requirements.txt
-	rm -rf venv/
+rm -rf venv/


### PR DESCRIPTION
The `pipenv lock --requirements` syntax doesn't work anymore so I've updated it to use the current `pipenv requirements` option.

> │ Error running command 'make install-requirements': exit status 2. Output:
> 4617│ python3 -m venv venv
> 4618│ # the requirements are generated so that the packages
> 4619│ # could be downloaded and packaged up for the lambda
> 4620│ . venv/bin/activate && sudo pipenv lock --requirements > requirements.txt
> 4621│ Usage: pipenv lock [OPTIONS]
> 4622│ Try 'pipenv lock -h' for help.
> 4623│
> 4624│ Error: No such option: --requirements Did you mean --quiet?
> 4625│ make: *** [Makefile:7: install-requirements] Error 2