### PR TITLE
DL 188 allow to see glue jobs/crawlers and Spark UI logs

### DIFF
--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -246,32 +246,6 @@ data "aws_iam_policy_document" "read_only_glue_access" {
       ])
     }
   }
-
-  statement {
-    sid    = "SparkUiKmsAccess"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
-    resources = [
-      var.spark_ui_output_storage_bucket.kms_key_arn,
-    ]
-  }
-
-  statement {
-    sid    = "SparkUiS3Access"
-    effect = "Allow"
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-    resources = [
-      var.spark_ui_output_storage_bucket.bucket_arn,
-      "${var.spark_ui_output_storage_bucket.bucket_arn}/${local.department_identifier}/*",
-    ]
-  }
 }
 
 resource "aws_iam_policy" "read_only_glue_access" {
@@ -741,32 +715,6 @@ data "aws_iam_policy_document" "glue_access_sso" {
         [for db in access_level.value : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"]
       ])
     }
-  }
-
-  statement {
-    sid    = "SparkUiKmsAccess"
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
-    resources = [
-      var.spark_ui_output_storage_bucket.kms_key_arn,
-    ]
-  }
-
-  statement {
-    sid    = "SparkUiS3Access"
-    effect = "Allow"
-    actions = [
-      "s3:Get*",
-      "s3:List*",
-    ]
-    resources = [
-      var.spark_ui_output_storage_bucket.bucket_arn,
-      "${var.spark_ui_output_storage_bucket.bucket_arn}/${local.department_identifier}/*",
-    ]
   }
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -246,6 +246,32 @@ data "aws_iam_policy_document" "read_only_glue_access" {
       ])
     }
   }
+
+  statement {
+    sid    = "SparkUiKmsAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+    resources = [
+      var.spark_ui_output_storage_bucket.kms_key_arn,
+    ]
+  }
+
+  statement {
+    sid    = "SparkUiS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+    resources = [
+      var.spark_ui_output_storage_bucket.bucket_arn,
+      "${var.spark_ui_output_storage_bucket.bucket_arn}/${local.department_identifier}/*",
+    ]
+  }
 }
 
 resource "aws_iam_policy" "read_only_glue_access" {
@@ -715,6 +741,32 @@ data "aws_iam_policy_document" "glue_access_sso" {
         [for db in access_level.value : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"]
       ])
     }
+  }
+
+  statement {
+    sid    = "SparkUiKmsAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
+    resources = [
+      var.spark_ui_output_storage_bucket.kms_key_arn,
+    ]
+  }
+
+  statement {
+    sid    = "SparkUiS3Access"
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+    resources = [
+      var.spark_ui_output_storage_bucket.bucket_arn,
+      "${var.spark_ui_output_storage_bucket.bucket_arn}/${local.department_identifier}/*",
+    ]
   }
 }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -221,7 +221,9 @@ data "aws_iam_policy_document" "read_only_glue_access" {
     resources = flatten([
       ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"],
       [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${db}"],
-      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"]
+      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:crawler/*"]
     ])
   }
 
@@ -576,7 +578,9 @@ data "aws_iam_policy_document" "glue_access" {
     resources = flatten([
       ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"],
       [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${db}"],
-      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"]
+      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:crawler/*"]
     ])
   }
 
@@ -687,7 +691,9 @@ data "aws_iam_policy_document" "glue_access_sso" {
     resources = flatten([
       ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"],
       [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${db}"],
-      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"]
+      [for db in local.common_department_databases : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${db}/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job/*"],
+      ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:crawler/*"]
     ])
   }
 

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -850,6 +850,46 @@ resource "aws_iam_policy" "departmental_cloudwatch_and_ecs_logs_access" {
   policy      = data.aws_iam_policy_document.departmental_cloudwatch_and_ecs_logs_access.json
 }
 
+// Glue console list and Spark UI access policy for departmental SSO users
+data "aws_iam_policy_document" "departmental_glue_console_list_and_spark_ui_access" {
+  statement {
+    sid    = "GlueConsoleListAndSparkUiAccess"
+    effect = "Allow"
+    actions = [
+      "glue:BatchGetStageFiles",
+      "glue:GetCrawlerMetrics",
+      "glue:GetCrawlers",
+      "glue:GetEnvironment",
+      "glue:GetExecutors",
+      "glue:GetExecutorsThreads",
+      "glue:GetJobs",
+      "glue:GetLogParsingStatus",
+      "glue:GetQueries",
+      "glue:GetQuery",
+      "glue:GetStage",
+      "glue:GetStageAttempt",
+      "glue:GetStageAttemptTaskList",
+      "glue:GetStageAttemptTaskSummary",
+      "glue:GetStageFiles",
+      "glue:GetStages",
+      "glue:GetStorage",
+      "glue:GetStorageUnit",
+      "glue:ListCrawlers",
+      "glue:ListJobs",
+      "glue:RequestLogParsing",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "departmental_glue_console_list_and_spark_ui_access" {
+  tags = var.tags
+
+  name        = lower("${var.identifier_prefix}-${local.department_identifier}-glue-console-list-spark-ui-access")
+  description = "Allows departmental SSO users to list Glue jobs and crawlers and access Glue Spark UI"
+  policy      = data.aws_iam_policy_document.departmental_glue_console_list_and_spark_ui_access.json
+}
+
 // Glue Agent Read only policy for glue scripts and mwaa bucket and run athena
 data "aws_iam_policy_document" "read_glue_scripts_and_mwaa_and_athena" {
   statement {

--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -39,6 +39,20 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_cloudwa
   }
 }
 
+resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_glue_console_list_and_spark_ui_access" {
+  count = local.deploy_sso ? 1 : 0
+
+  provider = aws.aws_hackit_account
+
+  instance_arn       = var.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
+
+  customer_managed_policy_reference {
+    name = aws_iam_policy.departmental_glue_console_list_and_spark_ui_access.name
+    path = "/"
+  }
+}
+
 # Attach CloudTrail access policy to SSO (data-and-insight only)
 resource "aws_ssoadmin_customer_managed_policy_attachment" "cloudtrail_access" {
   count = local.deploy_sso && local.department_identifier == "data-and-insight" && var.cloudtrail_bucket != null ? 1 : 0


### PR DESCRIPTION
## Summary

This change allows departmental SSO users to view AWS Glue jobs/crawlers in the console and access Glue Spark UI logs.

The change keeps resource-scoped Glue job/crawler permissions in the existing Glue policy documents, and adds a separate customer-managed IAM policy for Glue console list and Spark UI actions that AWS requires to use `Resource = "*"`.

## Changes

- Added Glue job and crawler ARNs to departmental Glue access policies:

- Added a new customer-managed IAM policy:
  - Create `departmental_glue_console_list_and_spark_ui_access` for the reasons:
    - Avoid adding it to the inline policy, as it will most likely exceed the maximum character limit.
    - Some Glue APIs do not support resource-level permissions in AWS IAM, so they must use `Resource = "*"`. (see doc [URL](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html)) or screenshot
    <img width="2824" height="150" alt="image" src="https://github.com/user-attachments/assets/c41c0cf2-8065-4360-948e-072a782b1e2f" />

- Attached the new customer-managed policy to departmental SSO permission sets

## A Note
- I’m not able to attach the testing policy to the departmental SSO role for the final test because the role is protected.

<img width="3389" height="215" alt="image" src="https://github.com/user-attachments/assets/e0bdb936-d3a2-4d93-b54a-66b193c23c32" />

