### PR TITLE
clean the partition before writing to it - idempotency rule

### DIFF
--- a/scripts/jobs/copy_tables_landing_to_raw.py
+++ b/scripts/jobs/copy_tables_landing_to_raw.py
@@ -48,7 +48,7 @@ def purge_today_partition(
     logger.info(f"Successfully purged partition for table {table_name}")
 
 
-## @params: [JOB_NAME]
+# @params: [JOB_NAME]
 args = getResolvedOptions(sys.argv, ["JOB_NAME"])
 
 sc = SparkContext()


### PR DESCRIPTION
A general rule to follow: make sure reruns always produce the same output.

I encountered an issue when re-running the Liberator copy landing to raw — it partly succeeded the first time, but the rerun caused duplicates for the entries that had already succeeded. It costs time to clean the duplications.