### PR TITLE
finally raise an error if any of the data quality check fails

### DIFF
--- a/scripts/jobs/planning/tascomi_create_daily_snapshot.py
+++ b/scripts/jobs/planning/tascomi_create_daily_snapshot.py
@@ -357,5 +357,6 @@ if __name__ == "__main__":
     finally:
         if len(dq_errors) > 0:
             logger.error(f"DQ Errors: {dq_errors}")
+            raise Exception(f"Data quality check failed: {'; '.join(dq_errors)}")
         spark.sparkContext._gateway.close()
         spark.stop()


### PR DESCRIPTION
After debugging and fixing with Tim, Anna, and Marta last week, Daro has confirmed that the data is now correct On last Friday.

However, it would be better to add one more step to make this more robust, apart from the previous [PR](https://github.com/LBHackney-IT/Data-Platform/pull/2187):
Finally, raise an error if any of the data quality checks fail, to avoid the issue where the data quality failed but no error message was received in the Google Chat space