### PR TITLE
Update the deprecated filter argument to alternate_identifier

### DIFF
--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -32,9 +32,11 @@ data "aws_identitystore_group" "department" {
 
   identity_store_id = var.identity_store_id
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = var.google_group_display_name
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = var.google_group_display_name
+    }
   }
 }
 


### PR DESCRIPTION
> │ Warning: Argument is deprecated
> │ 
> │   with module.department_children_family_services.data.aws_identitystore_group.department[0],
> │   on ../modules/department/60-aws-sso.tf line 28, in data "aws_identitystore_group" "department":
> │   28: data "aws_identitystore_group" "department" ***
> │ 
> │ filter is deprecated. Use alternate_identifier instead.

Update the deprecated filter argument to alternate_identifier in line with the latest AWS provider version in Core.([doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/identitystore_group)).