### PR TITLE
Feat/DL 206 Replace Airflow IAM users with roles in staging for two selected departments

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -5,9 +5,9 @@ data "aws_ssoadmin_instances" "sso_instances" {
 }
 
 locals {
-  sso_instance_arn                  = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].arns)[0], "")
-  identity_store_id                 = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].identity_store_ids)[0], "")
-  departmental_airflow_role_enabled = local.is_live_environment && !local.is_production_environment
+  sso_instance_arn          = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].arns)[0], "")
+  identity_store_id         = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].identity_store_ids)[0], "")
+  departmental_airflow_role = local.is_live_environment && !local.is_production_environment
 }
 
 module "department_housing_repairs" {
@@ -40,7 +40,6 @@ module "department_housing_repairs" {
   google_group_admin_display_name = local.google_group_admin_display_name
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -50,35 +49,33 @@ module "department_parking" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Parking"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Parking"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
   additional_glue_database_access = {
     read_only = [
       "${local.identifier_prefix}-liberator-raw-zone",
@@ -121,7 +118,6 @@ module "department_finance" {
   google_group_admin_display_name = local.google_group_admin_display_name
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -131,37 +127,35 @@ module "department_data_and_insight" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Data and Insight"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
-  cloudtrail_bucket                 = module.cloudtrail_storage
-  datahub_config_bucket             = module.datahub_config
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Data and Insight"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
+  cloudtrail_bucket               = module.cloudtrail_storage
+  datahub_config_bucket           = module.datahub_config
   additional_glue_database_access = {
     read_only  = []
     read_write = ["arcus_archive", "metastore"]
@@ -188,35 +182,33 @@ module "department_env_enforcement" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Env Enforcement"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
-  noiseworks_bucket                 = module.noiseworks_data_storage
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Env Enforcement"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
+  noiseworks_bucket               = module.noiseworks_data_storage
 }
 
 module "department_planning" {
@@ -225,35 +217,33 @@ module "department_planning" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Planning"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Planning"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
   additional_glue_database_access = {
     read_only  = []
     read_write = ["${local.identifier_prefix}-tascomi*"]
@@ -266,34 +256,34 @@ module "department_unrestricted" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Unrestricted"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Unrestricted"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  departmental_airflow_user       = true
+  departmental_airflow_role       = local.departmental_airflow_role
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket             = module.user_uploads
 }
 
 module "department_sandbox" {
@@ -327,7 +317,6 @@ module "department_sandbox" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-sandbox@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -337,35 +326,33 @@ module "department_benefits_and_housing_needs" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Bens Housing Needs"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Bens Housing Needs"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
   additional_glue_database_access = {
     read_only  = ["hben_raw_zone"]
     read_write = []
@@ -378,35 +365,33 @@ module "department_revenues" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Revenues"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Revenues"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
   additional_glue_database_access = {
     read_only = [
       "nndr_raw_zone",
@@ -423,35 +408,33 @@ module "department_environmental_services" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Env Services"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Env Services"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
 }
 
 module "department_housing" {
@@ -460,35 +443,33 @@ module "department_housing" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Housing"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Housing"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
   additional_s3_access = [
     {
       bucket_arn  = module.housing_nec_migration_storage.bucket_arn
@@ -546,7 +527,6 @@ module "department_children_and_education" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-children-and-family-services@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -581,7 +561,6 @@ module "department_customer_services" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-customer-services@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -616,7 +595,6 @@ module "department_hr_and_od" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-hr-and-od@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -626,35 +604,33 @@ module "department_streetscene" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Streetscene"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Streetscene"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
+  departmental_airflow_user       = true
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  user_uploads_bucket             = module.user_uploads
 }
 
 module "department_children_family_services" {
@@ -663,35 +639,35 @@ module "department_children_family_services" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                            = "../modules/department"
-  tags                              = module.tags.values
-  is_live_environment               = local.is_live_environment
-  environment                       = var.environment
-  application                       = local.application_snake
-  short_identifier_prefix           = local.short_identifier_prefix
-  identifier_prefix                 = local.identifier_prefix
-  name                              = "Child Fam Services"
-  landing_zone_bucket               = module.landing_zone
-  raw_zone_bucket                   = module.raw_zone
-  refined_zone_bucket               = module.refined_zone
-  trusted_zone_bucket               = module.trusted_zone
-  athena_storage_bucket             = module.athena_storage
-  glue_scripts_bucket               = module.glue_scripts
-  glue_temp_storage_bucket          = module.glue_temp_storage
-  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
-  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses             = var.redshift_public_ips
-  redshift_port                     = var.redshift_port
-  sso_instance_arn                  = local.sso_instance_arn
-  identity_store_id                 = local.identity_store_id
-  google_group_admin_display_name   = local.google_group_admin_display_name
-  google_group_display_name         = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
-  departmental_airflow_user         = true
-  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
-  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
-  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
-  user_uploads_bucket               = module.user_uploads
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Child Fam Services"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
+  departmental_airflow_user       = true
+  departmental_airflow_role       = local.departmental_airflow_role
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket             = module.user_uploads
   additional_glue_database_access = {
     read_only  = ["child_edu_refined", "hackney_casemanagement_live", "hackney_synergy_live"]
     read_write = []
@@ -700,16 +676,7 @@ module "department_children_family_services" {
 
 locals {
   departmental_airflow_role_arns = compact([
-    module.department_parking.airflow_role_arn,
-    module.department_data_and_insight.airflow_role_arn,
-    module.department_env_enforcement.airflow_role_arn,
-    module.department_planning.airflow_role_arn,
     module.department_unrestricted.airflow_role_arn,
-    module.department_benefits_and_housing_needs.airflow_role_arn,
-    module.department_revenues.airflow_role_arn,
-    module.department_environmental_services.airflow_role_arn,
-    module.department_housing.airflow_role_arn,
-    module.department_streetscene.airflow_role_arn,
     module.department_children_family_services.airflow_role_arn,
   ])
 }

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -5,8 +5,9 @@ data "aws_ssoadmin_instances" "sso_instances" {
 }
 
 locals {
-  sso_instance_arn  = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].arns)[0], "")
-  identity_store_id = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].identity_store_ids)[0], "")
+  sso_instance_arn                  = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].arns)[0], "")
+  identity_store_id                 = try(tolist(data.aws_ssoadmin_instances.sso_instances[0].identity_store_ids)[0], "")
+  departmental_airflow_role_enabled = local.is_live_environment && !local.is_production_environment
 }
 
 module "department_housing_repairs" {
@@ -39,6 +40,7 @@ module "department_housing_repairs" {
   google_group_admin_display_name = local.google_group_admin_display_name
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -48,33 +50,35 @@ module "department_parking" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Parking"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Parking"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_glue_database_access = {
     read_only = [
       "${local.identifier_prefix}-liberator-raw-zone",
@@ -117,6 +121,7 @@ module "department_finance" {
   google_group_admin_display_name = local.google_group_admin_display_name
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -126,35 +131,37 @@ module "department_data_and_insight" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Data and Insight"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
-  cloudtrail_bucket               = module.cloudtrail_storage
-  datahub_config_bucket           = module.datahub_config
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Data and Insight"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
+  cloudtrail_bucket                 = module.cloudtrail_storage
+  datahub_config_bucket             = module.datahub_config
   additional_glue_database_access = {
     read_only  = []
     read_write = ["arcus_archive", "metastore"]
@@ -181,33 +188,35 @@ module "department_env_enforcement" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Env Enforcement"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
-  noiseworks_bucket               = module.noiseworks_data_storage
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Env Enforcement"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
+  noiseworks_bucket                 = module.noiseworks_data_storage
 }
 
 module "department_planning" {
@@ -216,33 +225,35 @@ module "department_planning" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Planning"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Planning"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_glue_database_access = {
     read_only  = []
     read_write = ["${local.identifier_prefix}-tascomi*"]
@@ -255,32 +266,34 @@ module "department_unrestricted" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Unrestricted"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Unrestricted"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
 }
 
 module "department_sandbox" {
@@ -314,6 +327,7 @@ module "department_sandbox" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-sandbox@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -323,33 +337,35 @@ module "department_benefits_and_housing_needs" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Bens Housing Needs"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Bens Housing Needs"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_glue_database_access = {
     read_only  = ["hben_raw_zone"]
     read_write = []
@@ -362,33 +378,35 @@ module "department_revenues" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Revenues"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Revenues"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_glue_database_access = {
     read_only = [
       "nndr_raw_zone",
@@ -405,33 +423,35 @@ module "department_environmental_services" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Env Services"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Env Services"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
 }
 
 module "department_housing" {
@@ -440,33 +460,35 @@ module "department_housing" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Housing"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Housing"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_s3_access = [
     {
       bucket_arn  = module.housing_nec_migration_storage.bucket_arn
@@ -524,6 +546,7 @@ module "department_children_and_education" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-children-and-family-services@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -558,6 +581,7 @@ module "department_customer_services" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-customer-services@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -592,6 +616,7 @@ module "department_hr_and_od" {
   google_group_display_name       = "saml-aws-data-platform-collaborator-hr-and-od@hackney.gov.uk"
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
 }
 
@@ -601,33 +626,35 @@ module "department_streetscene" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Streetscene"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Streetscene"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
 }
 
 module "department_children_family_services" {
@@ -636,35 +663,53 @@ module "department_children_family_services" {
     aws.aws_hackit_account = aws.aws_hackit_account
   }
 
-  source                          = "../modules/department"
-  tags                            = module.tags.values
-  is_live_environment             = local.is_live_environment
-  environment                     = var.environment
-  application                     = local.application_snake
-  short_identifier_prefix         = local.short_identifier_prefix
-  identifier_prefix               = local.identifier_prefix
-  name                            = "Child Fam Services"
-  landing_zone_bucket             = module.landing_zone
-  raw_zone_bucket                 = module.raw_zone
-  refined_zone_bucket             = module.refined_zone
-  trusted_zone_bucket             = module.trusted_zone
-  athena_storage_bucket           = module.athena_storage
-  glue_scripts_bucket             = module.glue_scripts
-  glue_temp_storage_bucket        = module.glue_temp_storage
-  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
-  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
-  redshift_ip_addresses           = var.redshift_public_ips
-  redshift_port                   = var.redshift_port
-  sso_instance_arn                = local.sso_instance_arn
-  identity_store_id               = local.identity_store_id
-  google_group_admin_display_name = local.google_group_admin_display_name
-  google_group_display_name       = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
-  departmental_airflow_user       = true
-  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
-  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
-  user_uploads_bucket             = module.user_uploads
+  source                            = "../modules/department"
+  tags                              = module.tags.values
+  is_live_environment               = local.is_live_environment
+  environment                       = var.environment
+  application                       = local.application_snake
+  short_identifier_prefix           = local.short_identifier_prefix
+  identifier_prefix                 = local.identifier_prefix
+  name                              = "Child Fam Services"
+  landing_zone_bucket               = module.landing_zone
+  raw_zone_bucket                   = module.raw_zone
+  refined_zone_bucket               = module.refined_zone
+  trusted_zone_bucket               = module.trusted_zone
+  athena_storage_bucket             = module.athena_storage
+  glue_scripts_bucket               = module.glue_scripts
+  glue_temp_storage_bucket          = module.glue_temp_storage
+  spark_ui_output_storage_bucket    = module.spark_ui_output_storage
+  secrets_manager_kms_key           = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses             = var.redshift_public_ips
+  redshift_port                     = var.redshift_port
+  sso_instance_arn                  = local.sso_instance_arn
+  identity_store_id                 = local.identity_store_id
+  google_group_admin_display_name   = local.google_group_admin_display_name
+  google_group_display_name         = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
+  departmental_airflow_user         = true
+  departmental_airflow_role_enabled = local.departmental_airflow_role_enabled
+  mwaa_etl_scripts_bucket_arn       = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                      = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn           = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket               = module.user_uploads
   additional_glue_database_access = {
     read_only  = ["child_edu_refined", "hackney_casemanagement_live", "hackney_synergy_live"]
     read_write = []
   }
+}
+
+locals {
+  departmental_airflow_role_arns = compact([
+    module.department_parking.airflow_role_arn,
+    module.department_data_and_insight.airflow_role_arn,
+    module.department_env_enforcement.airflow_role_arn,
+    module.department_planning.airflow_role_arn,
+    module.department_unrestricted.airflow_role_arn,
+    module.department_benefits_and_housing_needs.airflow_role_arn,
+    module.department_revenues.airflow_role_arn,
+    module.department_environmental_services.airflow_role_arn,
+    module.department_housing.airflow_role_arn,
+    module.department_streetscene.airflow_role_arn,
+    module.department_children_family_services.airflow_role_arn,
+  ])
 }

--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -131,7 +131,7 @@ resource "aws_iam_role_policy" "mwaa_assume_role_policy" {
 }
 
 resource "aws_iam_role_policy" "mwaa_departmental_airflow_assume_role_policy" {
-  count = length(local.departmental_airflow_role_arns) > 0 ? 1 : 0
+  count = local.departmental_airflow_role ? 1 : 0
 
   name = "mwaa_departmental_airflow_assume_role_policy"
   role = aws_iam_role.mwaa_role.id

--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -130,6 +130,24 @@ resource "aws_iam_role_policy" "mwaa_assume_role_policy" {
   })
 }
 
+resource "aws_iam_role_policy" "mwaa_departmental_airflow_assume_role_policy" {
+  count = length(local.departmental_airflow_role_arns) > 0 ? 1 : 0
+
+  name = "mwaa_departmental_airflow_assume_role_policy"
+  role = aws_iam_role.mwaa_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "sts:AssumeRole",
+        Resource = local.departmental_airflow_role_arns
+      }
+    ]
+  })
+}
+
 # Security group for MWAA - self-referencing and allowing all traffic out
 # This is recommended in the doc, Matt recommended at current stage.
 # https://docs.aws.amazon.com/mwaa/latest/userguide/vpc-security.html

--- a/terraform/modules/department/01-inputs-required.tf
+++ b/terraform/modules/department/01-inputs-required.tf
@@ -141,11 +141,6 @@ variable "mwaa_key_arn" {
   type = string
 }
 
-variable "mwaa_execution_role_arn" {
-  description = "ARN of the MWAA execution role allowed to assume the departmental Airflow role"
-  type        = string
-}
-
 variable "user_uploads_bucket" {
   description = "User uploads S3 bucket"
   type = object({

--- a/terraform/modules/department/01-inputs-required.tf
+++ b/terraform/modules/department/01-inputs-required.tf
@@ -141,6 +141,11 @@ variable "mwaa_key_arn" {
   type = string
 }
 
+variable "mwaa_execution_role_arn" {
+  description = "ARN of the MWAA execution role allowed to assume the departmental Airflow role"
+  type        = string
+}
+
 variable "user_uploads_bucket" {
   description = "User uploads S3 bucket"
   type = object({

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -37,10 +37,16 @@ variable "departmental_airflow_user" {
   default     = false
 }
 
-variable "departmental_airflow_role_enabled" {
+variable "departmental_airflow_role" {
   description = "Enable departmental Airflow role-based authentication instead of IAM-user credentials"
   type        = bool
   default     = false
+}
+
+variable "mwaa_execution_role_arn" {
+  description = "ARN of the MWAA execution role allowed to assume the departmental Airflow role"
+  type        = string
+  default     = null
 }
 
 variable "region" {

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -37,6 +37,12 @@ variable "departmental_airflow_user" {
   default     = false
 }
 
+variable "departmental_airflow_role_enabled" {
+  description = "Enable departmental Airflow role-based authentication instead of IAM-user credentials"
+  type        = bool
+  default     = false
+}
+
 variable "region" {
   description = "AWS region"
   type        = string

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -107,42 +107,85 @@ locals {
     airflow_base_policy       = aws_iam_policy.airflow_base_policy.arn,
     department_ecs_passrole   = aws_iam_policy.department_ecs_passrole.arn
   }
+
+  use_airflow_user = var.departmental_airflow_user && !var.departmental_airflow_role_enabled
+  use_airflow_role = var.departmental_airflow_user && var.departmental_airflow_role_enabled
 }
 
-# IAM user and permission for departmetnal airflow user
+# IAM user and permission for departmental airflow user
 resource "aws_iam_user" "airflow_user" {
-  count = var.departmental_airflow_user ? 1 : 0
+  count = local.use_airflow_user ? 1 : 0
   name  = "${local.department_identifier}-airflow-user"
   tags  = var.tags
 }
 
 resource "aws_iam_user_policy_attachment" "airflow_user_policy_attachment" {
-  for_each   = var.departmental_airflow_user ? local.airflow_policy_map : {}
+  for_each   = local.use_airflow_user ? local.airflow_policy_map : {}
   user       = aws_iam_user.airflow_user[0].name
   policy_arn = each.value
 }
 
 resource "aws_iam_user_policy_attachment" "airflow_user_datahub_config_access" {
-  count      = var.departmental_airflow_user && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+  count      = local.use_airflow_user && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
   user       = aws_iam_user.airflow_user[0].name
   policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
 }
 
 resource "aws_iam_access_key" "airflow_user_key" {
-  count = var.departmental_airflow_user ? 1 : 0
+  count = local.use_airflow_user ? 1 : 0
   user  = aws_iam_user.airflow_user[0].name
+}
+
+data "aws_iam_policy_document" "airflow_role_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.mwaa_execution_role_arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "airflow_role" {
+  count = local.use_airflow_role ? 1 : 0
+
+  name               = "${local.department_identifier}-airflow-role"
+  assume_role_policy = data.aws_iam_policy_document.airflow_role_assume_role.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "airflow_role_policy_attachment" {
+  for_each = local.use_airflow_role ? local.airflow_policy_map : {}
+
+  role       = aws_iam_role.airflow_role[0].name
+  policy_arn = each.value
+}
+
+resource "aws_iam_role_policy_attachment" "airflow_role_datahub_config_access" {
+  count      = local.use_airflow_role && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+  role       = aws_iam_role.airflow_role[0].name
+  policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
 }
 
 # Store airflow user credentials in Secrets Manager with required format
 resource "aws_secretsmanager_secret" "airflow_user_secret" {
-  count = var.departmental_airflow_user ? 1 : 0
-  name  = "airflow/connections/${local.department_identifier}-airflow-aws-default"
+  count      = var.departmental_airflow_user ? 1 : 0
+  name       = "airflow/connections/${local.department_identifier}-airflow-aws-default"
+  kms_key_id = var.secrets_manager_kms_key.key_id
+  tags       = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {
   count     = var.departmental_airflow_user ? 1 : 0
   secret_id = aws_secretsmanager_secret.airflow_user_secret[0].id
-  secret_string = jsonencode({
+  secret_string = local.use_airflow_role ? jsonencode({
+    conn_type = "aws",
+    extra = jsonencode({
+      region_name = var.region,
+      role_arn    = aws_iam_role.airflow_role[0].arn
+    })
+    }) : jsonencode({
     conn_type = "aws",
     login     = aws_iam_access_key.airflow_user_key[0].id,
     password  = aws_iam_access_key.airflow_user_key[0].secret,

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -108,8 +108,8 @@ locals {
     department_ecs_passrole   = aws_iam_policy.department_ecs_passrole.arn
   }
 
-  use_airflow_user = var.departmental_airflow_user && !var.departmental_airflow_role_enabled
-  use_airflow_role = var.departmental_airflow_user && var.departmental_airflow_role_enabled
+  use_airflow_user = var.departmental_airflow_user && !var.departmental_airflow_role
+  use_airflow_role = var.departmental_airflow_user && var.departmental_airflow_role
 }
 
 # IAM user and permission for departmental airflow user
@@ -137,6 +137,8 @@ resource "aws_iam_access_key" "airflow_user_key" {
 }
 
 data "aws_iam_policy_document" "airflow_role_assume_role" {
+  count = local.use_airflow_role ? 1 : 0
+
   statement {
     actions = ["sts:AssumeRole"]
 
@@ -151,7 +153,7 @@ resource "aws_iam_role" "airflow_role" {
   count = local.use_airflow_role ? 1 : 0
 
   name               = "${local.department_identifier}-airflow-role"
-  assume_role_policy = data.aws_iam_policy_document.airflow_role_assume_role.json
+  assume_role_policy = data.aws_iam_policy_document.airflow_role_assume_role[0].json
   tags               = var.tags
 }
 
@@ -170,10 +172,8 @@ resource "aws_iam_role_policy_attachment" "airflow_role_datahub_config_access" {
 
 # Store airflow user credentials in Secrets Manager with required format
 resource "aws_secretsmanager_secret" "airflow_user_secret" {
-  count      = var.departmental_airflow_user ? 1 : 0
-  name       = "airflow/connections/${local.department_identifier}-airflow-aws-default"
-  kms_key_id = var.secrets_manager_kms_key.key_id
-  tags       = var.tags
+  count = var.departmental_airflow_user ? 1 : 0
+  name  = "airflow/connections/${local.department_identifier}-airflow-aws-default"
 }
 
 resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {

--- a/terraform/modules/department/99-outputs.tf
+++ b/terraform/modules/department/99-outputs.tf
@@ -77,3 +77,8 @@ output "environment" {
   description = "Environment e.g. dev, stg, prod"
   value       = var.environment
 }
+
+output "airflow_role_arn" {
+  description = "ARN of the departmental Airflow role when role-based auth is enabled"
+  value       = try(aws_iam_role.airflow_role[0].arn, null)
+}


### PR DESCRIPTION
## Summary

In `staging`, updates the departmental Airflow AWS connection setup so that two selected departments can use IAM roles instead of long-lived IAM user access keys.

After this PR, if all goes well, it will be rolled out to all departments in `staging `and then to `production`.

## Changes

- Adds a new optional department module flag: `departmental_airflow_role`.
- Keeps the existing `departmental_airflow_user` flag as the switch for creating the Airflow connection secret.
- Uses the legacy IAM user/access key approach when `departmental_airflow_role = false`.
- Uses the new IAM role approach when `departmental_airflow_role = true`.
- Enables the new role approach only for:
  - `Unrestricted`
  - `Child Fam Services`
- Limits the rollout to staging with:

  ```hcl
  local.is_live_environment && !local.is_production_environment