### PR TITLE
add crawler exclusions

### DIFF
--- a/terraform/core/18-rentsense-tables-ingestion.tf
+++ b/terraform/core/18-rentsense-tables-ingestion.tf
@@ -82,6 +82,7 @@ module "copy_mtfh_rentsense_dynamo_db_tables_to_raw_zone" {
     configuration = jsonencode({
       Version = 1.0
       Grouping = {
+        TableGoupingPolicy = "CombineCompatibleSchemas"
         TableLevelConfiguration = 3
       }
       CrawlerOutput = {


### PR DESCRIPTION
This crawler is intended to update the mtfh_* tables but is scanning the whole housing prefix and creating unintended tables in the housing-raw-zone database. 

Introduce exclusions to avoid these paths. 

Similar to #2284 / #2283 