### PR TITLE
Add expired object delete marker to S3 landing zone bucket

### DIFF
--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -44,7 +44,8 @@ module "landing_zone" {
     local.share_kms_key_with_housing_reporting_role,
     local.share_kms_key_with_academy_account
   ]
-  include_backup_policy_tags = false
+  include_backup_policy_tags   = false
+  expired_object_delete_marker = true
 }
 
 module "raw_zone" {

--- a/terraform/modules/s3-bucket/02-inputs-optional.tf
+++ b/terraform/modules/s3-bucket/02-inputs-optional.tf
@@ -156,3 +156,9 @@ variable "include_backup_policy_tags" {
   type        = bool
   default     = true
 }
+
+variable "expired_object_delete_marker" {
+  description = "Whether to delete expired object delete markers. Only applies to versioned buckets."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Based on the [doc ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expired_object_delete_marker-1) quoted as 
> [expired_object_delete_marker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#expired_object_delete_marker-4) - (Optional) On a versioned bucket (versioning-enabled or versioning-suspended bucket), you can add this element in the lifecycle configuration to direct Amazon S3 to delete expired object delete markers. This cannot be specified with Days or Date in a Lifecycle Expiration Policy

Add the expired_object_delete_marker to the s3 bucket module and enable it in the landing zone. This will ensure that objects in the landing zone are permanently deleted when they have a delete marker.