### PR TITLE
Move SSO Glue permissions to managed policies and add policy size checks

### DIFF
--- a/.github/actions/.helpers/check-sso-inline-policy-size.sh
+++ b/.github/actions/.helpers/check-sso-inline-policy-size.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly plan_path="${1:-plan.out}"
+readonly maximum_size=10240
+
+failed=0
+
+policy_sizes=$(
+  terraform show -json "$plan_path" |
+    jq -r '
+      .resource_changes[]?
+      | select(.type == "aws_ssoadmin_permission_set_inline_policy")
+      | select(.change.after != null)
+      | if (
+          .change.after_unknown.inline_policy? == true
+          or (.change.after.inline_policy | type) != "string"
+        )
+        then [.address, "unknown", 0]
+        else [
+          .address,
+          "known",
+          (.change.after.inline_policy | gsub("\\s"; "") | utf8bytelength)
+        ]
+        end
+      | @tsv
+    '
+)
+
+if [[ -n "$policy_sizes" ]]; then
+  while IFS=$'\t' read -r address status size; do
+    if [[ "$status" == "unknown" ]]; then
+      echo "::error title=SSO inline policy size unknown::${address} has an unknown inline_policy value, so its size cannot be checked."
+      failed=1
+    elif ((size > maximum_size)); then
+      echo "::error title=SSO inline policy too large::${address} contains ${size} non-whitespace UTF-8 bytes; the AWS maximum is ${maximum_size}."
+      failed=1
+    else
+      echo "${address}: ${size} non-whitespace UTF-8 bytes"
+    fi
+  done <<<"$policy_sizes"
+fi
+
+exit "$failed"

--- a/.github/actions/terraform-deploy/action.yml
+++ b/.github/actions/terraform-deploy/action.yml
@@ -109,6 +109,12 @@ runs:
       shell: bash
       working-directory: "${{ inputs.build_path }}"
 
+    - name: Check SSO inline policy sizes
+      run: |
+        bash "${{ github.action_path }}/../.helpers/check-sso-inline-policy-size.sh" plan.out
+      shell: bash
+      working-directory: "${{ inputs.build_path }}"
+
     - name: Terraform Apply
       id: apply
       run: |

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -102,3 +102,9 @@ runs:
         echo -e "\n"
       shell: bash
       working-directory: "${{ inputs.build_path }}"
+
+    - name: Check SSO inline policy sizes
+      run: |
+        bash "${{ github.action_path }}/../.helpers/check-sso-inline-policy-size.sh" plan.out
+      shell: bash
+      working-directory: "${{ inputs.build_path }}"

--- a/.github/workflows/plan-terraform.yml
+++ b/.github/workflows/plan-terraform.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v2.0.3
         with:
+          terraform_wrapper: false
           terraform_version: 1.2.0
 
       - name: Add a key to allow access to Infastructure

--- a/terraform/modules/department/50-aws-iam-policies.tf
+++ b/terraform/modules/department/50-aws-iam-policies.tf
@@ -722,6 +722,15 @@ data "aws_iam_policy_document" "glue_access_sso" {
   }
 }
 
+resource "aws_iam_policy" "glue_access_sso" {
+  count = var.environment == "stg" ? 1 : 0
+
+  tags = var.tags
+
+  name   = lower("${var.identifier_prefix}-${local.department_identifier}-glue-sso-access")
+  policy = data.aws_iam_policy_document.glue_access_sso.json
+}
+
 // Glue crawler access policy for staging environment only
 data "aws_iam_policy_document" "glue_crawler_access_staging" {
   statement {

--- a/terraform/modules/department/50-aws-iam-roles.tf
+++ b/terraform/modules/department/50-aws-iam-roles.tf
@@ -2,14 +2,12 @@
 data "aws_iam_policy_document" "sso_staging_user_policy" {
   override_policy_documents = local.create_notebook ? [
     data.aws_iam_policy_document.s3_department_access.json,
-    data.aws_iam_policy_document.glue_access_sso.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
     data.aws_iam_policy_document.redshift_department_read_access.json,
     data.aws_iam_policy_document.notebook_access[0].json,
     data.aws_iam_policy_document.glue_crawler_access_staging.json,
     ] : [
     data.aws_iam_policy_document.s3_department_access.json,
-    data.aws_iam_policy_document.glue_access_sso.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
     data.aws_iam_policy_document.redshift_department_read_access.json,
     data.aws_iam_policy_document.mwaa_department_web_server_access.json,
@@ -21,7 +19,6 @@ data "aws_iam_policy_document" "sso_staging_user_policy" {
 data "aws_iam_policy_document" "sso_production_user_policy" {
   override_policy_documents = [
     data.aws_iam_policy_document.read_only_s3_department_access.json,
-    data.aws_iam_policy_document.read_only_glue_access.json,
     data.aws_iam_policy_document.secrets_manager_read_only.json,
     data.aws_iam_policy_document.athena_can_write_to_s3.json,
     data.aws_iam_policy_document.mwaa_department_web_server_access_production.json,

--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -53,6 +53,20 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_glue_co
   }
 }
 
+resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_glue_access" {
+  count = local.deploy_sso ? 1 : 0
+
+  provider = aws.aws_hackit_account
+
+  instance_arn       = var.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
+
+  customer_managed_policy_reference {
+    name = var.environment == "stg" ? aws_iam_policy.glue_access_sso[0].name : aws_iam_policy.read_only_glue_access.name
+    path = "/"
+  }
+}
+
 # Attach CloudTrail access policy to SSO (data-and-insight only)
 resource "aws_ssoadmin_customer_managed_policy_attachment" "cloudtrail_access" {
   count = local.deploy_sso && local.department_identifier == "data-and-insight" && var.cloudtrail_bucket != null ? 1 : 0

--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -20,6 +20,10 @@ resource "aws_ssoadmin_permission_set_inline_policy" "department" {
 
   provider = aws.aws_hackit_account
 
+  depends_on = [
+    aws_ssoadmin_customer_managed_policy_attachment.departmental_glue_access
+  ]
+
   inline_policy      = var.environment == "stg" ? data.aws_iam_policy_document.sso_staging_user_policy.json : data.aws_iam_policy_document.sso_production_user_policy.json
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn


### PR DESCRIPTION
### Error

> Error: putting SSO Permission Set (arn:aws:sso:::permissionSet/ssoins-68042240bf234e38/ps-cbaf72fa18f4109e) Inline Policy: operation error SSO Admin: PutInlinePolicyToPermissionSet, https response error StatusCode: 400, RequestID: 07b84b77-2d2e-47c1-b8b8-6b40b37e0f0c, ValidationException: Current size of the non-whitespace characters present in the InlinePolicy Document is 10405 bytes which has exceeded the maximum limit of 10240 bytes

### Changes
- Moves existing Glue permissions out of departmental SSO inline policies.
- Reuses the existing production Glue policy and creates a dedicated staging SSO Glue policy.
- Preserves the existing actions, resources, conditions and environment-specific permissions.
- Adds CI validation for the AWS 10,240 non-whitespace byte inline policy limit.
- Fails validation when an inline policy size is unknown.

### CI validation
<img width="2564" height="772" alt="image" src="https://github.com/user-attachments/assets/67afc808-5362-42bd-a118-e084c078397f" />
