### PR TITLE
DL-256 Add Adult Social Care department

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -641,6 +641,42 @@ module "department_streetscene" {
   user_uploads_bucket             = module.user_uploads
 }
 
+module "department_adult_social_care" {
+  providers = {
+    aws                    = aws
+    aws.aws_hackit_account = aws.aws_hackit_account
+  }
+
+  source                          = "../modules/department"
+  tags                            = module.tags.values
+  is_live_environment             = local.is_live_environment
+  environment                     = var.environment
+  application                     = local.application_snake
+  short_identifier_prefix         = local.short_identifier_prefix
+  identifier_prefix               = local.identifier_prefix
+  name                            = "Adult Social Care"
+  landing_zone_bucket             = module.landing_zone
+  raw_zone_bucket                 = module.raw_zone
+  refined_zone_bucket             = module.refined_zone
+  trusted_zone_bucket             = module.trusted_zone
+  athena_storage_bucket           = module.athena_storage
+  glue_scripts_bucket             = module.glue_scripts
+  glue_temp_storage_bucket        = module.glue_temp_storage
+  spark_ui_output_storage_bucket  = module.spark_ui_output_storage
+  secrets_manager_kms_key         = aws_kms_key.secrets_manager_key
+  redshift_ip_addresses           = var.redshift_public_ips
+  redshift_port                   = var.redshift_port
+  sso_instance_arn                = local.sso_instance_arn
+  identity_store_id               = local.identity_store_id
+  google_group_admin_display_name = local.google_group_admin_display_name
+  google_group_display_name       = "saml-aws-data-platform-collaborator-asc@hackney.gov.uk"
+  departmental_airflow_role       = local.departmental_airflow_role
+  mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
+  mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
+  mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
+  user_uploads_bucket             = module.user_uploads
+}
+
 module "department_children_family_services" {
   providers = {
     aws                    = aws
@@ -683,6 +719,7 @@ module "department_children_family_services" {
 
 locals {
   departmental_airflow_role_arns = compact([
+    module.department_adult_social_care.airflow_role_arn,
     module.department_benefits_and_housing_needs.airflow_role_arn,
     module.department_children_family_services.airflow_role_arn,
     module.department_data_and_insight.airflow_role_arn,


### PR DESCRIPTION
- Adds the Adult Social Care department to the Terraform configuration.
- Enables the departmental Airflow role.
- The Google Group (saml-aws-data-platform-collaborator-asc@hackney.gov.uk) has been authorised by the Cloud team.