### PR TITLE
Change the name of the database that contains Metastreet data

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -160,7 +160,7 @@ module "department_data_and_insight" {
   datahub_ingestion_bucket        = module.datahub_ingestion
   additional_glue_database_access = {
     read_only  = []
-    read_write = ["arcus_archive", "metastore", "private_sector_housing_metastreet"]
+    read_write = ["arcus_archive", "metastore", "private_sector_housing"]
   }
   additional_s3_access = [
     {

--- a/terraform/etl/61-aws-glue-catalog-database.tf
+++ b/terraform/etl/61-aws-glue-catalog-database.tf
@@ -171,8 +171,8 @@ resource "aws_glue_catalog_database" "trusted_zone_tascomi" {
   }
 }
 
-resource "aws_glue_catalog_database" "private_sector_housing_metastreet" {
-  name        = "private_sector_housing_metastreet"
+resource "aws_glue_catalog_database" "private_sector_housing" {
+  name        = "private_sector_housing"
   description = "Data will be used by the Data and Insight team, not the Housing department."
 
   lifecycle {


### PR DESCRIPTION
Daro spotted that the keyword Metastreet has been included in the table name, so it does not need to be included in the database name.

**private_sector_housing** will be the new name. If we have other databases from private sector housing in the future, we can load them into this catalog database.