### PR TITLE
Enable departmental CSV uploads to create Glue Catalog tables

### DIFF
--- a/lambdas/csv_to_glue_catalog/main.py
+++ b/lambdas/csv_to_glue_catalog/main.py
@@ -8,8 +8,8 @@ Outputs:
 
 Operational notes:
     All generated columns use the Glue ``string`` type. The recommended S3 key
-    format is ``<department>/<project>/<table>/<file.csv>``. The legacy
-    ``<department>/<project>/<file.csv>`` format remains supported.
+    format is ``<department>/<target_table_name>/<file.csv>``. Every CSV in a
+    target table folder contributes data to the same Glue table.
 """
 
 import json
@@ -26,19 +26,18 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 
-def parse_s3_key(s3_key: str) -> tuple[str, str, str]:
-    """Extract the department, project, and table-name component from an S3 key.
+def parse_s3_key(s3_key: str) -> tuple[str, str]:
+    """Extract the department and target table name from an S3 key.
 
-    The recommended format uses a dedicated folder for each table:
-    ``<department>/<project>/<table>/<file.csv>``. For backward compatibility,
-    ``<department>/<project>/<file.csv>`` uses the file name as the table-name
-    component.
+    The required format is
+    ``<department>/<target_table_name>/<file.csv>``. The CSV file name does not
+    contribute to the Glue table name.
 
     Args:
         s3_key: URL-encoded S3 object key.
 
     Returns:
-        Department, project name, and table-name component.
+        Department and target table folder name.
 
     Raises:
         ValueError: If the key does not use a supported path or file format.
@@ -46,20 +45,19 @@ def parse_s3_key(s3_key: str) -> tuple[str, str, str]:
     decoded_key = unquote_plus(s3_key)
     path = PurePosixPath(decoded_key)
 
-    if len(path.parts) not in (3, 4):
+    if len(path.parts) != 3:
         raise ValueError(
             f"Invalid S3 key format: {s3_key}. Expected "
-            "<department>/<project>/<table>/<file.csv>"
+            "<department>/<target_table_name>/<file.csv>"
         )
 
     if path.suffix != ".csv":
         raise ValueError(f"File must be a CSV file: {path.name}")
 
     department = path.parts[0]
-    project_name = path.parts[1]
-    table_name_component = path.parts[2] if len(path.parts) == 4 else path.stem
+    target_table_name = path.parts[1]
 
-    return department, project_name, table_name_component
+    return department, target_table_name
 
 
 def normalize_name(name: str, lowercase: bool = True) -> str:
@@ -152,7 +150,8 @@ def extract_csv_column_definitions(bucket: str, key: str) -> dict[str, str]:
         columns_types[col_name] = "string"
 
     logger.info(
-        f"A total of {len(columns_types)} column definitions were extracted from CSV header"
+        f"A total of {len(columns_types)} column definitions were extracted "
+        "from the CSV header"
     )
     return columns_types
 
@@ -173,10 +172,7 @@ def create_glue_table(
         s3_key: S3 object key (file path)
         columns_types: Dictionary mapping column names to types
     """
-    # Extract directory path: s3://bucket/parking/user/file.csv -> s3://bucket/parking/user/
-    s3_path_parts = s3_key.rsplit("/", 1)
-    s3_directory = f"{s3_path_parts[0]}/" if len(s3_path_parts) > 1 else ""
-    s3_location = f"s3://{bucket}/{s3_directory}"
+    s3_location = build_s3_directory_location(bucket, s3_key)
 
     wr.catalog.create_csv_table(
         database=database_name,
@@ -189,6 +185,20 @@ def create_glue_table(
     logger.info(
         f"Successfully created table: {table_name} in database: {database_name}"
     )
+
+
+def build_s3_directory_location(bucket: str, s3_key: str) -> str:
+    """Build the S3 URI for the directory containing an object.
+
+    Args:
+        bucket: S3 bucket name.
+        s3_key: S3 object key.
+
+    Returns:
+        S3 directory URI with a trailing slash.
+    """
+    s3_directory = s3_key.rsplit("/", 1)[0]
+    return f"s3://{bucket}/{s3_directory}/"
 
 
 def delete_glue_table(database_name: str, table_name: str) -> None:
@@ -231,10 +241,13 @@ def process_single_event_record(
     decoded_s3_key = unquote_plus(s3_key)
     logger.info(f"Processing event: {event_name} for s3://{bucket}/{decoded_s3_key}")
 
-    _, project_name, table_name_component = parse_s3_key(s3_key)
-    table_name = (
-        f"{normalize_name(project_name)}_{normalize_name(table_name_component)}"
-    )
+    _, target_table_name = parse_s3_key(s3_key)
+    table_name = normalize_name(target_table_name)
+
+    if not table_name:
+        raise ValueError(
+            f"Target table folder must contain alphanumeric characters: {s3_key}"
+        )
 
     if event_name.startswith("ObjectCreated"):
         logger.info(f"Creating/updating table: {table_name}")
@@ -255,12 +268,26 @@ def process_single_event_record(
         return True, False
 
     elif event_name.startswith("ObjectRemoved"):
+        s3_location = build_s3_directory_location(bucket, decoded_s3_key)
+        remaining_csv_files = wr.s3.list_objects(
+            path=s3_location,
+            suffix=".csv",
+        )
+
+        if remaining_csv_files:
+            logger.info(
+                f"Keeping table: {table_name}; "
+                f"{len(remaining_csv_files)} CSV file(s) remain in {s3_location}"
+            )
+            return True, False
+
         logger.info(f"Deleting table: {table_name}")
 
         delete_glue_table(database_name=database_name, table_name=table_name)
 
         logger.info(
-            f"Successfully processed deletion: {decoded_s3_key} -> deleted table: {table_name}"
+            f"Successfully processed deletion: {decoded_s3_key} "
+            f"-> deleted table: {table_name}"
         )
         return True, False
 
@@ -324,7 +351,7 @@ def handle_sqs_event(event: dict[str, Any]) -> dict[str, Any]:
             logger.info(f"Processing file from message {message_id}: {s3_key}")
 
             # Extract and normalize department from S3 path to construct database name
-            department, _, _ = parse_s3_key(s3_key)
+            department, _ = parse_s3_key(s3_key)
             normalized_dept = department.replace("-", "_")
             database_name = f"{normalized_dept}_user_uploads_db"
             logger.info(
@@ -349,7 +376,8 @@ def handle_sqs_event(event: dict[str, Any]) -> dict[str, Any]:
 
     logger.info(
         f"Processing summary: {processed_count} processed, "
-        f"{skipped_count} skipped, {len(failed_message_ids)} failed, {total_records} total"
+        f"{skipped_count} skipped, {len(failed_message_ids)} failed, "
+        f"{total_records} total"
     )
 
     return {

--- a/lambdas/csv_to_glue_catalog/main.py
+++ b/lambdas/csv_to_glue_catalog/main.py
@@ -1,7 +1,15 @@
-"""
-Automatically creates/deletes Glue Catalog tables when CSV files are uploaded/deleted in S3.
+"""Synchronize user-uploaded CSV files with AWS Glue Catalog tables.
 
-Note: all column types of the created tables are defined as strings and please be aware when using them downstream.
+Inputs:
+    Receives S3 object-created and object-removed events through SQS.
+
+Outputs:
+    Creates, updates, or deletes Glue Catalog tables for supported uploads.
+
+Operational notes:
+    All generated columns use the Glue ``string`` type. The recommended S3 key
+    format is ``<department>/<project>/<table>/<file.csv>``. The legacy
+    ``<department>/<project>/<file.csv>`` format remains supported.
 """
 
 import json
@@ -19,33 +27,39 @@ logger.setLevel(logging.INFO)
 
 
 def parse_s3_key(s3_key: str) -> tuple[str, str, str]:
-    """Parse S3 key to extract department, user_name, and file_name.
+    """Extract the department, project, and table-name component from an S3 key.
 
-    Expected format: <department>/<user_name>/<file.csv>
-    Example: parking/davina/test_1.csv
+    The recommended format uses a dedicated folder for each table:
+    ``<department>/<project>/<table>/<file.csv>``. For backward compatibility,
+    ``<department>/<project>/<file.csv>`` uses the file name as the table-name
+    component.
 
     Args:
-        s3_key: URL-encoded S3 object key
+        s3_key: URL-encoded S3 object key.
 
     Returns:
-        Tuple of (department, user_name, file_base_name)
+        Department, project name, and table-name component.
+
+    Raises:
+        ValueError: If the key does not use a supported path or file format.
     """
     decoded_key = unquote_plus(s3_key)
     path = PurePosixPath(decoded_key)
 
-    if len(path.parts) < 3:
+    if len(path.parts) not in (3, 4):
         raise ValueError(
-            f"Invalid S3 key format: {s3_key}. Expected format: <department>/<user_name>/<file.csv>"
+            f"Invalid S3 key format: {s3_key}. Expected "
+            "<department>/<project>/<table>/<file.csv>"
         )
 
     if path.suffix != ".csv":
         raise ValueError(f"File must be a CSV file: {path.name}")
 
     department = path.parts[0]
-    user_name = path.parts[1]
-    file_base_name = path.stem
+    project_name = path.parts[1]
+    table_name_component = path.parts[2] if len(path.parts) == 4 else path.stem
 
-    return department, user_name, file_base_name
+    return department, project_name, table_name_component
 
 
 def normalize_name(name: str, lowercase: bool = True) -> str:
@@ -149,7 +163,7 @@ def create_glue_table(
     bucket: str,
     s3_key: str,
     columns_types: dict[str, str],
-):
+) -> None:
     """Create or recreate Glue Catalog table using AWS Data Wrangler.
 
     Args:
@@ -177,7 +191,7 @@ def create_glue_table(
     )
 
 
-def delete_glue_table(database_name: str, table_name: str):
+def delete_glue_table(database_name: str, table_name: str) -> None:
     """Delete Glue Catalog table using AWS Data Wrangler.
 
     Args:
@@ -217,8 +231,10 @@ def process_single_event_record(
     decoded_s3_key = unquote_plus(s3_key)
     logger.info(f"Processing event: {event_name} for s3://{bucket}/{decoded_s3_key}")
 
-    _, user_name, file_base_name = parse_s3_key(s3_key)
-    table_name = f"{normalize_name(user_name)}_{normalize_name(file_base_name)}"
+    _, project_name, table_name_component = parse_s3_key(s3_key)
+    table_name = (
+        f"{normalize_name(project_name)}_{normalize_name(table_name_component)}"
+    )
 
     if event_name.startswith("ObjectCreated"):
         logger.info(f"Creating/updating table: {table_name}")

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -77,13 +77,13 @@ module "department_parking" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
   additional_glue_database_access = {
     read_only = [
       "${local.identifier_prefix}-liberator-raw-zone",
       "${local.identifier_prefix}-liberator-refined-zone",
       "${local.identifier_prefix}-liberator-trusted-zone",
       "parking-ringgo-sftp-raw-zone",
-      "parking_user_uploads_db",
     ]
     read_write = []
   }
@@ -156,6 +156,7 @@ module "department_data_and_insight" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
   cloudtrail_bucket               = module.cloudtrail_storage
   datahub_ingestion_bucket        = module.datahub_ingestion
   additional_glue_database_access = {
@@ -287,6 +288,7 @@ module "department_unrestricted" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
 }
 
 module "department_sandbox" {
@@ -397,11 +399,11 @@ module "department_revenues" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
   additional_glue_database_access = {
     read_only = [
       "nndr_raw_zone",
       "ctax_raw_zone",
-      "revenues_user_uploads_db",
     ]
     read_write = []
   }
@@ -441,6 +443,7 @@ module "department_environmental_services" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
 }
 
 module "department_housing" {
@@ -477,6 +480,7 @@ module "department_housing" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
   additional_s3_access = [
     {
       bucket_arn  = module.housing_nec_migration_storage.bucket_arn
@@ -711,6 +715,7 @@ module "department_children_family_services" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
+  user_uploads_catalog_enabled    = true
   additional_glue_database_access = {
     read_only  = ["child_edu_refined", "hackney_casemanagement_live", "hackney_synergy_live"]
     read_write = []

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -288,7 +288,6 @@ module "department_unrestricted" {
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   mwaa_execution_role_arn         = aws_iam_role.mwaa_role.arn
   user_uploads_bucket             = module.user_uploads
-  user_uploads_catalog_enabled    = true
 }
 
 module "department_sandbox" {

--- a/terraform/etl/61-aws-glue-catalog-database.tf
+++ b/terraform/etl/61-aws-glue-catalog-database.tf
@@ -125,6 +125,7 @@ resource "aws_glue_catalog_database" "arcus_archive" {
 }
 
 locals {
+  # The protected Unrestricted database is retained, but its uploads and user access are disabled.
   department_user_uploads_databases = {
     parking            = "parking_user_uploads_db"
     housing            = "housing_user_uploads_db"

--- a/terraform/etl/61-aws-glue-catalog-database.tf
+++ b/terraform/etl/61-aws-glue-catalog-database.tf
@@ -125,7 +125,6 @@ resource "aws_glue_catalog_database" "arcus_archive" {
 }
 
 locals {
-  # The protected Unrestricted database is retained, but its uploads and user access are disabled.
   department_user_uploads_databases = {
     parking            = "parking_user_uploads_db"
     housing            = "housing_user_uploads_db"

--- a/terraform/etl/62-lambda-csv-to-glue-catalog.tf
+++ b/terraform/etl/62-lambda-csv-to-glue-catalog.tf
@@ -7,9 +7,13 @@ locals {
     housing            = "housing/"
     data_and_insight   = "data-and-insight/"
     child_fam_services = "child-fam-services/"
-    unrestricted       = "unrestricted/"
     env_services       = "env-services/"
     revenues           = "revenues/"
+  }
+
+  enabled_department_user_uploads_databases = {
+    for department in keys(local.department_user_uploads_prefixes) :
+    department => local.department_user_uploads_databases[department]
   }
 }
 
@@ -48,8 +52,8 @@ data "aws_iam_policy_document" "csv_to_glue_catalog_lambda_execution" {
     ]
     resources = concat(
       ["arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.data_platform.account_id}:catalog"],
-      [for db_name in values(local.department_user_uploads_databases) : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.data_platform.account_id}:database/${db_name}"],
-      [for db_name in values(local.department_user_uploads_databases) : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.data_platform.account_id}:table/${db_name}/*"]
+      [for db_name in values(local.enabled_department_user_uploads_databases) : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.data_platform.account_id}:database/${db_name}"],
+      [for db_name in values(local.enabled_department_user_uploads_databases) : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.data_platform.account_id}:table/${db_name}/*"]
     )
   }
 
@@ -60,7 +64,8 @@ data "aws_iam_policy_document" "csv_to_glue_catalog_lambda_execution" {
       "s3:GetObjectVersion",
     ]
     resources = [
-      "${module.user_uploads_data_source.bucket_arn}/*",
+      for prefix in values(local.department_user_uploads_prefixes) :
+      "${module.user_uploads_data_source.bucket_arn}/${prefix}*"
     ]
   }
 
@@ -72,6 +77,15 @@ data "aws_iam_policy_document" "csv_to_glue_catalog_lambda_execution" {
     resources = [
       module.user_uploads_data_source.bucket_arn,
     ]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        for prefix in values(local.department_user_uploads_prefixes) :
+        "${prefix}*"
+      ]
+    }
   }
 
   statement {

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -118,3 +118,9 @@ variable "additional_glue_database_access" {
     read_write = []
   }
 }
+
+variable "user_uploads_catalog_enabled" {
+  description = "Grant read-only access to the department's automatically managed user uploads Glue database"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -26,6 +26,10 @@ locals {
     "unrestricted-*-zone",
     "${var.identifier_prefix}-raw-zone-unrestricted-address-api"
   ]
+
+  department_user_uploads_databases = var.user_uploads_catalog_enabled ? [
+    "${replace(local.department_identifier, "-", "_")}_user_uploads_db"
+  ] : []
 }
 
 // S3 read only access policy
@@ -230,7 +234,7 @@ data "aws_iam_policy_document" "read_only_glue_access" {
   dynamic "statement" {
     for_each = {
       for k, v in {
-        read_only  = var.additional_glue_database_access.read_only
+        read_only  = concat(local.department_user_uploads_databases, var.additional_glue_database_access.read_only)
         read_write = var.additional_glue_database_access.read_write
       } : k => v if length(v) > 0
     }
@@ -587,7 +591,7 @@ data "aws_iam_policy_document" "glue_access" {
   dynamic "statement" {
     for_each = {
       for k, v in {
-        read_only  = var.additional_glue_database_access.read_only
+        read_only  = concat(local.department_user_uploads_databases, var.additional_glue_database_access.read_only)
         read_write = var.additional_glue_database_access.read_write
       } : k => v if length(v) > 0
     }
@@ -700,7 +704,7 @@ data "aws_iam_policy_document" "glue_access_sso" {
   dynamic "statement" {
     for_each = {
       for k, v in {
-        read_only  = var.additional_glue_database_access.read_only
+        read_only  = concat(local.department_user_uploads_databases, var.additional_glue_database_access.read_only)
         read_write = var.additional_glue_database_access.read_write
       } : k => v if length(v) > 0
     }

--- a/tests/lambdas/test_csv_to_glue_catalog.py
+++ b/tests/lambdas/test_csv_to_glue_catalog.py
@@ -1,0 +1,101 @@
+"""Tests for the user-uploaded CSV to Glue Catalog Lambda."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+LAMBDA_PATH = (
+    Path(__file__).parents[2] / "lambdas" / "csv_to_glue_catalog" / "main.py"
+)
+
+
+def load_lambda_module() -> ModuleType:
+    """Load the Lambda module without relying on its directory being on sys.path."""
+    spec = spec_from_file_location("csv_to_glue_catalog_main", LAMBDA_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load Lambda module from {LAMBDA_PATH}")
+
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+main = load_lambda_module()
+
+
+def test_parse_s3_key_uses_table_subfolder() -> None:
+    """Use the table folder for the recommended four-level key format."""
+    result = main.parse_s3_key("parking/ringgo/permits/permits_march.csv")
+
+    assert result == ("parking", "ringgo", "permits")
+
+
+def test_parse_s3_key_keeps_legacy_format_compatible() -> None:
+    """Use the file stem for a legacy three-level key."""
+    result = main.parse_s3_key("parking/ringgo/permits_march.csv")
+
+    assert result == ("parking", "ringgo", "permits_march")
+
+
+def test_parse_s3_key_rejects_ambiguous_nested_paths() -> None:
+    """Reject paths deeper than the documented table-folder layout."""
+    with pytest.raises(ValueError, match="Invalid S3 key format"):
+        main.parse_s3_key("parking/ringgo/permits/2026/permits_march.csv")
+
+
+@patch.object(main, "extract_csv_column_definitions", return_value={"id": "string"})
+@patch.object(main, "create_glue_table")
+def test_process_record_creates_table_from_project_and_table_folders(
+    create_glue_table: MagicMock,
+    _extract_csv_column_definitions: MagicMock,
+) -> None:
+    """Create an independent table from the project and table folder names."""
+    record = {
+        "eventName": "ObjectCreated:Put",
+        "s3": {
+            "bucket": {"name": "dataplatform-prod-user-uploads"},
+            "object": {
+                "key": "parking/ringgo/permits/permits_march.csv",
+            },
+        },
+    }
+
+    assert main.process_single_event_record(
+        record, "parking_user_uploads_db"
+    ) == (True, False)
+    create_glue_table.assert_called_once_with(
+        database_name="parking_user_uploads_db",
+        table_name="ringgo_permits",
+        bucket="dataplatform-prod-user-uploads",
+        s3_key="parking/ringgo/permits/permits_march.csv",
+        columns_types={"id": "string"},
+    )
+
+
+@patch.object(main.wr.catalog, "create_csv_table")
+def test_create_glue_table_uses_table_subfolder_as_location(
+    create_csv_table: MagicMock,
+) -> None:
+    """Point the Glue table at only its dedicated table subfolder."""
+    main.create_glue_table(
+        database_name="parking_user_uploads_db",
+        table_name="ringgo_permits",
+        bucket="dataplatform-prod-user-uploads",
+        s3_key="parking/ringgo/permits/permits_march.csv",
+        columns_types={"id": "string"},
+    )
+
+    create_csv_table.assert_called_once_with(
+        database="parking_user_uploads_db",
+        table="ringgo_permits",
+        path=(
+            "s3://dataplatform-prod-user-uploads/"
+            "parking/ringgo/permits/"
+        ),
+        columns_types={"id": "string"},
+        mode="overwrite",
+        skip_header_line_count=1,
+    )

--- a/tests/lambdas/test_csv_to_glue_catalog.py
+++ b/tests/lambdas/test_csv_to_glue_catalog.py
@@ -1,5 +1,6 @@
 """Tests for the user-uploaded CSV to Glue Catalog Lambda."""
 
+import json
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from types import ModuleType
@@ -26,39 +27,79 @@ def load_lambda_module() -> ModuleType:
 main = load_lambda_module()
 
 
-def test_parse_s3_key_uses_table_subfolder() -> None:
-    """Use the table folder for the recommended four-level key format."""
-    result = main.parse_s3_key("parking/ringgo/permits/permits_march.csv")
+def test_parse_s3_key_uses_target_table_folder() -> None:
+    """Use the table folder and ignore different CSV file names."""
+    january_result = main.parse_s3_key(
+        "parking/ringgo_permits/january.csv"
+    )
+    february_result = main.parse_s3_key(
+        "parking/ringgo_permits/february.csv"
+    )
 
-    assert result == ("parking", "ringgo", "permits")
+    assert january_result == ("parking", "ringgo_permits")
+    assert february_result == ("parking", "ringgo_permits")
 
 
-def test_parse_s3_key_keeps_legacy_format_compatible() -> None:
-    """Use the file stem for a legacy three-level key."""
-    result = main.parse_s3_key("parking/ringgo/permits_march.csv")
-
-    assert result == ("parking", "ringgo", "permits_march")
-
-
-def test_parse_s3_key_rejects_ambiguous_nested_paths() -> None:
-    """Reject paths deeper than the documented table-folder layout."""
+def test_parse_s3_key_rejects_missing_table_folder() -> None:
+    """Reject a CSV uploaded directly beneath the department folder."""
     with pytest.raises(ValueError, match="Invalid S3 key format"):
-        main.parse_s3_key("parking/ringgo/permits/2026/permits_march.csv")
+        main.parse_s3_key("parking/permits_march.csv")
+
+
+def test_parse_s3_key_rejects_nested_paths() -> None:
+    """Reject paths deeper than the required table-folder layout."""
+    with pytest.raises(ValueError, match="Invalid S3 key format"):
+        main.parse_s3_key("parking/ringgo/permits/permits_march.csv")
+
+
+def test_parse_s3_key_rejects_non_csv_files() -> None:
+    """Reject files that do not have the lowercase CSV extension."""
+    with pytest.raises(ValueError, match="File must be a CSV"):
+        main.parse_s3_key("parking/ringgo_permits/permits.xlsx")
+
+
+def test_handle_sqs_event_reports_invalid_path_as_batch_failure() -> None:
+    """Report an invalid CSV path so SQS can retry and route it to the DLQ."""
+    s3_event = {
+        "Records": [
+            {
+                "eventName": "ObjectCreated:Put",
+                "s3": {
+                    "bucket": {"name": "dataplatform-prod-user-uploads"},
+                    "object": {
+                        "key": "parking/ringgo/permits/permits.csv",
+                    },
+                },
+            }
+        ]
+    }
+    sqs_event = {
+        "Records": [
+            {
+                "messageId": "invalid-path",
+                "body": json.dumps(s3_event),
+            }
+        ]
+    }
+
+    assert main.handle_sqs_event(sqs_event) == {
+        "batchItemFailures": [{"itemIdentifier": "invalid-path"}]
+    }
 
 
 @patch.object(main, "extract_csv_column_definitions", return_value={"id": "string"})
 @patch.object(main, "create_glue_table")
-def test_process_record_creates_table_from_project_and_table_folders(
+def test_process_record_creates_table_from_target_table_folder(
     create_glue_table: MagicMock,
     _extract_csv_column_definitions: MagicMock,
 ) -> None:
-    """Create an independent table from the project and table folder names."""
+    """Create a table named after the target table folder."""
     record = {
         "eventName": "ObjectCreated:Put",
         "s3": {
             "bucket": {"name": "dataplatform-prod-user-uploads"},
             "object": {
-                "key": "parking/ringgo/permits/permits_march.csv",
+                "key": "parking/ringgo_permits/permits_march.csv",
             },
         },
     }
@@ -70,21 +111,21 @@ def test_process_record_creates_table_from_project_and_table_folders(
         database_name="parking_user_uploads_db",
         table_name="ringgo_permits",
         bucket="dataplatform-prod-user-uploads",
-        s3_key="parking/ringgo/permits/permits_march.csv",
+        s3_key="parking/ringgo_permits/permits_march.csv",
         columns_types={"id": "string"},
     )
 
 
 @patch.object(main.wr.catalog, "create_csv_table")
-def test_create_glue_table_uses_table_subfolder_as_location(
+def test_create_glue_table_uses_target_table_folder_as_location(
     create_csv_table: MagicMock,
 ) -> None:
-    """Point the Glue table at only its dedicated table subfolder."""
+    """Point the Glue table at its dedicated target table folder."""
     main.create_glue_table(
         database_name="parking_user_uploads_db",
         table_name="ringgo_permits",
         bucket="dataplatform-prod-user-uploads",
-        s3_key="parking/ringgo/permits/permits_march.csv",
+        s3_key="parking/ringgo_permits/permits_march.csv",
         columns_types={"id": "string"},
     )
 
@@ -93,9 +134,72 @@ def test_create_glue_table_uses_table_subfolder_as_location(
         table="ringgo_permits",
         path=(
             "s3://dataplatform-prod-user-uploads/"
-            "parking/ringgo/permits/"
+            "parking/ringgo_permits/"
         ),
         columns_types={"id": "string"},
         mode="overwrite",
         skip_header_line_count=1,
+    )
+
+
+@patch.object(main, "delete_glue_table")
+@patch.object(
+    main.wr.s3,
+    "list_objects",
+    return_value=[
+        "s3://dataplatform-prod-user-uploads/"
+        "parking/ringgo_permits/february.csv"
+    ],
+)
+def test_process_delete_keeps_table_when_csv_files_remain(
+    list_objects: MagicMock,
+    delete_glue_table: MagicMock,
+) -> None:
+    """Keep the table while another CSV remains in its table folder."""
+    record = {
+        "eventName": "ObjectRemoved:Delete",
+        "s3": {
+            "bucket": {"name": "dataplatform-prod-user-uploads"},
+            "object": {
+                "key": "parking/ringgo_permits/january.csv",
+            },
+        },
+    }
+
+    assert main.process_single_event_record(
+        record, "parking_user_uploads_db"
+    ) == (True, False)
+    list_objects.assert_called_once_with(
+        path=(
+            "s3://dataplatform-prod-user-uploads/"
+            "parking/ringgo_permits/"
+        ),
+        suffix=".csv",
+    )
+    delete_glue_table.assert_not_called()
+
+
+@patch.object(main, "delete_glue_table")
+@patch.object(main.wr.s3, "list_objects", return_value=[])
+def test_process_delete_removes_table_after_last_csv(
+    _list_objects: MagicMock,
+    delete_glue_table: MagicMock,
+) -> None:
+    """Delete the table when no CSV files remain in its table folder."""
+    record = {
+        "eventName": "ObjectRemoved:Delete",
+        "s3": {
+            "bucket": {"name": "dataplatform-prod-user-uploads"},
+            "object": {
+                "key": "parking/ringgo_permits/january.csv",
+            },
+        },
+    }
+
+    assert main.process_single_event_record(
+        record, "parking_user_uploads_db"
+    ) == (True, False)
+    delete_glue_table.assert_called_once_with(
+        database_name="parking_user_uploads_db",
+        table_name="ringgo_permits",
     )


### PR DESCRIPTION
## Summary

This PR enables six departments to upload CSV files through the AWS Console and automatically create corresponding Glue Catalog tables.

## Changes

- Uses `<department>/<target_table_name>/<file_name>.csv` as the required S3 structure.
- Creates the table name from `<target_table_name>` and ignores the CSV filename.
- Treats multiple CSV files in the same table folder as one table.
- Rejects CSV files with an invalid folder structure.
- Deletes the Glue table only after the final CSV in its folder is removed.
- Removes Unrestricted from the automation.
- Limits Lambda permissions to the enabled departments.
- Adds tests for table creation, path validation and deletion behaviour.