### PR TITLE
Batch role permissions

### DIFF
--- a/terraform/core/10-aws-s3-bucket-policies.tf
+++ b/terraform/core/10-aws-s3-bucket-policies.tf
@@ -384,4 +384,57 @@ locals {
       }
     ]
   }
+
+
+  #-----------------------------------------------------------------------------
+  # S3 Batch Copy Policies
+  #-----------------------------------------------------------------------------
+
+  allow_s3_batch_copy_kms_access_raw_zone = {
+    sid    = "Allow S3 Batch Copy to access raw zone KMS key"
+    effect = "Allow"
+    principals = {
+      type        = "AWS"
+      identifiers = [
+        aws_iam_role.batch_s3_copy_role.arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+  }
+
+  allow_s3_batch_copy_kms_access_refined_zone = {
+    sid    = "Allow S3 Batch Copy to access refined zone KMS key"
+    effect = "Allow"
+    principals = {
+      type        = "AWS"
+      identifiers = [
+        aws_iam_role.batch_s3_copy_role.arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+  }
+  
+  allow_s3_batch_copy_kms_access_trusted_zone = {
+    sid    = "Allow S3 Batch Copy to access trusted zone KMS key"
+    effect = "Allow"
+    principals = {
+      type        = "AWS"
+      identifiers = [
+        aws_iam_role.batch_s3_copy_role.arn
+      ]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+  }
 }

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -70,7 +70,8 @@ module "raw_zone" {
     ] : [],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod
-    ] : []
+    ] : [],
+    local.allow_s3_batch_copy_kms_access_raw_zone
   )
   include_backup_policy_tags = false
 }
@@ -95,7 +96,8 @@ module "refined_zone" {
     [local.rentsense_refined_zone_key_statement],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod
-    ] : []
+    ] : [],
+    local.allow_s3_batch_copy_kms_access_refined_zone
   )
   include_backup_policy_tags = false
 }
@@ -116,7 +118,8 @@ module "trusted_zone" {
   bucket_key_policy_statements = concat(
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod
-    ] : []
+    ] : [],
+    local.allow_s3_batch_copy_kms_access_trusted_zone
   )
   include_backup_policy_tags = false
 }

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -65,13 +65,13 @@ module "raw_zone" {
     ] : []
   )
   bucket_key_policy_statements = concat(
+    [local.allow_s3_batch_copy_kms_access_raw_zone],
     local.is_production_environment ? [
       local.s3_to_s3_copier_for_addresses_api_raw_zone_key_statement
     ] : [],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod
-    ] : [],
-    local.allow_s3_batch_copy_kms_access_raw_zone
+    ] : []
   )
   include_backup_policy_tags = false
 }
@@ -93,11 +93,13 @@ module "refined_zone" {
   )
 
   bucket_key_policy_statements = concat(
-    [local.rentsense_refined_zone_key_statement],
+    [
+      local.rentsense_refined_zone_key_statement,
+      local.allow_s3_batch_copy_kms_access_refined_zone
+    ],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod
-    ] : [],
-    local.allow_s3_batch_copy_kms_access_refined_zone
+    ] : []
   )
   include_backup_policy_tags = false
 }
@@ -116,10 +118,10 @@ module "trusted_zone" {
   ] : []
 
   bucket_key_policy_statements = concat(
+    [local.allow_s3_batch_copy_kms_access_trusted_zone],
     local.is_preprod_env ? [
       local.prod_to_pre_prod_data_sync_access_to_trusted_zone_key_statement_for_pre_prod
-    ] : [],
-    local.allow_s3_batch_copy_kms_access_trusted_zone
+    ] : []
   )
   include_backup_policy_tags = false
 }

--- a/terraform/core/60-batch-iam.tf
+++ b/terraform/core/60-batch-iam.tf
@@ -149,6 +149,38 @@ data "aws_iam_policy_document" "batch_s3_copy_service_role" {
       values   = ["${module.trusted_zone.bucket_arn}/*"]
     }
   }
+
+  statement {
+    sid = "S3BatchJobManifestAndReportAccess"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = ["${module.admin_bucket.bucket_arn}/*"]
+  }
+
+  statement {
+    sid = "KMSAccessForAdminBucket"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = [
+      module.admin_bucket.kms_key_arn
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.${var.aws_deploy_region}.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:s3:arn"
+      values   = ["${module.admin_bucket.bucket_arn}/*"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "batch_s3_copy_policy" {

--- a/terraform/core/60-batch-iam.tf
+++ b/terraform/core/60-batch-iam.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "batch_s3_copy_service_role" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = [module.raw_zone.bucket_arn]
+      values   = ["${module.raw_zone.bucket_arn}/*"]
     }
   }
 
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "batch_s3_copy_service_role" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = [module.refined_zone.bucket_arn]
+      values   = ["${module.refined_zone.bucket_arn}/*"]
     }
   }
 
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "batch_s3_copy_service_role" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:s3:arn"
-      values   = [module.trusted_zone.bucket_arn]
+      values   = ["${module.trusted_zone.bucket_arn}/*"]
     }
   }
 }

--- a/terraform/core/60-batch-iam.tf
+++ b/terraform/core/60-batch-iam.tf
@@ -201,7 +201,7 @@ resource "aws_iam_role" "batch_s3_copy_role" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          Service = "batch.amazonaws.com"
+          Service = "batchoperations.s3.amazonaws.com"
         }
       }
     ]


### PR DESCRIPTION
 This pull request introduces a series of IAM permission updates. The key changes include:


   - KMS Key Access: The S3 batch copy role is now granted access to the data zone KMS keys, enabling encrypted data to be copied
   - Trust Policy Update: The trust policy service has been updated to allow the s3 batch service to assume the role
   - Admin Bucket Access: The S3 batch copy role has been granted access to the admin bucket, allowing it to read the manifest files and write output logs from the task
   - Encryption Context: The encryption context has been updated because this will be the key for each object in the bucket, not just the bucket name