### PR TITLE
Allow FME to access the latest partition of the mosaic tables

### DIFF
--- a/terraform/core/23-FME-iam.tf
+++ b/terraform/core/23-FME-iam.tf
@@ -122,6 +122,7 @@ data "aws_iam_policy_document" "fme_access_to_s3" {
       [
         for folder in [
           "child-fam-services/mosaic",
+          "child-fam-services/latest_partition/mosaic",
           "unrestricted",
           "data-and-insight",
           "env-enforcement",


### PR DESCRIPTION
> AmazonAthenaConnector: The query failed: 'PERMISSION_DENIED: User: arn:aws:iam::365719730767:user/fme-user is not authorized to perform: s3:GetObject on resource: "arn:aws:s3:::dataplatform-prod-raw-zone/child-fam-services/latest_partition/mosaic/addresses/20260629_062338_00160_si9zh_b32234fb-ecd7-4d85-ae6b-21e6db0f16cb" because no identity-based policy allows the s3:GetObject action (Service: S3, Status Code: 403, Request ID: YXC4P8SQF8ZTGYG8, Extended Request ID: o7LHbNAMIKPR3XChMW0IK90K4H1IwT8ArP+xr7nwsXSIXSvuu++aRcsTFWpE5tUVZx4WD/2sMQc=)'

A small change: Marta also needs the latest partition of the mosaic tables. It is not under the mosaic prefix by accident; instead, it is under a latest_partition prefix. This PR is to add this prefix to FME.
