### PR TITLE
Create-glue-data-catalog-cloudtrail-logging

### DIFF
--- a/terraform/core/99-outputs.tf
+++ b/terraform/core/99-outputs.tf
@@ -40,3 +40,13 @@ output "mwaa_etl_scripts_bucket_arn" {
 output "mwaa_key_arn" {
   value = aws_kms_key.mwaa_key.arn
 }
+
+output "glue_data_catalog_cloudtrail_arn" {
+  description = "ARN of the CloudTrail logging Glue Data Catalog usage"
+  value       = aws_cloudtrail.glue_data_catalog_usage.arn
+}
+
+output "glue_data_catalog_cloudtrail_log_group" {
+  description = "CloudWatch Log Group for Glue Data Catalog CloudTrail"
+  value       = aws_cloudwatch_log_group.glue_data_catalog_cloudtrail.name
+}


### PR DESCRIPTION
Log Glue Data Catalog events to the CloudTrail bucket.

I think I've covered all database, table, and partition operations. I'm using the boto3 client documentation ([URL](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html)) to check all possible methods, as it's more efficient than going through AWS web pages one by one. Not sure if there's a better way to review all available methods for the Glue Data Catalog.