### PR TITLE
change the struct to one line to fix the cloudtrail table

### DIFF
--- a/terraform/etl/61-aws-glue-catalog-tables-and-views.tf
+++ b/terraform/etl/61-aws-glue-catalog-tables-and-views.tf
@@ -54,32 +54,7 @@ resource "aws_glue_catalog_table" "cloudtrail_management_events" {
 
     columns {
       name = "userIdentity"
-      type = <<-EOT
-        struct<
-          type:string,
-          principalId:string,
-          arn:string,
-          accountId:string,
-          invokedBy:string,
-          accessKeyId:string,
-          userName:string,
-          sessionContext:struct<
-            attributes:struct<
-              mfaAuthenticated:string,
-              creationDate:string>,
-            sessionIssuer:struct<
-              type:string,
-              principalId:string,
-              arn:string,
-              accountId:string,
-              userName:string>,
-            ec2RoleDelivery:string,
-            webIdFederationData:struct<
-              federatedprovider:string,
-              attributes:map<string,string>>
-          >
-        >
-      EOT
+      type = "struct<type:string,principalId:string,arn:string,accountId:string,invokedBy:string,accessKeyId:string,userName:string,sessionContext:struct<attributes:struct<mfaAuthenticated:string,creationDate:string>,sessionIssuer:struct<type:string,principalId:string,arn:string,accountId:string,userName:string>,ec2RoleDelivery:string,webIdFederationData:struct<federatedprovider:string,attributes:map<string,string>>>>"
     }
 
     columns {
@@ -189,13 +164,7 @@ resource "aws_glue_catalog_table" "cloudtrail_management_events" {
 
     columns {
       name = "tlsDetails"
-      type = <<-EOT
-        struct<
-          tlsVersion:string,
-          cipherSuite:string,
-          clientProvidedHostHeader:string
-        >
-      EOT
+      type = "struct<tlsVersion:string,cipherSuite:string,clientProvidedHostHeader:string>"
     }
   }
 


### PR DESCRIPTION
> at 'table.storageDescriptor.columns.24.member.type' failed to satisfy constraint: Member must satisfy regular expression pattern: [\u0020-\uD7FF\uE000-\uFFFD\uD800\uDC00-\uDBFF\uDFFF\t]*

For improved readability, I used EOT to split the types across multiple lines, but it appears that this approach doesn’t work here.

I've checked how others have implemented it – it needs to be on a single line.
