### PR TITLE
fix bucket access when paths list is empty

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -141,7 +141,7 @@ data "aws_iam_policy_document" "read_only_s3_department_access" {
       ]
       resources = concat(
         [additional_access_item.value.bucket_arn],
-        additional_access_item.value.paths == null ? [
+        try(length(additional_access_item.value.paths), 0) == 0 ? [
           "${additional_access_item.value.bucket_arn}/*"
           ] : [
           for path in additional_access_item.value.paths : "${additional_access_item.value.bucket_arn}/${path}/*"
@@ -373,7 +373,7 @@ data "aws_iam_policy_document" "s3_department_access" {
       actions = additional_access_item.value.actions
       resources = concat(
         [additional_access_item.value.bucket_arn],
-        additional_access_item.value.paths == null ? [
+        try(length(additional_access_item.value.paths), 0) == 0 ? [
           "${additional_access_item.value.bucket_arn}/*"
           ] : [
           for path in additional_access_item.value.paths : "${additional_access_item.value.bucket_arn}/${path}/*"


### PR DESCRIPTION
This change updates the department module to treat an empty paths list the same as null, granting whole bucket object access as intended.

The housing ECS task role was getting AccessDenied on PutObject to `housing_nec_migration_storage` even though that bucket was configured in `module.department_housing.additional_s3_access`. This is because in the department module paths = [] is documented as full-bucket access, but the generated IAM policy only included the bucket ARN and not bucket/*, so object-level actions were denied.

