### PR TITLE
DL-210 upgrade google provider version to ~> 6.0

### DIFF
--- a/terraform/core/00-init.tf
+++ b/terraform/core/00-init.tf
@@ -69,7 +69,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.0"
     }
   }
   backend "s3" {


### PR DESCRIPTION
After checking it on GCP with `Mario`, it turns out that 
**The immediate cause** is that the service account has already reached the maximum limit of 10 user-managed service account keys. The keys started to pile up in June 2025; before then, there was only one key.

**The more fundamental cause** is below:

> │ Error: Provider produced inconsistent result after apply
> │ 
> │ When applying changes to
> │ google_service_account_key.housing_json_credentials[0], provider
> │ "provider[\"registry.terraform.io/hashicorp/google\"]" produced an
> │ unexpected new value: Root resource was present, but now absent.
> │ 
> │ This is a bug in the provider, which should be reported in the provider's
> │ own issue tracker.
> ╵
> Releasing state lock. This may take a few moments...
> Error: Process completed with exit code 1.

**This is caused by the provider creating the key and then immediately calling keys.get.**

This is mentioned in the following issue:
https://github.com/hashicorp/terraform-provider-google/issues/17332

The maintainers of the `terraform-provider-google` repository eventually fixed it via this merged PR:
https://github.com/hashicorp/terraform-provider-google/pull/18566

This bug fix is included in the release notes for `v5.37.0`:
https://github.com/hashicorp/terraform-provider-google/releases?page=12

Therefore, we need to upgrade to a version above `5.37.0`. Since the latest version is now `v7`, I think we should upgrade to major version v6 rather than staying on `v5`.

For this repo, Google usage looks quite limited. If the major version upgrade introduces breaking changes, I will adjust the Terraform code accordingly later.

### Changes:

- Manually delete all the keys before Mar 2026 on the GCP console by Mario
- Upgrade terraform-provider-google version to `v6` via this PR.
