### PR TITLE
upgrade ETL aws provider to ~>5.0

### DIFF
--- a/terraform/etl/00-init.tf
+++ b/terraform/etl/00-init.tf
@@ -1,10 +1,10 @@
 # Core Infrastructure
 provider "aws" {
   region = var.aws_deploy_region
-  
-  dynamic assume_role {
+
+  dynamic "assume_role" {
     for_each = local.is_live_environment ? [1] : []
-    
+
     content {
       role_arn     = "arn:aws:iam::${var.aws_deploy_account_id}:role/${var.aws_deploy_iam_role_name}"
       session_name = "Terraform"
@@ -15,7 +15,7 @@ provider "aws" {
 provider "aws" {
   alias  = "aws_api_account"
   region = var.aws_deploy_region
-  
+
   assume_role {
     role_arn     = "arn:aws:iam::${var.aws_api_account_id}:role/${var.aws_deploy_iam_role_name}"
     session_name = "Terraform"
@@ -25,10 +25,10 @@ provider "aws" {
 provider "aws" {
   alias  = "aws_hackit_account"
   region = "eu-west-1"
-  
-  dynamic assume_role {
-    for_each = local.is_live_environment ? [1] : [] 
-    
+
+  dynamic "assume_role" {
+    for_each = local.is_live_environment ? [1] : []
+
     content {
       role_arn     = "arn:aws:iam::${var.aws_hackit_account_id}:role/${var.aws_deploy_iam_role_name}"
       session_name = "DataPlatform"
@@ -50,7 +50,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Upgrade the AWS Terraform provider to `~>5.0`.

This is necessary to update the python 3.9 lambda runtimes that are reaching end of life. Python 3.11 was added in provider 4.56 and Python 3.12 is supported by this change giving us an upgrade path through to Oct '28.

Plans show no changes are to be made in production, stg shows minor configuration changes that appear trivial. 
I will do a thorough review of changes made on apply. 

