### PR TITLE
use latest SHA instead of tag for tj action

### DIFF
--- a/.github/workflows/flake8_linter_python_files.yml
+++ b/.github/workflows/flake8_linter_python_files.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get Changed Files
         id: changed-files
-        uses: tj-actions/changed-files@fd9f32e836e6013a9c2a742b07d7d52bf03674c2
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # v46.0.1
         with:
           files: |
             **.py


### PR DESCRIPTION
The latest version of `tj-action` is `v46.0.1`, released yesterday (16 March 2025). See [URL](https://github.com/tj-actions/changed-files/pull/2474/commits/fd9f32e836e6013a9c2a742b07d7d52bf03674c2).

The author suggested increasing the tag, as it is mutable, but the SHA is not.

Therefore, we are switching to SHA to increase the security and avoid unexpected updates in the future.