### PR TITLE
DL 203  create the datahub ingestion bucket

### DIFF
--- a/terraform/compliance/s3.feature
+++ b/terraform/compliance/s3.feature
@@ -13,7 +13,7 @@ Feature: S3
   @exclude_module.file_sync_destination_nec.aws_s3_bucket.log_bucket
   @exclude_module.arcus_data_storage.aws_s3_bucket.bucket
   @exclude_module.user_uploads.aws_s3_bucket.bucket
-  @exclude_module.datahub_config.aws_s3_bucket.bucket
+  @exclude_module.datahub_ingestion.aws_s3_bucket.bucket
 
   # This rule is in place for legacy buckets created with the deprecated block within the aws_s3_bucket resource
   Scenario: Data must be encrypted at rest for buckets created using server_side_encryption_configuration property within bucket resource

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -157,7 +157,7 @@ module "department_data_and_insight" {
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
   cloudtrail_bucket               = module.cloudtrail_storage
-  datahub_config_bucket           = module.datahub_config
+  datahub_ingestion_bucket        = module.datahub_ingestion
   additional_glue_database_access = {
     read_only  = []
     read_write = ["arcus_archive", "metastore"]
@@ -170,8 +170,8 @@ module "department_data_and_insight" {
       actions     = ["s3:Get*", "s3:List*", ]
     },
     {
-      bucket_arn  = module.datahub_config.bucket_arn
-      kms_key_arn = module.datahub_config.kms_key_arn
+      bucket_arn  = module.datahub_ingestion.bucket_arn
+      kms_key_arn = module.datahub_ingestion.kms_key_arn
       paths       = []
       actions     = ["s3:Get*", "s3:List*", "s3:Put*", "s3:Delete*"]
     },

--- a/terraform/core/10-aws-s3-utility-buckets.tf
+++ b/terraform/core/10-aws-s3-utility-buckets.tf
@@ -165,18 +165,23 @@ module "user_uploads" {
 }
 
 #===============================================================================
-# DataHub Config Bucket to store the DataHub YAML configuration files
+# DataHub Ingestion Bucket to store ETL scripts and YAML configuration files
 #===============================================================================
 
-module "datahub_config" {
+module "datahub_ingestion" {
   source                     = "../modules/s3-bucket"
   tags                       = module.tags.values
   project                    = var.project
   environment                = var.environment
   identifier_prefix          = local.identifier_prefix
-  bucket_name                = "datahub-config"
-  bucket_identifier          = "datahub-config"
+  bucket_name                = "datahub-ingestion"
+  bucket_identifier          = "datahub-ingestion"
   include_backup_policy_tags = false
+}
+
+moved {
+  from = module.datahub_config
+  to   = module.datahub_ingestion
 }
 
 #===============================================================================

--- a/terraform/etl/60-airflow-variables-and-connnections.tf
+++ b/terraform/etl/60-airflow-variables-and-connnections.tf
@@ -141,14 +141,14 @@ resource "aws_secretsmanager_secret_version" "mtfh_secrets" {
   }
 }
 
-resource "aws_secretsmanager_secret" "datahub_config" {
-  name        = "airflow/variables/datahub_config"
-  description = "Configuration for DataHub integration. Includes DataHub cluster_name, task_defination, gms_url, and network."
+resource "aws_secretsmanager_secret" "datahub_ingestion" {
+  name        = "airflow/variables/datahub_ingestion"
+  description = "Configuration for DataHub ingestion. Includes DataHub cluster_name, task_defination, gms_url, and network."
   tags        = module.tags.values
 }
 
-resource "aws_secretsmanager_secret_version" "datahub_config" {
-  secret_id = aws_secretsmanager_secret.datahub_config.id
+resource "aws_secretsmanager_secret_version" "datahub_ingestion" {
+  secret_id = aws_secretsmanager_secret.datahub_ingestion.id
   secret_string = jsonencode({
     value = "UPDATE_IN_CONSOLE"
   })

--- a/terraform/etl/99-moved.tf
+++ b/terraform/etl/99-moved.tf
@@ -40,3 +40,13 @@ moved {
   to   = module.data_and_insight_hb_combined[0].module.import_file_from_g_drive.aws_cloudwatch_event_target.run_lambda
 }
 
+moved {
+  from = aws_secretsmanager_secret.datahub_config
+  to   = aws_secretsmanager_secret.datahub_ingestion
+}
+
+moved {
+  from = aws_secretsmanager_secret_version.datahub_config
+  to   = aws_secretsmanager_secret_version.datahub_ingestion
+}
+

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -84,8 +84,8 @@ variable "noiseworks_bucket" {
   default = null
 }
 
-variable "datahub_config_bucket" {
-  description = "DataHub config S3 bucket"
+variable "datahub_ingestion_bucket" {
+  description = "DataHub ingestion S3 bucket for ETL scripts and YAML configuration files"
   type = object({
     bucket_id   = string
     bucket_arn  = string

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -1556,12 +1556,12 @@ resource "aws_iam_policy" "noiseworks_access_policy" {
   policy      = data.aws_iam_policy_document.noiseworks_access[0].json
 }
 
-// Write access to DataHub config bucket for Data and Insight department only
-data "aws_iam_policy_document" "datahub_config_access" {
-  count = local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+// Write access to DataHub ingestion bucket for Data and Insight department only
+data "aws_iam_policy_document" "datahub_ingestion_access" {
+  count = local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
 
   statement {
-    sid    = "DataHubConfigKmsAccess"
+    sid    = "DataHubIngestionKmsAccess"
     effect = "Allow"
     actions = [
       "kms:Encrypt",
@@ -1570,11 +1570,11 @@ data "aws_iam_policy_document" "datahub_config_access" {
       "kms:GenerateDataKey*",
       "kms:DescribeKey"
     ]
-    resources = [var.datahub_config_bucket.kms_key_arn]
+    resources = [var.datahub_ingestion_bucket.kms_key_arn]
   }
 
   statement {
-    sid    = "DataHubConfigS3WriteAccess"
+    sid    = "DataHubIngestionS3WriteAccess"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -1585,15 +1585,15 @@ data "aws_iam_policy_document" "datahub_config_access" {
       "s3:DeleteObject"
     ]
     resources = [
-      var.datahub_config_bucket.bucket_arn,
-      "${var.datahub_config_bucket.bucket_arn}/*"
+      var.datahub_ingestion_bucket.bucket_arn,
+      "${var.datahub_ingestion_bucket.bucket_arn}/*"
     ]
   }
 }
 
-resource "aws_iam_policy" "datahub_config_access_policy" {
-  count       = local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
-  name        = lower("${var.identifier_prefix}-${local.department_identifier}-datahub-config-access-policy")
-  description = "Allows ${local.department_identifier} department write access to DataHub config bucket"
-  policy      = data.aws_iam_policy_document.datahub_config_access[0].json
+resource "aws_iam_policy" "datahub_ingestion_access_policy" {
+  count       = local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
+  name        = lower("${var.identifier_prefix}-${local.department_identifier}-datahub-ingestion-access-policy")
+  description = "Allows ${local.department_identifier} department write access to DataHub ingestion bucket"
+  policy      = data.aws_iam_policy_document.datahub_ingestion_access[0].json
 }

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -137,10 +137,10 @@ resource "aws_iam_role_policy_attachment" "airflow_role_policy_attachment" {
   policy_arn = each.value
 }
 
-resource "aws_iam_role_policy_attachment" "airflow_role_datahub_config_access" {
-  count      = var.departmental_airflow_role && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+resource "aws_iam_role_policy_attachment" "airflow_role_datahub_ingestion_access" {
+  count      = var.departmental_airflow_role && local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
   role       = aws_iam_role.airflow_role[0].name
-  policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
+  policy_arn = aws_iam_policy.datahub_ingestion_access_policy[0].arn
 }
 
 # Store the departmental Airflow AWS connection in Secrets Manager.
@@ -194,10 +194,10 @@ resource "aws_iam_role_policy_attachment" "ecs_parameter_store_access" {
   policy_arn = aws_iam_policy.parameter_store_read_only.arn
 }
 
-resource "aws_iam_role_policy_attachment" "datahub_config_access_attachment" {
-  count      = local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+resource "aws_iam_role_policy_attachment" "datahub_ingestion_access_attachment" {
+  count      = local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
   role       = aws_iam_role.department_ecs_role.name
-  policy_arn = aws_iam_policy.datahub_config_access_policy[0].arn
+  policy_arn = aws_iam_policy.datahub_ingestion_access_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "noiseworks_access_attachment" {

--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -68,9 +68,9 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "cloudtrail_access" {
   }
 }
 
-# Attach DataHub config access policy to SSO (data-and-insight only)
-resource "aws_ssoadmin_customer_managed_policy_attachment" "datahub_config_access" {
-  count = local.deploy_sso && local.department_identifier == "data-and-insight" && var.datahub_config_bucket != null ? 1 : 0
+# Attach DataHub ingestion access policy to SSO (data-and-insight only)
+resource "aws_ssoadmin_customer_managed_policy_attachment" "datahub_ingestion_access" {
+  count = local.deploy_sso && local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
 
   provider = aws.aws_hackit_account
 
@@ -78,7 +78,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "datahub_config_acces
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
 
   customer_managed_policy_reference {
-    name = aws_iam_policy.datahub_config_access_policy[0].name
+    name = aws_iam_policy.datahub_ingestion_access_policy[0].name
     path = "/"
   }
 }

--- a/terraform/modules/department/99-moved.tf
+++ b/terraform/modules/department/99-moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = aws_iam_role_policy_attachment.airflow_role_datahub_config_access
+  to   = aws_iam_role_policy_attachment.airflow_role_datahub_ingestion_access
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.datahub_config_access_attachment
+  to   = aws_iam_role_policy_attachment.datahub_ingestion_access_attachment
+}
+
+moved {
+  from = aws_iam_policy.datahub_config_access_policy
+  to   = aws_iam_policy.datahub_ingestion_access_policy
+}
+
+moved {
+  from = aws_ssoadmin_customer_managed_policy_attachment.datahub_config_access
+  to   = aws_ssoadmin_customer_managed_policy_attachment.datahub_ingestion_access
+}


### PR DESCRIPTION
Destroy the DataHub config bucket and create the DataHub ingestion bucket, as it will include both config files and ETL scripts used in the DataHub ingestion container.

Avoid creating two buckets here to keep things simple.