### PR TITLE
Add a note about the CodeBuild webhook

### DIFF
--- a/terraform/core/48-staging-codebuild-dap-airflow-sync.tf
+++ b/terraform/core/48-staging-codebuild-dap-airflow-sync.tf
@@ -1,3 +1,9 @@
+# GitHub webhook UI note:
+# - After Terraform creates the CodeBuild webhook, manually untick the Pull requests
+#   trigger checkbox in the GitHub repository webhook settings.
+# - Then scroll to the bottom, and click "Update webhook" so
+#   YAML auto-fix pull request activity does not trigger the CodeBuild webhook.
+
 # Workflow overview:
 # - This staging-only Terraform creates the AWS CodeConnections, CodeBuild, IAM, CloudWatch Logs,
 #   and webhook resources needed to sync the `dap-airflow` GitHub repository into the staging MWAA buckets.


### PR DESCRIPTION
Terraform [aws_codebuild_webhook ](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_webhook#scope_configuration) does not directly control those GitHub checkboxes. Just add a note to untick the pull request option from the checkbox.

