### PR TITLE
DL-208 Allow D&I to write to the MetaStreet database

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -160,7 +160,7 @@ module "department_data_and_insight" {
   datahub_ingestion_bucket        = module.datahub_ingestion
   additional_glue_database_access = {
     read_only  = []
-    read_write = ["arcus_archive", "metastore"]
+    read_write = ["arcus_archive", "metastore", "private_sector_housing_metastreet"]
   }
   additional_s3_access = [
     {


### PR DESCRIPTION
Grant write permission to the new database

> shared:Failed to write history table batch #1: An error occurred (AccessDeniedException) when calling the GetTable operation: User: arn:aws:sts::120038763019:assumed-role/dataplatform-stg-data-and-insight-ecs-task-role/2f7d41a91a75478ba71e36c8ab9ee49b is not authorized to perform: glue:GetTable on resource