### PR TITLE
add athena budget alert

### DIFF
--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -41,7 +41,7 @@ module "aws_budget_athena" {
   threshold                  = 100
   threshold_type             = "PERCENTAGE"
   notification_type          = "ACTUAL"
-  subscriber_email_addresses = data.aws_ssm_parameter.budget_alert_recipients
+  subscriber_email_addresses = [data.aws_ssm_parameter.budget_alert_recipients.value]
 
   enable_anomaly_detection       = true
   anomaly_monitor_name           = "AthenaDailyAnomalyMonitor"
@@ -75,7 +75,7 @@ module "aws_budget_glue" {
   threshold                  = 100
   threshold_type             = "PERCENTAGE"
   notification_type          = "ACTUAL"
-  subscriber_email_addresses = data.aws_ssm_parameter.budget_alert_recipients
+  subscriber_email_addresses = [data.aws_ssm_parameter.budget_alert_recipients.value]
 
   enable_anomaly_detection       = true
   anomaly_monitor_name           = "AthenaDailyAnomalyMonitor"

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -9,3 +9,26 @@ module "set_budget_limit_amount" {
   account_id                     = data.aws_caller_identity.data_platform.account_id
   emails_to_notify               = var.emails_to_notify_with_budget_alerts
 }
+
+
+module "aws_budget" {
+  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh"
+
+  budget_name               = "Athena Daily Budget Alert"
+  budget_type               = "COST"
+  limit_amount              = "3"
+  time_unit                 = "DAILY"
+
+  cost_filter = [
+    {
+      name   = "Service"
+      values = ["Amazon Athena"]
+    }
+  ]
+
+  comparison_operator       = "GREATER_THAN"
+  threshold                 = 100
+  threshold_type            = "PERCENTAGE"
+  notification_type         = "ACTUAL"
+  subscriber_email_address  = var.emails_to_notify_with_budget_alerts
+}

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -20,7 +20,7 @@ data "aws_ssm_parameter" "budget_alert_recipients" {
   name = aws_ssm_parameter.budget_alert_recipients.value
 }
 
-module "aws_budget" {
+module "aws_budget_athena" {
   count  = local.is_live_environment ? 1 : 0
   source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
   tags   = module.tags.values
@@ -34,6 +34,40 @@ module "aws_budget" {
     {
       name   = "Service"
       values = ["Amazon Athena"]
+    }
+  ]
+
+  comparison_operator        = "GREATER_THAN"
+  threshold                  = 100
+  threshold_type             = "PERCENTAGE"
+  notification_type          = "ACTUAL"
+  subscriber_email_addresses = data.aws_ssm_parameter.budget_alert_recipients
+
+  enable_anomaly_detection       = true
+  anomaly_monitor_name           = "AthenaDailyAnomalyMonitor"
+  anomaly_monitor_type           = "DIMENSIONAL"
+  anomaly_monitor_dimension      = "SERVICE"
+  anomaly_subscription_name      = "AthenaDailySubscription"
+  anomaly_subscription_frequency = "DAILY"
+  threshold_key                  = "ANOMALY_TOTAL_IMPACT_ABSOLUTE"
+  match_options                  = ["GREATER_THAN_OR_EQUAL"]
+  threshold_values               = ["1"]
+}
+
+module "aws_budget_glue" {
+  count  = local.is_live_environment ? 1 : 0
+  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
+  tags   = module.tags.values
+
+  budget_name  = "Glue Daily Budget Alert"
+  budget_type  = "COST"
+  limit_amount = local.is_production_environment ? "45" : "15"
+  time_unit    = "DAILY"
+
+  cost_filter = [
+    {
+      name   = "Service"
+      values = ["Amazon Glue"]
     }
   ]
 

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -23,7 +23,6 @@ data "aws_ssm_parameter" "budget_alert_recipients" {
 module "aws_budget_athena" {
   count  = local.is_live_environment ? 1 : 0
   source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
-  tags   = module.tags.values
 
   budget_name  = "Athena Daily Budget Alert"
   budget_type  = "COST"
@@ -57,7 +56,7 @@ module "aws_budget_athena" {
 module "aws_budget_glue" {
   count  = local.is_live_environment ? 1 : 0
   source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
-  tags   = module.tags.values
+
 
   budget_name  = "Glue Daily Budget Alert"
   budget_type  = "COST"

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -22,7 +22,7 @@ data "aws_ssm_parameter" "budget_alert_recipients" {
 
 module "aws_budget" {
   count  = local.is_live_environment ? 1 : 0
-  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=d3a5e0e0751aafcc786dfcbd45af38ed9d834dec"
+  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
 
   budget_name  = "Athena Daily Budget Alert"
   budget_type  = "COST"

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -27,7 +27,7 @@ module "aws_budget_athena" {
 
   budget_name  = "Athena Daily Budget Alert"
   budget_type  = "COST"
-  limit_amount = local.is_production_environment ? "3" : "1"
+  limit_amount = local.is_production_environment ? "5" : "3"
   time_unit    = "DAILY"
 
   cost_filter = [

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -23,7 +23,7 @@ data "aws_ssm_parameter" "budget_alert_recipients" {
 
 module "aws_budget_athena" {
   count  = local.is_live_environment ? 1 : 0
-  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
+  source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=176a7e7234d74d94d5116c7f0b5d59f6e6db0a48" # v1.4.0
 
   budget_name  = "Athena Daily Budget Alert"
   budget_type  = "COST"

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -13,7 +13,7 @@ module "set_budget_limit_amount" {
 resource "aws_ssm_parameter" "budget_alert_recipients" {
   name = "budget-alert-recipients"
   type = "StringList"
-  tags = var.tags
+  tags = module.tags.values
 }
 
 data "aws_ssm_parameter" "budget_alert_recipients" {
@@ -23,6 +23,7 @@ data "aws_ssm_parameter" "budget_alert_recipients" {
 module "aws_budget" {
   count  = local.is_live_environment ? 1 : 0
   source = "github.com/LBHackney-IT/ce-aws-budgets-lbh.git?ref=671dab00698fbef054ebc15b7928e03aae525583"
+  tags   = module.tags.values
 
   budget_name  = "Athena Daily Budget Alert"
   budget_type  = "COST"

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -11,7 +11,7 @@ module "set_budget_limit_amount" {
 }
 
 resource "aws_ssm_parameter" "budget_alert_recipients" {
-  name  = "budget-alert-recipients"
+  name  = "/data-and-insight/budget-alert-recipients"
   type  = "StringList"
   value = "value"
   tags  = module.tags.values

--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -11,9 +11,10 @@ module "set_budget_limit_amount" {
 }
 
 resource "aws_ssm_parameter" "budget_alert_recipients" {
-  name = "budget-alert-recipients"
-  type = "StringList"
-  tags = module.tags.values
+  name  = "budget-alert-recipients"
+  type  = "StringList"
+  value = "value"
+  tags  = module.tags.values
 }
 
 data "aws_ssm_parameter" "budget_alert_recipients" {


### PR DESCRIPTION
Introduces budget alerts with anomaly detection for AWS Athena and Glue services. 

The email list for alert distribution is managed in parameter store under the parameter `/data-and-insight/budget-alert-recipients`