### PR TITLE
add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto eol=lf
+
+*.tf text eol=lf
+*.tfvars text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.zip binary


### PR DESCRIPTION
Adds a .gitattributes file to define attributes for file paths. 

This configuration is specifically to handle end of line characters - I got very large diffs because my wsl set up had changed the eol character to `crlf` rather than `lf`. 

Additionally ensures some binary types are encoded as such. 

https://git-scm.com/docs/gitattributes 