### PR TITLE
Add tags to aws_glue_workflow for csv ingestion modules

### DIFF
--- a/terraform/modules/import-data-from-spreadsheet-job/02-inputs-optional.tf
+++ b/terraform/modules/import-data-from-spreadsheet-job/02-inputs-optional.tf
@@ -15,3 +15,9 @@ variable "enable_bookmarking" {
   type        = bool
   default     = false
 }
+
+variable "tags" {
+  description = "AWS tags"
+  type        = map(string)
+  default     = null
+}

--- a/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
+++ b/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
@@ -29,11 +29,12 @@ module "spreadsheet_import" {
         TableLevelConfiguration = 3
       }
     })
-    table_prefix      = null
+    table_prefix = null
   }
   trigger_enabled = false
 }
 
 resource "aws_glue_workflow" "workflow" {
   name = "${var.identifier_prefix}${local.import_name}-${var.output_folder_name}"
+  tags = var.tags
 }

--- a/terraform/modules/import-spreadsheet-file-from-g-drive/10-import-spreadsheet-file-from-g-drive.tf
+++ b/terraform/modules/import-spreadsheet-file-from-g-drive/10-import-spreadsheet-file-from-g-drive.tf
@@ -47,4 +47,5 @@ module "import_data_from_spreadsheet_job" {
   identifier_prefix              = var.identifier_prefix
   spark_ui_output_storage_id     = var.spark_ui_output_storage_id
   enable_bookmarking             = var.enable_bookmarking
+  tags                           = var.tags
 }


### PR DESCRIPTION
It looks like I changed the wrong place in last PR, sorry.

The main module is using source `import-spreadsheet-file-from-g-drive`, which uses `import-data-from-spreadsheet-job`.

This time should work fine
![image](https://github.com/user-attachments/assets/0dbd5ee1-728b-444d-8870-43ab31b17304)
