### PR TITLE
Dl 67/liberator crawler config

### DIFF
--- a/terraform/etl/33-aws-glue-liberator-data.tf
+++ b/terraform/etl/33-aws-glue-liberator-data.tf
@@ -35,6 +35,11 @@ resource "aws_glue_crawler" "landing_zone_liberator" {
   recrawl_policy {
     recrawl_behavior = "CRAWL_NEW_FOLDERS_ONLY"
   }
+
+  schema_change_policy {
+    delete_behavior = "LOG"
+    update_behavior = "LOG"
+  }
 }
 
 // LIBERATOR RAW ZONE

--- a/terraform/etl/33-aws-glue-liberator-data.tf
+++ b/terraform/etl/33-aws-glue-liberator-data.tf
@@ -31,6 +31,10 @@ resource "aws_glue_crawler" "landing_zone_liberator" {
     path       = "s3://${module.landing_zone_data_source.bucket_id}/parking/liberator"
     exclusions = local.glue_crawler_excluded_blobs
   }
+
+  recrawl_policy {
+    recrawl_behavior = "CRAWL_NEW_FOLDERS_ONLY"
+  }
 }
 
 // LIBERATOR RAW ZONE
@@ -138,7 +142,7 @@ resource "aws_glue_crawler" "refined_zone_parking_liberator_crawler" {
   database_name = aws_glue_catalog_database.refined_zone_liberator.name
   name          = "${local.identifier_prefix}-refined-zone-liberator"
   role          = data.aws_iam_role.glue_role.arn
-  schedule      = local.is_production_environment  || !local.is_live_environment ? null : "cron(30 8 * * ? *)"
+  schedule      = local.is_production_environment || !local.is_live_environment ? null : "cron(30 8 * * ? *)"
 
   s3_target {
     path       = "s3://${module.refined_zone_data_source.bucket_id}/parking/liberator/"


### PR DESCRIPTION
Addresses the following error by setting the schema change policy to LOG for the required values - defaults to [delete_behavior](https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta2/docs/resources/glue_crawler#delete_behavior-1) = DEPRECATE_IN_DATABASE and [update_behavior](https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta2/docs/resources/glue_crawler#update_behavior-1) = UPDATE_IN_DATABASE, which don't make sense if you're not rescanning the old partitions.  

> ╷
> │ Error: updating Glue Crawler (***-landing-zone-liberator): InvalidInputException: The SchemaChangePolicy for "Crawl new folders only" Amazon S3 target can have only LOG DeleteBehavior value and LOG UpdateBehavior value.
> │ ***
> │   RespMetadata: ***
> │     StatusCode: 400,
> │     RequestID: "83a5a347-af44-49eb-ad49-6d1d065bd38b"
> │   ***,
> │   Message_: "The SchemaChangePolicy for \"Crawl new folders only\" Amazon S3 target can have only LOG DeleteBehavior value and LOG UpdateBehavior value."
> │ ***
> │ 
> │   with aws_glue_crawler.landing_zone_liberator,
> │   on 33-aws-glue-liberator-data.tf line 23, in resource "aws_glue_crawler" "landing_zone_liberator":
> │   23: resource "aws_glue_crawler" "landing_zone_liberator" ***
> │ 
> ╵