### PR TITLE
ignore changes to parameter value

### DIFF
--- a/terraform/core/34-aws-budget-alerting.tf
+++ b/terraform/core/34-aws-budget-alerting.tf
@@ -25,7 +25,7 @@ resource "aws_ssm_parameter" "budget_alert_recipients" {
 }
 
 data "aws_ssm_parameter" "budget_alert_recipients" {
-  name = aws_ssm_parameter.budget_alert_recipients.value
+  name = aws_ssm_parameter.budget_alert_recipients.name
 }
 
 module "aws_budget_athena" {


### PR DESCRIPTION
Quick fix to allow the creation of the SSM parameter that was already created in the console for testing. 

I will update the values once the deployment pipeline has run then run the workflow again to sync the values between parameter store and the budget resources.