### PR TITLE
make resources list

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -330,7 +330,9 @@ locals {
         var.academy_data_source_arn
       ]
     }
-    resources = "*"
+    resources = [
+      "*"
+    ]
   }
 }
 


### PR DESCRIPTION
resources in the policy block need to be a list - fixing this error in the deployment run

> │ Error: updating KMS Key (16c05009-e071-4763-af20-b181b0f3d3d7): updating policy: MalformedPolicyDocumentException: 

> Policy contains a statement with one or more invalid principals.
> │ 
> │   with module.landing_zone.aws_kms_key.key,
> │   on ../modules/s3-bucket/10-s3-bucket.tf line 54, in resource "aws_kms_key" "key":
> │   54: resource "aws_kms_key" "key" ***
> │ 
> ╵
> Releasing state lock. This may take a few moments...
> Error: Process completed with exit code 1.
https://github.com/LBHackney-IT/Data-Platform/actions/runs/14853828019/job/41704436468