### PR TITLE
allow lf registration role to use zone keys

### DIFF
--- a/terraform/core/10-aws-s3-bucket-policies.tf
+++ b/terraform/core/10-aws-s3-bucket-policies.tf
@@ -104,6 +104,16 @@ locals {
     "kms:CreateGrant"
   ]
 
+  lakeformation_registration_role_arn = "arn:aws:iam::${data.aws_secretsmanager_secret_version.pre_production_account_id.secret_string}:role/dap-lf-location-registration"
+
+  lakeformation_registration_kms_actions = [
+    "kms:Decrypt",
+    "kms:DescribeKey",
+    "kms:Encrypt",
+    "kms:GenerateDataKey*",
+    "kms:ReEncrypt*"
+  ]
+
   prod_to_preprod_s3_actions = [
     "s3:ListBucket",
     "s3:PutObject*",
@@ -159,6 +169,16 @@ locals {
     principals = {
       type        = "AWS"
       identifiers = [local.prod_to_preprod_sync_role_arn]
+    }
+  }
+
+  lakeformation_registration_key_statement_for_pre_prod = {
+    sid     = "LakeFormationRegistrationKeyAccess"
+    effect  = "Allow"
+    actions = local.lakeformation_registration_kms_actions
+    principals = {
+      type        = "AWS"
+      identifiers = [local.lakeformation_registration_role_arn]
     }
   }
 

--- a/terraform/core/10-aws-s3-buckets.tf
+++ b/terraform/core/10-aws-s3-buckets.tf
@@ -75,7 +75,8 @@ module "raw_zone" {
       local.s3_to_s3_copier_for_addresses_api_raw_zone_key_statement
     ] : [],
     local.is_preprod_env ? [
-      local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod
+      local.prod_to_pre_prod_data_sync_access_to_raw_zone_key_statement_for_pre_prod,
+      local.lakeformation_registration_key_statement_for_pre_prod
     ] : []
   )
   include_backup_policy_tags = false
@@ -104,7 +105,8 @@ module "refined_zone" {
       local.allow_s3_batch_copy_kms_access_refined_zone
     ],
     local.is_preprod_env ? [
-      local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod
+      local.prod_to_pre_prod_data_sync_access_to_refined_zone_key_statement_for_pre_prod,
+      local.lakeformation_registration_key_statement_for_pre_prod
     ] : []
   )
   include_backup_policy_tags = false


### PR DESCRIPTION
Allows the pre-production lake formation registration role to use the corresponding KMS keys. 