### PR TITLE
Dl 64/add nec migration outputs db

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -425,6 +425,10 @@ module "department_housing" {
     {
       database_name = "housing_nec_migration"
       actions       = ["glue:CreateTable", "glue:UpdateTable", "glue:DeleteTable", "glue:GetTable", "glue:GetTables", "glue:GetDatabase"]
+    },
+    {
+      database_name = "housing_nec_migration_outputs"
+      actions       = ["glue:CreateTable", "glue:UpdateTable", "glue:DeleteTable", "glue:GetTable", "glue:GetTables", "glue:GetDatabase"]
     }
   ]
 }

--- a/terraform/etl/61-aws-glue-catalog-database.tf
+++ b/terraform/etl/61-aws-glue-catalog-database.tf
@@ -30,6 +30,13 @@ resource "aws_glue_catalog_database" "housing_nec_migration_database" {
   }
 }
 
+resource "aws_glue_catalog_database" "housing_nec_migration_outputs_database" {
+  name = "housing_nec_migration_outputs"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 resource "aws_glue_catalog_database" "ctax_raw_zone" {
   name = "ctax_raw_zone"


### PR DESCRIPTION
Adds a new Glue catalog database for NEC housing migration outputs: `housing_nec_migration_outputs`

Adds permissions so that the housing department can alter tables within the `housing_nec_migration_outputs` database
