### PR TITLE
DL-5-create-cloudtrail-table-with-partition-projection

### DIFF
--- a/terraform/etl/61-aws-glue-catalog-tables-and-views.tf
+++ b/terraform/etl/61-aws-glue-catalog-tables-and-views.tf
@@ -248,11 +248,15 @@ SELECT
 FROM "${aws_glue_catalog_database.metastore.name}"."${aws_glue_catalog_table.cloudtrail_management_events.name}"
 WHERE eventSource = 'glue.amazonaws.com'
   AND eventName IN (
-    'CreateTable',
-    'UpdateTable',
-    'BatchCreatePartition',
-    'DeleteTable',
-    'BatchDeletePartition'
+    -- Database operations
+    'CreateDatabase', 'GetDatabase', 'GetDatabases', 'UpdateDatabase', 'DeleteDatabase',
+    -- Table operations
+    'CreateTable', 'GetTable', 'GetTables', 'UpdateTable', 'DeleteTable',
+    'GetTableVersion', 'GetTableVersions', 'DeleteTableVersion',
+    -- Partition operations
+    'CreatePartition', 'GetPartition', 'GetPartitions', 'UpdatePartition', 'DeletePartition',
+    'GetPartitionIndexes', 'CreatePartitionIndex', 'DeletePartitionIndex',
+    'BatchCreatePartition', 'BatchDeletePartition'
   )
 EOF
     catalog     = "awsdatacatalog"


### PR DESCRIPTION
- Create a partitioned CloudTrail event-management table, and a view for Glue (database and table)-related events. 
- The view:
  - can be created directly using SQL DDL, whereas the table cannot.
  - Parse the database and table names from the requestParameters
  - rename the partition columns in order to enable filtering after joining with other metadata tables.

Some useful docs about creation of CloudTrail log table ([doc](https://docs.aws.amazon.com/athena/latest/ug/create-cloudtrail-table.html)) and partition it using projection ([doc](https://docs.aws.amazon.com/athena/latest/ug/create-cloudtrail-table-partition-projection.html)). The log table includes all attributes that CloudTrail offers.