### PR TITLE
chore: update qlik sg ingress rules

### DIFF
--- a/terraform/modules/qlik-sense-server/10-aws-ec2.tf
+++ b/terraform/modules/qlik-sense-server/10-aws-ec2.tf
@@ -75,32 +75,30 @@ resource "aws_security_group" "qlik_sense" {
     from_port   = 139
     to_port     = 139
     protocol    = "tcp"
-    cidr_blocks = ["10.151.11.27/32"]  # Replace with specific IP ranges for better security
+    cidr_blocks = ["10.151.11.27/32"] # Replace with specific IP ranges for better security
   }
 
   ingress {
     from_port   = 445
     to_port     = 445
     protocol    = "tcp"
-    cidr_blocks = ["10.151.11.27/32"]  # Replace with specific IP ranges for better security
+    cidr_blocks = ["10.151.11.27/32"] # Replace with specific IP ranges for better security
   }
 
   ingress {
-    description      = "Allow inbound HTTP traffic"
-    from_port        = 80
-    to_port          = 80
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    description = "Allow inbound HTTP traffic"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.20.13/32"]
   }
 
   ingress {
-    description      = "Allow inbound HTTPS traffic"
-    from_port        = 443
-    to_port          = 443
-    protocol         = "tcp"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
+    description = "Allow inbound HTTPS traffic"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["192.168.20.13/32"]
   }
 
   ingress {


### PR DESCRIPTION
- Updating overly permissive Security Group Inbound rules. 

- Restricting access to Qlik server from the Hub Trust interface.

Ref. [CE-2658](https://hackney.atlassian.net/browse/CE-2658)

[CE-2658]: https://hackney.atlassian.net/browse/CE-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ