### PR TITLE
lower environment tag value

### DIFF
--- a/terraform/modules/s3-bucket/10-s3-bucket.tf
+++ b/terraform/modules/s3-bucket/10-s3-bucket.tf
@@ -131,7 +131,9 @@ data "aws_iam_policy_document" "bucket" {
 }
 
 locals {
-  standard_s3_tags = var.tags
+  standard_s3_tags = merge(var.tags, {
+    "Environment" = lower(var.environment)
+  })
 
   filtered_s3_tags = {
     for key, value in local.standard_s3_tags :


### PR DESCRIPTION
Updating the bucket tags to align with the tagging policy here:
https://github.com/LBHackney-IT/lbhackney-it.github.io/pull/25

`Environment`: The name of the environment, must be one of `dev`, `stg`, `prod` or `mgmt`

`var.environment` resolves to either `Dev`, `Stg` or `Prod` but must be lower case. 