### PR TITLE
set enforce_workgroup_configuration to false

### DIFF
--- a/terraform/modules/department/25-aws-athena.tf
+++ b/terraform/modules/department/25-aws-athena.tf
@@ -7,7 +7,7 @@ resource "aws_athena_workgroup" "department_workgroup" {
   force_destroy = !var.is_live_environment
 
   configuration {
-    enforce_workgroup_configuration    = true
+    enforce_workgroup_configuration    = false
     publish_cloudwatch_metrics_enabled = true
 
     result_configuration {


### PR DESCRIPTION
`true `forces the workgroup settings to override client-side query settings; `false `allows client-side settings ([URL](https://docs.aws.amazon.com/athena/latest/APIReference/API_WorkGroupConfiguration.html))

This will help run `awswrangler.athena.start_query_execution` with the specified kms_key in the function to overwrite the one in Athena workgroup, as well as in other similar cases where the workgroup configuration needs to be overridden.