### PR TITLE
exclude the nec-migration-data-quality-tests from crawler config

### DIFF
--- a/terraform/core/39-housing-interim-finance-db-ingestion.tf
+++ b/terraform/core/39-housing-interim-finance-db-ingestion.tf
@@ -88,6 +88,7 @@ module "ingest_housing_interim_finance_database_to_housing_raw_zone" {
     "*/housingfinance*",
     "*/ingestion-details*",
     "*/mtfh*",
+    "*/nec-migration-data-quality-tests*",
     "*/temp_backup*",
     "*.json",
     "*.txt",


### PR DESCRIPTION
This corresponding table will be created and update by glue [script ](https://github.com/LBHackney-IT/Data-Platform/blob/main/scripts/jobs/housing/housing_nec_migration_apply_gx_dq_tests.py)
Exclude it from crawler sources' paths