### PR TITLE
add admin buckets

### DIFF
--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -7,6 +7,7 @@ Feature: S3
   @exclude_aws_s3_bucket.mwaa_bucket
   @exclude_aws_s3_bucket.mwaa_etl_scripts_bucket
   @exclude_module.housing_nec_migration_storage.aws_s3_bucket.bucket
+  @exclude_module.admin_bucket.aws_s3_bucket.bucket
 
   # This rule is in place for legacy buckets created with the deprecated block within the aws_s3_bucket resource 
   Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -560,3 +560,15 @@ module "housing_nec_migration_storage" {
   bucket_identifier          = "housing-nec-migration-storage"
   include_backup_policy_tags = false
 }
+
+module "admin_bucket" {
+  source = "../modules/s3-bucket"
+
+  tags                       = module.tags.values
+  project                    = var.project
+  environment                = var.environment
+  identifier_prefix          = local.identifier_prefix
+  bucket_name                = "Admin Storage"
+  bucket_identifier          = "admin"
+  include_backup_policy_tags = false
+}


### PR DESCRIPTION
Creates `dataplatform-{env}-admin` buckets for storing administrative outputs e.g. s3 inventory reports