### PR TITLE
add excluded paths to crawler

### DIFF
--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -78,6 +78,22 @@ module "ingest_housing_interim_finance_database_to_housing_raw_zone" {
     })
     table_prefix = null
   }
+  glue_crawler_excluded_blobs = [
+    "*/archive*",
+    "*/data-quality*",
+    "*/glue-*",
+    "*/google-sheets*",
+    "*/govnotify*",
+    "*/housingfinance*",
+    "*/ingestion-details*",
+    "*/mtfh*",
+    "*/temp_backup*",
+    "*.json",
+    "*.txt",
+    "*.zip",
+    "*.xlsx",
+    "*.html",
+  ] 
 }
 
 resource "aws_ssm_parameter" "ingest_housing_interim_finance_database_to_housing_raw_zone_crawler_name" {

--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -70,6 +70,7 @@ module "ingest_housing_interim_finance_database_to_housing_raw_zone" {
     configuration = jsonencode({
       Version = 1.0
       Grouping = {
+        TableGroupingPolicy     = "CombineCompatibleSchemas"
         TableLevelConfiguration = 3
       }
       CrawlerOutput = {
@@ -93,7 +94,7 @@ module "ingest_housing_interim_finance_database_to_housing_raw_zone" {
     "*.zip",
     "*.xlsx",
     "*.html",
-  ] 
+  ]
 }
 
 resource "aws_ssm_parameter" "ingest_housing_interim_finance_database_to_housing_raw_zone_crawler_name" {


### PR DESCRIPTION
This crawler is only intended to read files under the `housing/sow2b*` prefix so I'm excluding the others.

similar to #2290 