### PR TITLE
Upgrade Liberator RDS MySQL to 8.4.10

### DIFF
--- a/terraform/modules/sql-to-rds-snapshot/30-rds.tf
+++ b/terraform/modules/sql-to-rds-snapshot/30-rds.tf
@@ -5,19 +5,20 @@ resource "aws_db_subnet_group" "default" {
 }
 
 resource "aws_db_instance" "ingestion_db" {
-  allocated_storage      = 15
-  max_allocated_storage  = 45
-  engine                 = "mysql"
-  engine_version         = "8.0"
-  instance_class         = "db.t3.small"
-  identifier             = var.instance_name
-  db_subnet_group_name   = aws_db_subnet_group.default.name
-  username               = "dataplatform"
-  password               = random_password.rds_password.result
-  skip_final_snapshot    = true
-  vpc_security_group_ids = [aws_security_group.snapshot_db.id]
-  apply_immediately      = true
-  ca_cert_identifier     = "rds-ca-rsa2048-g1"
+  allocated_storage           = 15
+  max_allocated_storage       = 45
+  engine                      = "mysql"
+  engine_version              = "8.4.10"
+  allow_major_version_upgrade = true
+  instance_class              = "db.t3.small"
+  identifier                  = var.instance_name
+  db_subnet_group_name        = aws_db_subnet_group.default.name
+  username                    = "dataplatform"
+  password                    = random_password.rds_password.result
+  skip_final_snapshot         = true
+  vpc_security_group_ids      = [aws_security_group.snapshot_db.id]
+  apply_immediately           = true
+  ca_cert_identifier          = "rds-ca-rsa2048-g1"
 }
 
 resource "random_password" "rds_password" {


### PR DESCRIPTION
## Summary

Following a reminder from Selwyn Preston about MySQL 8.0.42 reaching end of life, this upgrades the Liberator snapshot RDS databases in staging and production to MySQL 8.4.10.

- Pins the RDS engine to MySQL 8.4.10 (the latest version for now).
- Enables the required major-version upgrade.
- Avoids continued reliance on RDS Extended Support.