### PR TITLE
remove all traces of Airflow users

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -72,7 +72,6 @@ module "department_parking" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -152,7 +151,6 @@ module "department_data_and_insight" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -208,7 +206,6 @@ module "department_env_enforcement" {
   sso_instance_arn                = local.sso_instance_arn
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -246,7 +243,6 @@ module "department_planning" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -286,7 +282,6 @@ module "department_unrestricted" {
   sso_instance_arn                = local.sso_instance_arn
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -357,7 +352,6 @@ module "department_benefits_and_housing_needs" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -398,7 +392,6 @@ module "department_revenues" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -443,7 +436,6 @@ module "department_environmental_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -480,7 +472,6 @@ module "department_housing" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -643,7 +634,6 @@ module "department_streetscene" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -680,7 +670,6 @@ module "department_children_family_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
-  departmental_airflow_user       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -31,12 +31,6 @@ variable "notebook_instance" {
   default = null
 }
 
-variable "departmental_airflow_user" {
-  description = "Flag to create departmental Airflow user"
-  type        = bool
-  default     = false
-}
-
 variable "departmental_airflow_role" {
   description = "Enable departmental Airflow role-based authentication instead of IAM-user credentials"
   type        = bool

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -107,37 +107,10 @@ locals {
     airflow_base_policy       = aws_iam_policy.airflow_base_policy.arn,
     department_ecs_passrole   = aws_iam_policy.department_ecs_passrole.arn
   }
-
-  use_airflow_user = var.departmental_airflow_user && !var.departmental_airflow_role
-  use_airflow_role = var.departmental_airflow_user && var.departmental_airflow_role
-}
-
-# IAM user and permission for departmental airflow user
-resource "aws_iam_user" "airflow_user" {
-  count = local.use_airflow_user ? 1 : 0
-  name  = "${local.department_identifier}-airflow-user"
-  tags  = var.tags
-}
-
-resource "aws_iam_user_policy_attachment" "airflow_user_policy_attachment" {
-  for_each   = local.use_airflow_user ? local.airflow_policy_map : {}
-  user       = aws_iam_user.airflow_user[0].name
-  policy_arn = each.value
-}
-
-resource "aws_iam_user_policy_attachment" "airflow_user_datahub_config_access" {
-  count      = local.use_airflow_user && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
-  user       = aws_iam_user.airflow_user[0].name
-  policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
-}
-
-resource "aws_iam_access_key" "airflow_user_key" {
-  count = local.use_airflow_user ? 1 : 0
-  user  = aws_iam_user.airflow_user[0].name
 }
 
 data "aws_iam_policy_document" "airflow_role_assume_role" {
-  count = local.use_airflow_role ? 1 : 0
+  count = var.departmental_airflow_role ? 1 : 0
 
   statement {
     actions = ["sts:AssumeRole"]
@@ -150,7 +123,7 @@ data "aws_iam_policy_document" "airflow_role_assume_role" {
 }
 
 resource "aws_iam_role" "airflow_role" {
-  count = local.use_airflow_role ? 1 : 0
+  count = var.departmental_airflow_role ? 1 : 0
 
   name               = "${local.department_identifier}-airflow-role"
   assume_role_policy = data.aws_iam_policy_document.airflow_role_assume_role[0].json
@@ -158,38 +131,33 @@ resource "aws_iam_role" "airflow_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "airflow_role_policy_attachment" {
-  for_each = local.use_airflow_role ? local.airflow_policy_map : {}
+  for_each = var.departmental_airflow_role ? local.airflow_policy_map : {}
 
   role       = aws_iam_role.airflow_role[0].name
   policy_arn = each.value
 }
 
 resource "aws_iam_role_policy_attachment" "airflow_role_datahub_config_access" {
-  count      = local.use_airflow_role && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+  count      = var.departmental_airflow_role && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
   role       = aws_iam_role.airflow_role[0].name
   policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
 }
 
-# Store airflow user credentials in Secrets Manager with required format
+# Store the departmental Airflow AWS connection in Secrets Manager.
 resource "aws_secretsmanager_secret" "airflow_user_secret" {
-  count = var.departmental_airflow_user ? 1 : 0
+  count = var.departmental_airflow_role ? 1 : 0
   name  = "airflow/connections/${local.department_identifier}-airflow-aws-default"
 }
 
 resource "aws_secretsmanager_secret_version" "airflow_user_secret_version" {
-  count     = var.departmental_airflow_user ? 1 : 0
+  count     = var.departmental_airflow_role ? 1 : 0
   secret_id = aws_secretsmanager_secret.airflow_user_secret[0].id
-  secret_string = local.use_airflow_role ? jsonencode({
+  secret_string = jsonencode({
     conn_type = "aws",
     extra = jsonencode({
       region_name = var.region,
       role_arn    = aws_iam_role.airflow_role[0].arn
     })
-    }) : jsonencode({
-    conn_type = "aws",
-    login     = aws_iam_access_key.airflow_user_key[0].id,
-    password  = aws_iam_access_key.airflow_user_key[0].secret,
-    extra     = jsonencode({ region_name = var.region })
   })
 }
 


### PR DESCRIPTION
The Airflow IAM roles have been deployed to production and are working well. I tested them with two DAGs.

Ready to remove the Airflow user-related traces to make the Terraform code cleaner. Nothing will actually be deployed.
