### PR TITLE
remove table prefix created by crawler in google sheet ingestion

### DIFF
--- a/terraform/etl/60-airflow-etl-used-crawlers.tf
+++ b/terraform/etl/60-airflow-etl-used-crawlers.tf
@@ -136,8 +136,6 @@ resource "aws_glue_crawler" "google_sheet_ingestion_raw_zone" {
     path = "s3://${module.raw_zone_data_source.bucket_id}/${each.value.identifier}/google-sheets/"
   }
 
-  table_prefix = "${each.value.identifier_snake_case}_"
-
   configuration = jsonencode({
     Version = 1.0
     Grouping = {


### PR DESCRIPTION
Remove the default prefix added by the crawler in Google Sheet ingestion