### PR TITLE
add alloy connection to MWAA

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -244,3 +244,28 @@ resource "aws_mwaa_environment" "mwaa" {
     })
   }
 }
+
+# Connections
+
+resource "aws_secretsmanager_secret" "mwaa_alloy_api_connection" {
+  name = "airflow/connections/alloy"
+  tags = module.tags.values
+}
+
+resource "aws_secretsmanager_secret_version" "mwaa_alloy_api_connection" {
+  secret_id = aws_secretsmanager_secret.mwaa_alloy_api_connection.id
+  secret_string = jsonencode({
+    conn_type = "http",
+    host      = "https://api.uk.alloyapp.io",
+    password  = "UPDATE_IN_CONSOLE",
+    port      = null,
+    schema    = null,
+    extra     = null,
+  })
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+}
+
+

--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -258,9 +258,8 @@ resource "aws_secretsmanager_secret_version" "mwaa_alloy_api_connection" {
     conn_type = "http",
     host      = "https://api.uk.alloyapp.io",
     password  = "UPDATE_IN_CONSOLE",
-    port      = null,
-    schema    = null,
-    extra     = null,
+    port      = 443,
+    schema    = "https",
   })
 
   lifecycle {


### PR DESCRIPTION
Creates a secret to be used for API calls to the Alloy API from MWAA.

This is required for updates to the Alloy ingestion DAG in this PR: [Alloy secret handling #524.](https://github.com/LBHackney-IT/dap-airflow/pull/524)