### PR TITLE
grant qlik user to access the files in the cloudtrail bucket

### DIFF
--- a/terraform/core/24-qlik-iam.tf
+++ b/terraform/core/24-qlik-iam.tf
@@ -53,7 +53,8 @@ data "aws_iam_policy_document" "qlik_can_read_from_s3_and_athena" {
       "${module.raw_zone.bucket_arn}/*",
       "${module.refined_zone.bucket_arn}/*",
       "${module.trusted_zone.bucket_arn}/*",
-      "${module.athena_storage.bucket_arn}/*"
+      "${module.athena_storage.bucket_arn}/*",
+      "${module.cloudtrail_storage.bucket_arn}/*"
     ]
   }
 
@@ -78,7 +79,8 @@ data "aws_iam_policy_document" "qlik_can_read_from_s3_and_athena" {
       module.athena_storage.kms_key_arn,
       module.raw_zone.kms_key_arn,
       module.refined_zone.kms_key_arn,
-      module.trusted_zone.kms_key_arn
+      module.trusted_zone.kms_key_arn,
+      module.cloudtrail_storage.kms_key_arn
     ]
   }
 


### PR DESCRIPTION
Got below error when building dashboard in the Qlik - needs to grant Qlik user permission to access the data
<img width="1889" height="262" alt="image" src="https://github.com/user-attachments/assets/33694fe4-08bd-48b4-988c-9254d21f73fb" />
