### PR TITLE
Change FSA API name prefix

### DIFF
--- a/terraform/etl/06-aws-secrets-manager.tf
+++ b/terraform/etl/06-aws-secrets-manager.tf
@@ -247,8 +247,8 @@ resource "aws_secretsmanager_secret_version" "planning_tascomi_api_key" {
 }
 
 resource "aws_secretsmanager_secret" "fsa_api_creds" {
-  name        = "/env-services/fsa-api-creds"
-  description = "FSA API Credentials for Regulatory Services"
+  name        = "/data-and-insight/fsa-api-creds"
+  description = "FSA API Credentials for D&I on behalf of Regulatory Services"
   tags        = module.tags.values
 }
 


### PR DESCRIPTION
Daro’s concern is that putting it under env-services could imply the data belongs to Env Services and may give access to users who shouldn’t see Food Registration data.
And he recommends to put it under D&I for now.