### PR TITLE
Add larger ephemeral storage configuration to ECS task definition

### DIFF
--- a/terraform/modules/aws-ecs-fargate-task/12-aws-ecs.tf
+++ b/terraform/modules/aws-ecs-fargate-task/12-aws-ecs.tf
@@ -46,6 +46,10 @@ resource "aws_ecs_task_definition" "task_definition" {
     operating_system_family = "LINUX"
     cpu_architecture        = "X86_64"
   }
+
+  ephemeral_storage {
+    size_in_gib = 50
+  }
 }
 
 resource "aws_cloudwatch_log_group" "ecs_task_logs" {


### PR DESCRIPTION
By default, an ECS Fargate task only has 20 GiB of ephemeral storage ([doc](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/fargate-task-storage.html?utm_source=chatgpt.com)
), which is not enough to unzip the Liberator .sql snapshot (see screenshot), so I explicitly increased it to 50 GiB.

<img width="1512" height="402" alt="image" src="https://github.com/user-attachments/assets/a0de6758-622e-4932-9875-cfcbea79bdf8" />
