### PR TITLE
Remove the unused crawler allocation_refined

### DIFF
--- a/terraform/etl/60-airflow-etl-used-crawlers.tf
+++ b/terraform/etl/60-airflow-etl-used-crawlers.tf
@@ -1,5 +1,3 @@
-# mosaic ETL resources
-
 resource "aws_glue_crawler" "mosaic_raw_zone" {
   count         = local.is_live_environment ? 1 : 0
   name          = "${local.short_identifier_prefix}${module.department_children_family_services_data_source.identifier}-mosaic-raw-zone"
@@ -8,29 +6,6 @@ resource "aws_glue_crawler" "mosaic_raw_zone" {
 
   s3_target {
     path = "s3://${module.raw_zone_data_source.bucket_id}/${module.department_children_family_services_data_source.identifier}/mosaic/"
-  }
-
-  configuration = jsonencode({
-    Version = 1.0
-    Grouping = {
-      TableLevelConfiguration = 4
-    }
-    CrawlerOutput = {
-      Partitions = { AddOrUpdateBehavior = "InheritFromTable" }
-      Tables     = { AddOrUpdateBehavior = "MergeNewColumns" }
-    }
-  })
-  tags = module.tags.values
-}
-
-resource "aws_glue_crawler" "allocations_refined_tables" {
-  count         = local.is_live_environment ? 1 : 0
-  name          = "${local.short_identifier_prefix}${module.department_children_family_services_data_source.identifier}-allocations-refined-tables"
-  role          = module.department_children_family_services_data_source.glue_role_arn
-  database_name = module.department_children_family_services_data_source.refined_zone_catalog_database_name
-
-  s3_target {
-    path = "s3://${module.refined_zone_data_source.bucket_id}/${module.department_children_family_services_data_source.identifier}/mosaic/"
   }
 
   configuration = jsonencode({


### PR DESCRIPTION
While refactoring the Mosaic DAG, I came across this crawler. It's no longer in use, so it's being deleted in this PR.