### PR TITLE
Feat/housing create view permissions nec

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -421,6 +421,12 @@ module "department_housing" {
       actions     = ["s3:Get*", "s3:List*", "s3:Put*", "s3:Delete*"]
     }
   ]
+  additional_glue_database_access = [
+    {
+      database_name = "housing_nec_migration"
+      actions       = ["glue:CreateTable", "glue:UpdateTable", "glue:DeleteTable", "glue:GetTable", "glue:GetTables", "glue:GetDatabase"]
+    }
+  ]
 }
 
 module "department_children_and_education" {

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -67,3 +67,15 @@ variable "cloudtrail_bucket" {
   })
   default = null
 }
+
+variable "additional_glue_database_access" {
+  description = <<EOF
+    Additional Glue database access to grant to the department.
+    Allows specifying specific databases and the actions that can be performed on them.
+  EOF
+  type = list(object({
+    database_name = string
+    actions       = list(string)
+  }))
+  default = []
+}

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -187,8 +187,8 @@ data "aws_iam_policy_document" "read_only_glue_access" {
       effect  = "Allow"
       actions = additional_db_access.value.actions
       resources = [
-        "arn:aws:glue:*:*:database/${additional_db_access.value.database_name}",
-        "arn:aws:glue:*:*:table/${additional_db_access.value.database_name}/*"
+        "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:database/${additional_db_access.value.database_name}",
+        "arn:aws:glue:eu-west-2:${data.aws_caller_identity.current.account_id}:table/${additional_db_access.value.database_name}/*"
       ]
     }
   }
@@ -521,20 +521,6 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:Query*",
     ]
     resources = ["*"]
-  }
-
-  dynamic "statement" {
-    for_each = var.additional_glue_database_access
-    iterator = additional_db_access
-    content {
-      sid     = "AdditionalGlueDatabaseFullAccess${replace(additional_db_access.value.database_name, "/[^a-zA-Z0-9]/", "")}"
-      effect  = "Allow"
-      actions = additional_db_access.value.actions
-      resources = [
-        "arn:aws:glue:*:*:database/${additional_db_access.value.database_name}",
-        "arn:aws:glue:*:*:table/${additional_db_access.value.database_name}/*"
-      ]
-    }
   }
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -178,6 +178,20 @@ data "aws_iam_policy_document" "read_only_glue_access" {
     ]
     resources = ["*"]
   }
+
+  dynamic "statement" {
+    for_each = var.additional_glue_database_access
+    iterator = additional_db_access
+    content {
+      sid     = "AdditionalGlueDatabaseAccess${replace(additional_db_access.value.database_name, "/[^a-zA-Z0-9]/", "")}"
+      effect  = "Allow"
+      actions = additional_db_access.value.actions
+      resources = [
+        "arn:aws:glue:*:*:database/${additional_db_access.value.database_name}",
+        "arn:aws:glue:*:*:table/${additional_db_access.value.database_name}/*"
+      ]
+    }
+  }
 }
 
 resource "aws_iam_policy" "read_only_glue_access" {
@@ -507,6 +521,20 @@ data "aws_iam_policy_document" "glue_access" {
       "glue:Query*",
     ]
     resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.additional_glue_database_access
+    iterator = additional_db_access
+    content {
+      sid     = "AdditionalGlueDatabaseFullAccess${replace(additional_db_access.value.database_name, "/[^a-zA-Z0-9]/", "")}"
+      effect  = "Allow"
+      actions = additional_db_access.value.actions
+      resources = [
+        "arn:aws:glue:*:*:database/${additional_db_access.value.database_name}",
+        "arn:aws:glue:*:*:table/${additional_db_access.value.database_name}/*"
+      ]
+    }
   }
 }
 


### PR DESCRIPTION
Adds a variable `additional_glue_database_access` to the department module to allow departments non-standard access to specific Glue databases. 

Grants the `housing` department the permission to create, update and delete tables in the `housing_nec_migration` database to meet a need the migration have to be able to create, alter and delete views in that database.