### PR TITLE
configure housing income crawler

### DIFF
--- a/terraform/core/12-housing-income-collection-db-ingestion.tf
+++ b/terraform/core/12-housing-income-collection-db-ingestion.tf
@@ -69,11 +69,13 @@ module "ingest_housing_income_collection_database_to_housing_raw_zone" {
     configuration = jsonencode({
       Version = 1.0
       Grouping = {
+        TableGroupingPolicy = "CombineCompatibleSchemas"
         TableLevelConfiguration = 3
       }
       CrawlerOutput = {
         Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
       }
+      Exclusions = ["mtfh*", "archive*", "data-quality*", "glue-*", "google-sheets*", "govnotify*", "ingestion-details*", "temp_backup*"]
     })
     table_prefix = null
   }


### PR DESCRIPTION
This crawler is scanning the whole housing path and creating a bit of a mess in the `housing-raw-zone` database. 

- exclude paths not related to this dataset
- combine compatible schemas so new tables aren't created that are in fact partitions of the same table