### PR TITLE
increase the workers for tascomi_create_daily_snapshot_planning

### DIFF
--- a/terraform/etl/24-aws-glue-tascomi-data.tf
+++ b/terraform/etl/24-aws-glue-tascomi-data.tf
@@ -264,7 +264,7 @@ module "tascomi_create_daily_snapshot" {
   job_name                       = "${local.short_identifier_prefix}tascomi_create_daily_snapshot_planning"
   glue_version                   = "2.0"
   glue_job_worker_type           = "G.2X"
-  number_of_workers_for_glue_job = 20
+  number_of_workers_for_glue_job = 16
   helper_module_key              = data.aws_s3_object.helpers.key
   pydeequ_zip_key                = data.aws_s3_object.pydeequ.key
   spark_ui_output_storage_id     = module.spark_ui_output_storage_data_source.bucket_id


### PR DESCRIPTION
The `application `table requires more resources to process—it has been failing for the past three days. Previously, it used 16 workers, but this was reduced to 12. I’d now like to increase it back to 16 or even 20 workers. Let’s try 20 workers for now—it’s working well so far.
We have a migration ticket on tascomi jobs later - need to think about how to optimise this to reduce the workers.

Update:
> │ Error: Invalid value for variable
> │ 
> │   on 24-aws-glue-tascomi-data.tf line 267, in module "tascomi_create_daily_snapshot":
> │  267:   number_of_workers_for_glue_job = 20
> │     ├────────────────
> │     │ var.number_of_workers_for_glue_job is 20
> │ 
> │ Number of workers should be greater than or equal to 2 and less than or
> │ equal to 16.

Our current Terraform AWS provider looks only provide max 16 workers. Let me change to 16 for now.