### PR TITLE
fix the creation of glue catalog trail

### DIFF
--- a/terraform/core/88-glue-data-catalog-logging.tf
+++ b/terraform/core/88-glue-data-catalog-logging.tf
@@ -67,10 +67,6 @@ resource "aws_cloudtrail" "glue_data_catalog_usage" {
   advanced_event_selector {
     name = "Log Glue Data Catalog events only"
     field_selector {
-      field  = "eventCategory"
-      equals = ["Management"]
-    }
-    field_selector {
       field  = "eventSource"
       equals = ["glue.amazonaws.com"]
     }


### PR DESCRIPTION
Removed eventCategory = 'Management' field selector due to AWS CloudTrail service restriction that prevents combining eventCategory = 'Management' with eventSource selectors based on the error message from [github action](https://github.com/LBHackney-IT/Data-Platform/actions/runs/16521009638/job/46723203365).

The eventSource and eventName filters are sufficient to capture the desired Glue Data Catalog events.