### PR TITLE
Fix: Correcting S3 Permissions for Inventory

### DIFF
--- a/terraform/core/10-aws-s3-bucket-policies.tf
+++ b/terraform/core/10-aws-s3-bucket-policies.tf
@@ -294,7 +294,7 @@ locals {
     }
   ]
 
-  allow_s3_access_to_raw_zone_kms_key = {
+  allow_s3_kms_generatedatakey_from_raw_zone = {
     sid    = "Allow Amazon S3 use of the customer managed key"
     effect = "Allow"
     principals = {
@@ -312,7 +312,7 @@ locals {
     ])
   }
 
-  allow_s3_access_to_refined_zone_kms_key = {
+  allow_s3_kms_generatedatakey_from_refined_zone = {
     sid    = "Allow Amazon S3 use of the customer managed key"
     effect = "Allow"
     principals = {
@@ -330,7 +330,7 @@ locals {
     ])
   }
 
-  allow_s3_access_to_trusted_zone_kms_key = {
+  allow_s3_kms_generatedatakey_from_trusted_zone = {
     sid    = "Allow Amazon S3 use of the customer managed key"
     effect = "Allow"
     principals = {
@@ -347,6 +347,7 @@ locals {
       }
     ])
   }
+
 
   #-----------------------------------------------------------------------------
   # Admin Bucket Policies

--- a/terraform/core/10-aws-s3-bucket-policies.tf
+++ b/terraform/core/10-aws-s3-bucket-policies.tf
@@ -295,7 +295,7 @@ locals {
   ]
 
   allow_s3_kms_generatedatakey_from_raw_zone = {
-    sid    = "Allow Amazon S3 use of the customer managed key"
+    sid    = "Allow Amazon S3 use of the raw zone customer managed key"
     effect = "Allow"
     principals = {
       type        = "Service"
@@ -313,7 +313,7 @@ locals {
   }
 
   allow_s3_kms_generatedatakey_from_refined_zone = {
-    sid    = "Allow Amazon S3 use of the customer managed key"
+    sid    = "Allow Amazon S3 use of the refined zone customer managed key"
     effect = "Allow"
     principals = {
       type        = "Service"
@@ -331,7 +331,7 @@ locals {
   }
 
   allow_s3_kms_generatedatakey_from_trusted_zone = {
-    sid    = "Allow Amazon S3 use of the customer managed key"
+    sid    = "Allow Amazon S3 use of the trusted zone customer managed key"
     effect = "Allow"
     principals = {
       type        = "Service"

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -70,8 +70,7 @@ module "raw_zone" {
     ] : [],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod
-    ] : [],
-    [local.allow_s3_access_to_raw_zone_kms_key]
+    ] : []
   )
   include_backup_policy_tags = false
 }
@@ -96,8 +95,7 @@ module "refined_zone" {
     [local.rentsense_refined_zone_key_statement],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod
-    ] : [],
-    [local.allow_s3_access_to_refined_zone_kms_key]
+    ] : []
   )
   include_backup_policy_tags = false
 }
@@ -118,8 +116,7 @@ module "trusted_zone" {
   bucket_key_policy_statements = concat(
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod
-    ] : [],
-    [local.allow_s3_access_to_trusted_zone_kms_key]
+    ] : []
   )
   include_backup_policy_tags = false
 }

--- a/terraform/core/10-aws-s3-special-buckets.tf
+++ b/terraform/core/10-aws-s3-special-buckets.tf
@@ -51,5 +51,10 @@ module "admin_bucket" {
   bucket_name                = "Admin Storage"
   bucket_identifier          = "admin"
   bucket_policy_statements   = [local.grant_s3_write_permission_to_admin_bucket]
+  bucket_key_policy_statements = [
+    local.allow_s3_kms_generatedatakey_from_raw_zone,
+    local.allow_s3_kms_generatedatakey_from_refined_zone,
+    local.allow_s3_kms_generatedatakey_from_trusted_zone
+    ]
   include_backup_policy_tags = false
 }


### PR DESCRIPTION
I had this the wrong way round before (#2312)  with policies for the source bucket keys rather than allowing actions from the source buckets to use the admin bucket key. 

- Rename policy statements to better reflect their usage
- Remove policy attachments from source bucket keys
- Attach policy statements to admin bucket key
- Update SIDs so they are unique and better describe the statement effect