### PR TITLE
Stop adding BackupPolicy tag Qlik storage

### DIFF
--- a/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
+++ b/terraform/modules/qlik-sense-server/15-aws-ec2-prod.tf
@@ -1,12 +1,12 @@
 locals {
   backup_ami_id_prod = "ami-0a9bac68a32217ec9"
   ec2_tags_prod = {
-    Application = "Qlik"
+    Application  = "Qlik"
     BackupPolicy = title(var.environment)
     Name         = "${var.identifier_prefix}-qlik-sense-restore"
   }
   ec2_tags_prod_restore = {
-    Application = "Qlik"
+    Application  = "Qlik"
     BackupPolicy = title(var.environment)
     Name         = "${var.identifier_prefix}-qlik-sense-restore-2"
   }
@@ -44,9 +44,14 @@ resource "aws_instance" "qlik_sense_prod_instance" {
     encrypted             = true
     delete_on_termination = false
     kms_key_id            = aws_kms_key.key.arn
-    tags                  = merge(var.tags, local.ec2_tags_prod)
-    volume_size           = 1000
-    volume_type           = "gp3"
+    # BackupPolicy tags will be automatically removed from volumes by cloud custodian
+    # https://github.com/LBHackney-IT/ce-cloud-custodian/blob/be250a45b282b9bd3771cc0990a8a8e00c669888/custodian/policies/prod-ou/remove-tag-from-ebs-volumes.yaml
+    tags = {
+      for key, value in merge(var.tags, local.ec2_tags_prod) :
+      key => value if key != "BackupPolicy"
+    }
+    volume_size = 1000
+    volume_type = "gp3"
   }
 
   lifecycle {


### PR DESCRIPTION
Filters the tags applied to the storage block attached to the Qlik EC2. This data is already backed up automatically and there is a cloud custodian rule to remove the tag - this results in our plans re-adding the tag every run.

refs:
```
policies:
  - name: remove-backup-tag-from-ebs-volumes
    comment: |
      *Removes BackupPolicy tag from ebs volumes in the Prod OU only.*
      CHANGE
      Since EC2 instances in the Prod OU are automatically backed up, including all EBS volumes, this action ensures that duplicate backups are not created.
    resource: ebs
    mode: 
      type: periodic
      schedule: "rate(1 hour)"
      role: CloudCustodian/CE_Cloud_Custodian_Policy_Execution_Role
      memory: 128
    filters:
      - "tag:BackupPolicy": "present"
    actions: 
      - type: remove-tag
        tags:
          - BackupPolicy
```        

https://github.com/LBHackney-IT/ce-cloud-custodian/blob/be250a45b282b9bd3771cc0990a8a8e00c669888/custodian/policies/prod-ou/remove-tag-from-ebs-volumes.yaml

 
![plan to add BackupPolicy tag](https://github.com/user-attachments/assets/4652f013-99d8-48b1-9a89-205b35639b2e)

![production volume without BackupPolicy tag](https://github.com/user-attachments/assets/30c776f1-e5c3-4fcf-951c-6e66c7e56e38)

