### PR TITLE
Allow FME user access the CFS mosaic data

### DIFF
--- a/terraform/core/23-FME-iam.tf
+++ b/terraform/core/23-FME-iam.tf
@@ -121,6 +121,7 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
       ],
       [
         for folder in [
+          "child-fam-services",
           "unrestricted",
           "data-and-insight",
           "env-enforcement",

--- a/terraform/core/23-FME-iam.tf
+++ b/terraform/core/23-FME-iam.tf
@@ -121,7 +121,7 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
       ],
       [
         for folder in [
-          "child-fam-services",
+          "child-fam-services/mosaic",
           "unrestricted",
           "data-and-insight",
           "env-enforcement",


### PR DESCRIPTION
Marta requested access to CFS Mosaic data using the FME Athena connector (via #data-analytics-platform channel). She already has an FME access key that is used for the data from our DataPlatform.

This PR Adds the `child-fam-services/mosaic` S3 prefix to the existing FME IAM user read permissions.

This is not ideal, but it is a quick fix. We may need to review the FME user to see whether it supports role assumption or federated authentication, or at least rotate the secrete key, which has not been rotated since 2022.