### PR TITLE
update aws_db_instance.id to aws_db_instance.identifier

### DIFF
--- a/terraform/modules/sql-to-rds-snapshot/10-ecs.tf
+++ b/terraform/modules/sql-to-rds-snapshot/10-ecs.tf
@@ -3,7 +3,7 @@ locals {
     { name : "MYSQL_HOST", value : aws_db_instance.ingestion_db.address },
     { name : "MYSQL_USER", value : aws_db_instance.ingestion_db.username },
     { name : "MYSQL_PASS", value : random_password.rds_password.result },
-    { name : "RDS_INSTANCE_ID", value : aws_db_instance.ingestion_db.id },
+    { name : "RDS_INSTANCE_ID", value : aws_db_instance.ingestion_db.identifier },
     { name : "BUCKET_NAME", value : var.watched_bucket_name },
   ]
 
@@ -71,7 +71,7 @@ module "sql_to_parquet" {
         { name : "MYSQL_HOST", value : aws_db_instance.ingestion_db.address },
         { name : "MYSQL_USER", value : aws_db_instance.ingestion_db.username },
         { name : "MYSQL_PASS", value : random_password.rds_password.result },
-        { name : "RDS_INSTANCE_ID", value : aws_db_instance.ingestion_db.id },
+        { name : "RDS_INSTANCE_ID", value : aws_db_instance.ingestion_db.identifier },
         { name : "BUCKET_NAME", value : var.watched_bucket_name },
       ]
     }

--- a/terraform/modules/sql-to-rds-snapshot/99-outputs.tf
+++ b/terraform/modules/sql-to-rds-snapshot/99-outputs.tf
@@ -5,7 +5,7 @@ output "ecr_repository_worker_endpoint" {
 }
 
 output "rds_instance_id" {
-  value = aws_db_instance.ingestion_db.id
+  value = aws_db_instance.ingestion_db.identifier
 }
 
 output "cloudwatch_event_rule_name" {


### PR DESCRIPTION
**Summary**
This change updates the `aws_db_instance` resource attribute from `.id` to .`identifier` to align with a breaking change in version 5.0.0 of the Terraform AWS provider.

The Problem
Following the upgrade to the Terraform AWS provider `~>5.0` (introduced in PR #2335), the value returned by `aws_db_instance.id`  changed from the user-defined DB Instance Identifier to the immutable DBI Resource ID.

This caused our rds create-db-snapshot process to fail, as it was receiving the incorrect ID format.

The Solution
The failing references have been updated to use `aws_db_instance.identifier`, which now holds the DB Instance Identifier value as expected.

A search of the codebase confirms no other resources are affected by this specific attribute change.

Related Links
[Terraform AWS Provider v5.0 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#aws_db_instanceid-is-no-longer-the-identifier)

