### PR TITLE
add athena:GetWorkGroup action to Airflow

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -993,6 +993,7 @@ data "aws_iam_policy_document" "airflow_base_policy" {
       "athena:StartQueryExecution",
       "athena:GetQueryExecution",
       "athena:GetQueryResults",
+      "athena:GetWorkGroup",
       "athena:ListDatabases",
       "athena:ListTableMetadata",
       "athena:GetTableMetadata"


### PR DESCRIPTION
Allow the Airflow workers to get Athena Workgroups.