### PR TITLE
Support quoted CSV and direct TSV uploads in Glue Catalog automation

### DIFF
--- a/lambdas/csv_to_glue_catalog/main.py
+++ b/lambdas/csv_to_glue_catalog/main.py
@@ -302,7 +302,7 @@ def extract_csv_column_definitions(
             on_bad_lines="skip",
         )
     except Exception as error:
-        logger.error("Failed to read delimited file from S3: %s", error)
+        logger.exception("Failed to read delimited file from S3")
         raise ValueError(f"Unable to read delimited file: {error}") from error
 
     if len(df.columns) == 0:
@@ -677,9 +677,8 @@ def handle_sqs_event(event: dict[str, Any]) -> dict[str, Any]:
                 skipped_count += 1
                 logger.info(f"Skipped message {message_id}")
 
-        except Exception as e:
-            error_msg = f"Error processing SQS message {message_id}: {str(e)}"
-            logger.error(error_msg, exc_info=True)
+        except Exception:
+            logger.exception("Error processing SQS message %s", message_id)
             failed_message_ids.append(message_id)
 
     logger.info(

--- a/lambdas/csv_to_glue_catalog/main.py
+++ b/lambdas/csv_to_glue_catalog/main.py
@@ -1,4 +1,4 @@
-"""Synchronize user-uploaded CSV files with AWS Glue Catalog tables.
+"""Synchronize user-uploaded CSV and TSV files with AWS Glue Catalog tables.
 
 Inputs:
     Receives S3 object-created and object-removed events through SQS.
@@ -8,10 +8,12 @@ Outputs:
 
 Operational notes:
     All generated columns use the Glue ``string`` type. The recommended S3 key
-    format is ``<department>/<target_table_name>/<file.csv>``. Every CSV in a
-    target table folder contributes data to the same Glue table.
+    format is ``<department>/<target_table_name>/<file.csv|file.tsv>``. Every
+    file in a target table folder contributes data to the same Glue table and
+    must use the same extension and delimiter.
 """
 
+import csv
 import json
 import logging
 import re
@@ -21,17 +23,170 @@ from typing import Any
 from urllib.parse import unquote_plus
 
 import awswrangler as wr
+import boto3
 
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+OPEN_CSV_SERDE = "org.apache.hadoop.hive.serde2.OpenCSVSerde"
+QUOTE_CHARACTER = '"'
+ESCAPE_CHARACTER = "\\"
+CSV_SAMPLE_BYTE_COUNT = 65_536
+DEFAULT_CSV_DELIMITER = ","
+SUPPORTED_CSV_DELIMITERS = (",", "\t", "|")
+SUPPORTED_FILE_EXTENSIONS = (".csv", ".tsv")
+DELIMITER_NAMES = {
+    ",": "comma",
+    "\t": "tab",
+    "|": "pipe",
+}
+
+
+def read_csv_sample(bucket: str, key: str) -> str:
+    """Read the beginning of a CSV object for delimiter detection.
+
+    Args:
+        bucket: S3 bucket name.
+        key: S3 object key.
+
+    Returns:
+        UTF-8 decoded sample from the beginning of the object.
+
+    Raises:
+        ValueError: If the sample cannot be downloaded or decoded.
+    """
+    try:
+        response = boto3.client("s3").get_object(
+            Bucket=bucket,
+            Key=key,
+            Range=f"bytes=0-{CSV_SAMPLE_BYTE_COUNT - 1}",
+        )
+        sample_bytes = response["Body"].read()
+        return sample_bytes.decode("utf-8-sig")
+    except Exception as error:
+        logger.error("Failed to sample CSV from S3: %s", error)
+        raise ValueError(f"Unable to sample CSV file: {error}") from error
+
+
+def detect_delimiter_from_sample(sample: str) -> str:
+    """Detect a supported CSV delimiter from a text sample.
+
+    Args:
+        sample: Text sampled from the beginning of a CSV file.
+
+    Returns:
+        Detected comma, tab, or pipe delimiter.
+
+    Raises:
+        ValueError: If the sample is empty or its delimiter is unsupported or
+            ambiguous.
+    """
+    if not sample.strip():
+        raise ValueError("CSV file is empty")
+
+    try:
+        dialect = csv.Sniffer().sniff(
+            sample,
+            delimiters="".join(SUPPORTED_CSV_DELIMITERS),
+        )
+        return dialect.delimiter
+    except csv.Error:
+        header = next(
+            (line for line in sample.splitlines() if line.strip()),
+            "",
+        )
+        candidate_delimiters = [
+            delimiter
+            for delimiter in SUPPORTED_CSV_DELIMITERS
+            if len(
+                next(
+                    csv.reader(
+                        [header],
+                        delimiter=delimiter,
+                        quotechar=QUOTE_CHARACTER,
+                        escapechar=ESCAPE_CHARACTER,
+                    )
+                )
+            )
+            > 1
+        ]
+
+        if len(candidate_delimiters) == 1:
+            return candidate_delimiters[0]
+
+        if not candidate_delimiters and ";" not in header:
+            logger.warning(
+                "No delimiter found in a single-column CSV header; "
+                "defaulting to comma"
+            )
+            return DEFAULT_CSV_DELIMITER
+
+        raise ValueError(
+            "Unable to detect one supported CSV delimiter "
+            "(comma, tab, or pipe)"
+        )
+
+
+def detect_csv_delimiter(bucket: str, key: str) -> str:
+    """Detect the delimiter used by a CSV object in S3.
+
+    Args:
+        bucket: S3 bucket name.
+        key: S3 object key.
+
+    Returns:
+        Detected comma, tab, or pipe delimiter.
+    """
+    return detect_delimiter_from_sample(read_csv_sample(bucket, key))
+
+
+def get_supported_file_extension(file_path: str) -> str:
+    """Return the supported lowercase extension from a file path.
+
+    Args:
+        file_path: S3 key or URI ending with a file name.
+
+    Returns:
+        The lowercase ``.csv`` or ``.tsv`` extension.
+
+    Raises:
+        ValueError: If the extension is not supported.
+    """
+    extension = PurePosixPath(file_path).suffix
+    if extension not in SUPPORTED_FILE_EXTENSIONS:
+        raise ValueError(
+            "File must use a lowercase .csv or .tsv extension: "
+            f"{PurePosixPath(file_path).name}"
+        )
+
+    return extension
+
+
+def get_file_delimiter(bucket: str, key: str) -> str:
+    """Return the delimiter declared or detected for a supported file.
+
+    TSV files deterministically use Tab. CSV files retain content-based
+    delimiter detection for comma, Tab, or pipe.
+
+    Args:
+        bucket: S3 bucket name.
+        key: S3 object key.
+
+    Returns:
+        Delimiter used by the file.
+    """
+    if get_supported_file_extension(key) == ".tsv":
+        return "\t"
+
+    return detect_csv_delimiter(bucket, key)
 
 
 def parse_s3_key(s3_key: str) -> tuple[str, str]:
     """Extract the department and target table name from an S3 key.
 
     The required format is
-    ``<department>/<target_table_name>/<file.csv>``. The CSV file name does not
-    contribute to the Glue table name.
+    ``<department>/<target_table_name>/<file.csv|file.tsv>``. The file name
+    does not contribute to the Glue table name.
 
     Args:
         s3_key: URL-encoded S3 object key.
@@ -48,11 +203,10 @@ def parse_s3_key(s3_key: str) -> tuple[str, str]:
     if len(path.parts) != 3:
         raise ValueError(
             f"Invalid S3 key format: {s3_key}. Expected "
-            "<department>/<target_table_name>/<file.csv>"
+            "<department>/<target_table_name>/<file.csv|file.tsv>"
         )
 
-    if path.suffix != ".csv":
-        raise ValueError(f"File must be a CSV file: {path.name}")
+    get_supported_file_extension(decoded_key)
 
     department = path.parts[0]
     target_table_name = path.parts[1]
@@ -61,10 +215,10 @@ def parse_s3_key(s3_key: str) -> tuple[str, str]:
 
 
 def normalize_name(name: str, lowercase: bool = True) -> str:
-    """Normalize name by replacing all non-alphanumeric characters with underscores.
+    """Replace all non-alphanumeric name characters with underscores.
 
-    Strips accents, and converts to lowercase (optional). Consecutive non-alphanumeric
-    characters are replaced with a single underscore.
+    Strips accents, and converts to lowercase (optional). Consecutive
+    non-alphanumeric characters are replaced with a single underscore.
 
     Args:
         name: Original name (column name, file name, user name, etc.)
@@ -103,42 +257,53 @@ def deduplicate_column_names(columns: list[str]) -> list[str]:
     return deduped_headers
 
 
-def extract_csv_column_definitions(bucket: str, key: str) -> dict[str, str]:
-    """Extract column names from CSV header, normalize and deduplicate them.
+def extract_csv_column_definitions(
+    bucket: str,
+    key: str,
+    delimiter: str,
+) -> dict[str, str]:
+    """Extract, normalize, and deduplicate columns from a CSV or TSV file.
 
     Returns dictionary mapping column names to types (all string type).
 
     Args:
-        bucket: S3 bucket name
-        key: S3 object key (file path)
+        bucket: S3 bucket name.
+        key: S3 object key.
+        delimiter: Character separating fields in the file.
 
     Returns:
-        Dictionary mapping column names to types (all 'string')
+        Dictionary mapping column names to the Glue ``string`` type.
 
     Raises:
-        ValueError: If CSV file has no header row or empty header row
+        ValueError: If the file cannot be read or has an invalid header row.
     """
     s3_path = f"s3://{bucket}/{key}"
 
     try:
         df = wr.s3.read_csv(
             path=s3_path,
+            sep=delimiter,
+            quotechar=QUOTE_CHARACTER,
+            escapechar=ESCAPE_CHARACTER,
             nrows=1,
             use_threads=False,
             encoding="utf-8-sig",
             on_bad_lines="skip",
         )
-    except Exception as e:
-        logger.error(f"Failed to read CSV from S3: {e}")
-        raise ValueError(f"Unable to read CSV file: {e}") from e
+    except Exception as error:
+        logger.error("Failed to read delimited file from S3: %s", error)
+        raise ValueError(f"Unable to read delimited file: {error}") from error
 
     if len(df.columns) == 0:
-        raise ValueError("CSV file has no header row")
+        raise ValueError("File has no header row")
 
     column_names = list(df.columns)
 
-    if not column_names or all(not col or col.strip() == "" for col in column_names):
-        raise ValueError("CSV file has empty or invalid header row")
+    if not column_names or all(
+        not col or col.strip() == ""
+        for col in column_names
+    ):
+        raise ValueError("File has empty or invalid header row")
 
     normalized_headers = [normalize_name(col) for col in column_names]
     deduped_headers = deduplicate_column_names(normalized_headers)
@@ -151,7 +316,7 @@ def extract_csv_column_definitions(bucket: str, key: str) -> dict[str, str]:
 
     logger.info(
         f"A total of {len(columns_types)} column definitions were extracted "
-        "from the CSV header"
+        "from the file header"
     )
     return columns_types
 
@@ -162,15 +327,17 @@ def create_glue_table(
     bucket: str,
     s3_key: str,
     columns_types: dict[str, str],
+    delimiter: str,
 ) -> None:
-    """Create or recreate Glue Catalog table using AWS Data Wrangler.
+    """Create or recreate a Glue Catalog table for a CSV or TSV file.
 
     Args:
-        database_name: Glue database name
-        table_name: Glue table name
-        bucket: S3 bucket name
-        s3_key: S3 object key (file path)
-        columns_types: Dictionary mapping column names to types
+        database_name: Glue database name.
+        table_name: Glue table name.
+        bucket: S3 bucket name.
+        s3_key: S3 object key.
+        columns_types: Dictionary mapping column names to types.
+        delimiter: Character separating fields in the file.
     """
     s3_location = build_s3_directory_location(bucket, s3_key)
 
@@ -180,11 +347,17 @@ def create_glue_table(
         path=s3_location,
         columns_types=columns_types,
         mode="overwrite",
+        sep=delimiter,
         skip_header_line_count=1,
+        serde_library=OPEN_CSV_SERDE,
+        serde_parameters={
+            "separatorChar": delimiter,
+            "quoteChar": QUOTE_CHARACTER,
+            "escapeChar": ESCAPE_CHARACTER,
+        },
     )
-    logger.info(
-        f"Successfully created table: {table_name} in database: {database_name}"
-    )
+    logger.info("Successfully created table: %s in database: %s",
+                table_name, database_name)
 
 
 def build_s3_directory_location(bucket: str, s3_key: str) -> str:
@@ -201,6 +374,95 @@ def build_s3_directory_location(bucket: str, s3_key: str) -> str:
     return f"s3://{bucket}/{s3_directory}/"
 
 
+def list_table_files(bucket: str, s3_key: str) -> list[str]:
+    """List supported lowercase files in the object's table folder.
+
+    Args:
+        bucket: S3 bucket name.
+        s3_key: S3 object key.
+
+    Returns:
+        S3 URIs for lowercase CSV and TSV files in the table folder.
+    """
+    return wr.s3.list_objects(
+        path=build_s3_directory_location(bucket, s3_key),
+        suffix=list(SUPPORTED_FILE_EXTENSIONS),
+    )
+
+
+def detect_table_delimiter(bucket: str, file_paths: list[str]) -> str:
+    """Require all files in a table folder to use one format and delimiter.
+
+    Args:
+        bucket: S3 bucket name.
+        file_paths: S3 URIs for files in one table folder.
+
+    Returns:
+        The single delimiter detected across the table folder.
+
+    Raises:
+        ValueError: If no files remain or extensions or delimiters are mixed.
+    """
+    if not file_paths:
+        raise ValueError(
+            "No CSV or TSV files remain in the target table folder"
+        )
+
+    file_keys = [
+        get_s3_key_from_uri(file_path, bucket)
+        for file_path in file_paths
+    ]
+    extensions = {
+        get_supported_file_extension(file_key)
+        for file_key in file_keys
+    }
+    if len(extensions) != 1:
+        raise ValueError(
+            "All files in a target table folder must use the same extension; "
+            f"detected: {', '.join(sorted(extensions))}"
+        )
+
+    delimiters = {
+        get_file_delimiter(
+            bucket,
+            file_key,
+        )
+        for file_key in file_keys
+    }
+    if len(delimiters) != 1:
+        delimiter_names = ", ".join(
+            sorted(DELIMITER_NAMES[delimiter] for delimiter in delimiters)
+        )
+        raise ValueError(
+            "All files in a target table folder must use the same "
+            f"delimiter; detected: {delimiter_names}"
+        )
+
+    return next(iter(delimiters))
+
+
+def get_s3_key_from_uri(s3_uri: str, bucket: str) -> str:
+    """Extract an object key from an S3 URI in the expected bucket.
+
+    Args:
+        s3_uri: Fully qualified S3 object URI.
+        bucket: Expected S3 bucket name.
+
+    Returns:
+        Object key without the bucket prefix.
+
+    Raises:
+        ValueError: If the URI is not in the expected bucket.
+    """
+    bucket_prefix = f"s3://{bucket}/"
+    if not s3_uri.startswith(bucket_prefix):
+        raise ValueError(
+            f"Unexpected S3 URI returned while listing files: {s3_uri}"
+        )
+
+    return s3_uri.removeprefix(bucket_prefix)
+
+
 def delete_glue_table(database_name: str, table_name: str) -> None:
     """Delete Glue Catalog table using AWS Data Wrangler.
 
@@ -209,9 +471,8 @@ def delete_glue_table(database_name: str, table_name: str) -> None:
         table_name: Glue table name
     """
     wr.catalog.delete_table_if_exists(database=database_name, table=table_name)
-    logger.info(
-        f"Successfully deleted table: {table_name} from database: {database_name}"
-    )
+    logger.info("Successfully deleted table: %s from database: %s",
+                table_name, database_name)
 
 
 def process_single_event_record(
@@ -239,20 +500,32 @@ def process_single_event_record(
         return False, True
 
     decoded_s3_key = unquote_plus(s3_key)
-    logger.info(f"Processing event: {event_name} for s3://{bucket}/{decoded_s3_key}")
+    logger.info(
+        "Processing event: %s for s3://%s/%s",
+        event_name,
+        bucket,
+        decoded_s3_key,
+    )
 
     _, target_table_name = parse_s3_key(s3_key)
     table_name = normalize_name(target_table_name)
 
     if not table_name:
         raise ValueError(
-            f"Target table folder must contain alphanumeric characters: {s3_key}"
+            "Target table folder must contain alphanumeric characters: "
+            f"{s3_key}"
         )
 
     if event_name.startswith("ObjectCreated"):
         logger.info(f"Creating/updating table: {table_name}")
 
-        columns_types = extract_csv_column_definitions(bucket, decoded_s3_key)
+        table_files = list_table_files(bucket, decoded_s3_key)
+        delimiter = detect_table_delimiter(bucket, table_files)
+        columns_types = extract_csv_column_definitions(
+            bucket,
+            decoded_s3_key,
+            delimiter,
+        )
 
         create_glue_table(
             database_name=database_name,
@@ -260,24 +533,39 @@ def process_single_event_record(
             bucket=bucket,
             s3_key=decoded_s3_key,
             columns_types=columns_types,
+            delimiter=delimiter,
         )
 
-        logger.info(
-            f"Successfully processed upload: {decoded_s3_key} -> table: {table_name}"
-        )
+        logger.info("Successfully processed upload: %s -> table: %s",
+                    decoded_s3_key, table_name)
         return True, False
 
-    elif event_name.startswith("ObjectRemoved"):
+    if event_name.startswith("ObjectRemoved"):
         s3_location = build_s3_directory_location(bucket, decoded_s3_key)
-        remaining_csv_files = wr.s3.list_objects(
-            path=s3_location,
-            suffix=".csv",
-        )
+        remaining_files = list_table_files(bucket, decoded_s3_key)
 
-        if remaining_csv_files:
+        if remaining_files:
+            delimiter = detect_table_delimiter(bucket, remaining_files)
+            remaining_s3_key = get_s3_key_from_uri(
+                sorted(remaining_files)[0],
+                bucket,
+            )
+            columns_types = extract_csv_column_definitions(
+                bucket,
+                remaining_s3_key,
+                delimiter,
+            )
+            create_glue_table(
+                database_name=database_name,
+                table_name=table_name,
+                bucket=bucket,
+                s3_key=remaining_s3_key,
+                columns_types=columns_types,
+                delimiter=delimiter,
+            )
             logger.info(
-                f"Keeping table: {table_name}; "
-                f"{len(remaining_csv_files)} CSV file(s) remain in {s3_location}"
+                f"Rebuilt table: {table_name}; {len(remaining_files)} "
+                f"supported file(s) remain in {s3_location}"
             )
             return True, False
 
@@ -291,12 +579,13 @@ def process_single_event_record(
         )
         return True, False
 
-    else:
-        logger.warning(f"Unsupported event type: {event_name}")
-        return False, True
+    logger.warning(f"Unsupported event type: {event_name}")
+    return False, True
 
 
-def extract_s3_event_from_sqs_record(sqs_record: dict[str, Any]) -> dict[str, Any]:
+def extract_s3_event_from_sqs_record(
+    sqs_record: dict[str, Any],
+) -> dict[str, Any]:
     """Extract S3 event from SQS message body.
 
     Args:
@@ -317,7 +606,8 @@ def extract_s3_event_from_sqs_record(sqs_record: dict[str, Any]) -> dict[str, An
 def handle_sqs_event(event: dict[str, Any]) -> dict[str, Any]:
     """Handle SQS event containing S3 event notifications.
 
-    Process each SQS message, extract S3 events, and handle partial batch failures.
+    Process each SQS message, extract S3 events, and handle partial batch
+    failures.
 
     Args:
         event: SQS event dictionary containing Records array of SQS messages
@@ -341,21 +631,28 @@ def handle_sqs_event(event: dict[str, Any]) -> dict[str, Any]:
             s3_event_record = extract_s3_event_from_sqs_record(sqs_record)
 
             if not s3_event_record:
-                logger.warning(f"No S3 event found in SQS message {message_id}")
+                logger.warning(
+                    "No S3 event found in SQS message %s",
+                    message_id,
+                )
                 skipped_count += 1
                 continue
 
             s3_key = (
-                s3_event_record.get("s3", {}).get("object", {}).get("key", "unknown")
+                s3_event_record.get("s3", {})
+                .get("object", {})
+                .get("key", "unknown")
             )
             logger.info(f"Processing file from message {message_id}: {s3_key}")
 
-            # Extract and normalize department from S3 path to construct database name
+            # Normalize the S3 department to construct the database name.
             department, _ = parse_s3_key(s3_key)
             normalized_dept = department.replace("-", "_")
             database_name = f"{normalized_dept}_user_uploads_db"
             logger.info(
-                f"Using database '{database_name}' for department '{department}'"
+                "Using database '%s' for department '%s'",
+                database_name,
+                department,
             )
 
             was_processed, was_skipped = process_single_event_record(

--- a/lambdas/csv_to_glue_catalog/main.py
+++ b/lambdas/csv_to_glue_catalog/main.py
@@ -16,6 +16,7 @@ Operational notes:
 import csv
 import json
 import logging
+import os
 import re
 import unicodedata
 from pathlib import PurePosixPath
@@ -24,6 +25,7 @@ from urllib.parse import unquote_plus
 
 import awswrangler as wr
 import boto3
+from botocore.config import Config
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -35,11 +37,19 @@ CSV_SAMPLE_BYTE_COUNT = 65_536
 DEFAULT_CSV_DELIMITER = ","
 SUPPORTED_CSV_DELIMITERS = (",", "\t", "|")
 SUPPORTED_FILE_EXTENSIONS = (".csv", ".tsv")
+EXPECTED_BUCKET_OWNER = os.environ["EXPECTED_BUCKET_OWNER"]
 DELIMITER_NAMES = {
     ",": "comma",
     "\t": "tab",
     "|": "pipe",
 }
+S3_CLIENT = boto3.client(
+    "s3",
+    config=Config(
+        connect_timeout=3,
+        read_timeout=10,
+    ),
+)
 
 
 def read_csv_sample(bucket: str, key: str) -> str:
@@ -56,15 +66,16 @@ def read_csv_sample(bucket: str, key: str) -> str:
         ValueError: If the sample cannot be downloaded or decoded.
     """
     try:
-        response = boto3.client("s3").get_object(
+        response = S3_CLIENT.get_object(
             Bucket=bucket,
             Key=key,
             Range=f"bytes=0-{CSV_SAMPLE_BYTE_COUNT - 1}",
+            ExpectedBucketOwner=EXPECTED_BUCKET_OWNER,
         )
         sample_bytes = response["Body"].read()
         return sample_bytes.decode("utf-8-sig")
     except Exception as error:
-        logger.error("Failed to sample CSV from S3: %s", error)
+        logger.exception("Failed to sample CSV from S3")
         raise ValueError(f"Unable to sample CSV file: {error}") from error
 
 

--- a/terraform/etl/62-lambda-csv-to-glue-catalog.tf
+++ b/terraform/etl/62-lambda-csv-to-glue-catalog.tf
@@ -160,7 +160,7 @@ module "csv_to_glue_catalog_lambda" {
   ]
   description = "Automatically creates/deletes Glue Catalog tables when CSV or TSV files are uploaded/deleted in user_uploads bucket"
   environment_variables = {
-    GLUE_DATABASE_NAME = "parking_user_uploads_db"
+    EXPECTED_BUCKET_OWNER = data.aws_caller_identity.data_platform.account_id
   }
   tags = module.tags.values
 }

--- a/terraform/etl/62-lambda-csv-to-glue-catalog.tf
+++ b/terraform/etl/62-lambda-csv-to-glue-catalog.tf
@@ -1,5 +1,5 @@
 # Lambda function to automatically create/delete Glue Catalog tables
-# Workflow: S3 CSV upload/delete → SQS → Lambda → Glue Catalog table create/delete (retry once on failure → DLQ)
+# Workflow: S3 CSV/TSV upload/delete → SQS → Lambda → Glue Catalog table create/delete (retry once on failure → DLQ)
 
 locals {
   department_user_uploads_prefixes = {
@@ -9,6 +9,18 @@ locals {
     child_fam_services = "child-fam-services/"
     env_services       = "env-services/"
     revenues           = "revenues/"
+  }
+
+  supported_user_uploads_file_extensions = [".csv", ".tsv"]
+
+  user_uploads_notification_filters = {
+    for filter in setproduct(
+      keys(local.department_user_uploads_prefixes),
+      local.supported_user_uploads_file_extensions
+      ) : "${filter[0]}_${trimprefix(filter[1], ".")}" => {
+      prefix = local.department_user_uploads_prefixes[filter[0]]
+      suffix = filter[1]
+    }
   }
 
   enabled_department_user_uploads_databases = {
@@ -146,7 +158,7 @@ module "csv_to_glue_catalog_lambda" {
   layers = [
     "arn:aws:lambda:${data.aws_region.current.name}:336392948345:layer:AWSSDKPandas-Python311:20"
   ]
-  description = "Automatically creates/deletes Glue Catalog tables when CSV files are uploaded/deleted in user_uploads bucket"
+  description = "Automatically creates/deletes Glue Catalog tables when CSV or TSV files are uploaded/deleted in user_uploads bucket"
   environment_variables = {
     GLUE_DATABASE_NAME = "parking_user_uploads_db"
   }
@@ -203,12 +215,12 @@ resource "aws_s3_bucket_notification" "user_uploads_csv_notification" {
   bucket = module.user_uploads_data_source.bucket_id
 
   dynamic "queue" {
-    for_each = local.department_user_uploads_prefixes
+    for_each = local.user_uploads_notification_filters
     content {
       queue_arn     = aws_sqs_queue.csv_to_glue_catalog_events.arn
       events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:*"]
-      filter_prefix = queue.value
-      filter_suffix = ".csv"
+      filter_prefix = queue.value.prefix
+      filter_suffix = queue.value.suffix
     }
   }
 

--- a/tests/lambdas/test_csv_to_glue_catalog.py
+++ b/tests/lambdas/test_csv_to_glue_catalog.py
@@ -1,6 +1,7 @@
 """Tests for the user-uploaded CSV and TSV to Glue Catalog Lambda."""
 
 import json
+import os
 from importlib.util import module_from_spec, spec_from_file_location
 from io import StringIO
 from pathlib import Path
@@ -15,18 +16,34 @@ LAMBDA_PATH = (
 )
 
 
-def load_lambda_module() -> ModuleType:
+def load_lambda_module() -> tuple[ModuleType, MagicMock]:
     """Load the Lambda module without relying on its directory in sys.path."""
     spec = spec_from_file_location("csv_to_glue_catalog_main", LAMBDA_PATH)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load Lambda module from {LAMBDA_PATH}")
 
     module = module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    with (
+        patch.dict(
+            os.environ,
+            {"EXPECTED_BUCKET_OWNER": "123456789012"},
+        ),
+        patch("boto3.client") as boto3_client,
+    ):
+        spec.loader.exec_module(module)
+    return module, boto3_client
 
 
-main = load_lambda_module()
+main, boto3_client = load_lambda_module()
+
+
+def test_s3_client_is_initialized_once_with_explicit_timeouts() -> None:
+    """Configure the reusable S3 client with bounded network timeouts."""
+    boto3_client.assert_called_once()
+    assert boto3_client.call_args.args == ("s3",)
+    config = boto3_client.call_args.kwargs["config"]
+    assert config.connect_timeout == 3
+    assert config.read_timeout == 10
 
 
 def test_parse_s3_key_uses_target_table_folder() -> None:
@@ -109,14 +126,13 @@ def test_detect_delimiter_rejects_semicolon_delimited_content() -> None:
         main.detect_delimiter_from_sample(sample)
 
 
-@patch.object(main.boto3, "client")
+@patch.object(main, "S3_CLIENT")
 def test_read_csv_sample_uses_bounded_s3_range(
-    boto3_client: MagicMock,
+    s3_client: MagicMock,
 ) -> None:
-    """Read only the first 64 KiB and decode an optional UTF-8 BOM."""
+    """Read a bounded sample from the expected bucket owner."""
     body = MagicMock()
     body.read.return_value = b"\xef\xbb\xbfid|description\n"
-    s3_client = boto3_client.return_value
     s3_client.get_object.return_value = {"Body": body}
 
     sample = main.read_csv_sample(
@@ -129,6 +145,7 @@ def test_read_csv_sample_uses_bounded_s3_range(
         Bucket="dataplatform-prod-user-uploads",
         Key="parking/notes/notes.csv",
         Range="bytes=0-65535",
+        ExpectedBucketOwner="123456789012",
     )
 
 

--- a/tests/lambdas/test_csv_to_glue_catalog.py
+++ b/tests/lambdas/test_csv_to_glue_catalog.py
@@ -1,11 +1,13 @@
-"""Tests for the user-uploaded CSV to Glue Catalog Lambda."""
+"""Tests for the user-uploaded CSV and TSV to Glue Catalog Lambda."""
 
 import json
 from importlib.util import module_from_spec, spec_from_file_location
+from io import StringIO
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 LAMBDA_PATH = (
@@ -14,7 +16,7 @@ LAMBDA_PATH = (
 
 
 def load_lambda_module() -> ModuleType:
-    """Load the Lambda module without relying on its directory being on sys.path."""
+    """Load the Lambda module without relying on its directory in sys.path."""
     spec = spec_from_file_location("csv_to_glue_catalog_main", LAMBDA_PATH)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load Lambda module from {LAMBDA_PATH}")
@@ -28,12 +30,12 @@ main = load_lambda_module()
 
 
 def test_parse_s3_key_uses_target_table_folder() -> None:
-    """Use the table folder and ignore different CSV file names."""
+    """Use the table folder and ignore different supported file names."""
     january_result = main.parse_s3_key(
         "parking/ringgo_permits/january.csv"
     )
     february_result = main.parse_s3_key(
-        "parking/ringgo_permits/february.csv"
+        "parking/ringgo_permits/february.tsv"
     )
 
     assert january_result == ("parking", "ringgo_permits")
@@ -52,10 +54,261 @@ def test_parse_s3_key_rejects_nested_paths() -> None:
         main.parse_s3_key("parking/ringgo/permits/permits_march.csv")
 
 
-def test_parse_s3_key_rejects_non_csv_files() -> None:
-    """Reject files that do not have the lowercase CSV extension."""
-    with pytest.raises(ValueError, match="File must be a CSV"):
-        main.parse_s3_key("parking/ringgo_permits/permits.xlsx")
+@pytest.mark.parametrize("extension", [".xlsx", ".CSV", ".TSV", ".psv"])
+def test_parse_s3_key_rejects_unsupported_or_uppercase_extensions(
+    extension: str,
+) -> None:
+    """Accept only lowercase CSV and TSV extensions."""
+    with pytest.raises(
+        ValueError,
+        match=r"lowercase \.csv or \.tsv extension",
+    ):
+        main.parse_s3_key(f"parking/ringgo_permits/permits{extension}")
+
+
+@pytest.mark.parametrize(
+    ("sample", "expected_delimiter"),
+    [
+        (
+            "id,description\n"
+            '1,"Secondary carer, residential care, or another caring role"\n',
+            ",",
+        ),
+        (
+            "id\tdescription\n"
+            '1\t"Secondary carer, residential care, or another caring role"\n',
+            "\t",
+        ),
+        (
+            "id|description\n"
+            '1|"Secondary carer, residential care, or another caring role"\n',
+            "|",
+        ),
+    ],
+)
+def test_detect_delimiter_from_csv_content(
+    sample: str,
+    expected_delimiter: str,
+) -> None:
+    """Detect comma, tab, or pipe while respecting quoted commas."""
+    assert main.detect_delimiter_from_sample(sample) == expected_delimiter
+
+
+def test_detect_delimiter_defaults_single_column_csv_to_comma() -> None:
+    """Use comma metadata when a one-column CSV has no separator to detect."""
+    sample = 'description\n"One value"\n"Another value"\n'
+
+    assert main.detect_delimiter_from_sample(sample) == ","
+
+
+def test_detect_delimiter_rejects_semicolon_delimited_content() -> None:
+    """Reject a delimiter outside the supported comma, tab, and pipe set."""
+    sample = "id;description\n1;Unsupported delimiter\n"
+
+    with pytest.raises(ValueError, match="comma, tab, or pipe"):
+        main.detect_delimiter_from_sample(sample)
+
+
+@patch.object(main.boto3, "client")
+def test_read_csv_sample_uses_bounded_s3_range(
+    boto3_client: MagicMock,
+) -> None:
+    """Read only the first 64 KiB and decode an optional UTF-8 BOM."""
+    body = MagicMock()
+    body.read.return_value = b"\xef\xbb\xbfid|description\n"
+    s3_client = boto3_client.return_value
+    s3_client.get_object.return_value = {"Body": body}
+
+    sample = main.read_csv_sample(
+        "dataplatform-prod-user-uploads",
+        "parking/notes/notes.csv",
+    )
+
+    assert sample == "id|description\n"
+    s3_client.get_object.assert_called_once_with(
+        Bucket="dataplatform-prod-user-uploads",
+        Key="parking/notes/notes.csv",
+        Range="bytes=0-65535",
+    )
+
+
+@patch.object(main, "read_csv_sample")
+def test_get_file_delimiter_uses_tab_for_tsv_without_sampling(
+    read_csv_sample: MagicMock,
+) -> None:
+    """Treat the TSV extension as an explicit Tab delimiter declaration."""
+    assert main.get_file_delimiter(
+        "dataplatform-prod-user-uploads",
+        "parking/notes/notes.tsv",
+    ) == "\t"
+    read_csv_sample.assert_not_called()
+
+
+@patch.object(main, "detect_csv_delimiter", return_value="|")
+def test_get_file_delimiter_detects_csv_content(
+    detect_csv_delimiter: MagicMock,
+) -> None:
+    """Retain content-based delimiter detection for CSV files."""
+    assert main.get_file_delimiter(
+        "dataplatform-prod-user-uploads",
+        "parking/notes/notes.csv",
+    ) == "|"
+    detect_csv_delimiter.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        "parking/notes/notes.csv",
+    )
+
+
+def test_extract_csv_columns_preserves_quoted_commas() -> None:
+    """Treat a comma inside a double-quoted value as field content."""
+    csv_text = (
+        "id,description\n"
+        '1,"Secondary carer, residential care, or another caring role"\n'
+    )
+
+    def read_csv_with_lambda_dialect(**kwargs: object) -> pd.DataFrame:
+        """Read the fixture using the dialect passed to AWS Wrangler."""
+        pandas_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"path", "use_threads"}
+        }
+        data_frame = pd.read_csv(StringIO(csv_text), **pandas_kwargs)
+        assert data_frame.loc[0, "description"] == (
+            "Secondary carer, residential care, or another caring role"
+        )
+        return data_frame
+
+    with patch.object(
+        main.wr.s3,
+        "read_csv",
+        side_effect=read_csv_with_lambda_dialect,
+    ):
+        columns = main.extract_csv_column_definitions(
+            "dataplatform-prod-user-uploads",
+            "parking/caring/caring.csv",
+            ",",
+        )
+
+    assert columns == {"id": "string", "description": "string"}
+
+
+def test_extract_tsv_columns_preserves_unquoted_commas() -> None:
+    """Treat commas in a Google Sheets TSV value as normal field content."""
+    tsv_text = (
+        "id\tdescription\n"
+        "1\tSecondary carer, residential care, or another caring role\n"
+    )
+
+    def read_tsv_with_lambda_dialect(**kwargs: object) -> pd.DataFrame:
+        """Read the fixture using the dialect passed to AWS Wrangler."""
+        pandas_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key not in {"path", "use_threads"}
+        }
+        data_frame = pd.read_csv(StringIO(tsv_text), **pandas_kwargs)
+        assert data_frame.loc[0, "description"] == (
+            "Secondary carer, residential care, or another caring role"
+        )
+        return data_frame
+
+    with patch.object(
+        main.wr.s3,
+        "read_csv",
+        side_effect=read_tsv_with_lambda_dialect,
+    ):
+        columns = main.extract_csv_column_definitions(
+            "dataplatform-prod-user-uploads",
+            "parking/caring/caring.tsv",
+            "\t",
+        )
+
+    assert columns == {"id": "string", "description": "string"}
+
+
+@pytest.mark.parametrize("delimiter", ["\t", "|"])
+@patch.object(main.wr.s3, "read_csv")
+def test_extract_columns_uses_detected_delimiter(
+    read_csv: MagicMock,
+    delimiter: str,
+) -> None:
+    """Use the detected delimiter with the shared quote and escape rules."""
+    read_csv.return_value = SimpleNamespace(columns=["id", "description"])
+
+    columns = main.extract_csv_column_definitions(
+        "dataplatform-prod-user-uploads",
+        "parking/notes/notes.csv",
+        delimiter,
+    )
+
+    assert columns == {"id": "string", "description": "string"}
+    read_csv.assert_called_once_with(
+        path=(
+            "s3://dataplatform-prod-user-uploads/"
+            "parking/notes/notes.csv"
+        ),
+        sep=delimiter,
+        quotechar='"',
+        escapechar="\\",
+        nrows=1,
+        use_threads=False,
+        encoding="utf-8-sig",
+        on_bad_lines="skip",
+    )
+
+
+@patch.object(main, "get_file_delimiter", side_effect=[",", ","])
+def test_detect_table_delimiter_accepts_matching_csv_files(
+    get_file_delimiter: MagicMock,
+) -> None:
+    """Return the common delimiter used by all CSV files in a table folder."""
+    file_paths = [
+        "s3://dataplatform-prod-user-uploads/parking/permits/january.csv",
+        "s3://dataplatform-prod-user-uploads/parking/permits/february.csv",
+    ]
+
+    assert main.detect_table_delimiter(
+        "dataplatform-prod-user-uploads",
+        file_paths,
+    ) == ","
+    assert get_file_delimiter.call_count == 2
+
+
+@patch.object(main, "get_file_delimiter", side_effect=[",", "|"])
+def test_detect_table_delimiter_rejects_mixed_delimiters(
+    _get_file_delimiter: MagicMock,
+) -> None:
+    """Reject a table folder containing CSV files with different delimiters."""
+    file_paths = [
+        "s3://dataplatform-prod-user-uploads/parking/permits/january.csv",
+        "s3://dataplatform-prod-user-uploads/parking/permits/february.csv",
+    ]
+
+    with pytest.raises(ValueError, match="same delimiter"):
+        main.detect_table_delimiter(
+            "dataplatform-prod-user-uploads",
+            file_paths,
+        )
+
+
+@patch.object(main, "get_file_delimiter")
+def test_detect_table_delimiter_rejects_mixed_extensions(
+    get_file_delimiter: MagicMock,
+) -> None:
+    """Reject mixed CSV and TSV files before inspecting their delimiters."""
+    file_paths = [
+        "s3://dataplatform-prod-user-uploads/parking/permits/january.csv",
+        "s3://dataplatform-prod-user-uploads/parking/permits/february.tsv",
+    ]
+
+    with pytest.raises(ValueError, match="same extension"):
+        main.detect_table_delimiter(
+            "dataplatform-prod-user-uploads",
+            file_paths,
+        )
+
+    get_file_delimiter.assert_not_called()
 
 
 def test_handle_sqs_event_reports_invalid_path_as_batch_failure() -> None:
@@ -87,19 +340,34 @@ def test_handle_sqs_event_reports_invalid_path_as_batch_failure() -> None:
     }
 
 
-@patch.object(main, "extract_csv_column_definitions", return_value={"id": "string"})
+@patch.object(main, "detect_table_delimiter", return_value="\t")
+@patch.object(
+    main,
+    "list_table_files",
+    return_value=[
+        "s3://dataplatform-prod-user-uploads/"
+        "parking/ringgo_permits/permits_march.tsv"
+    ],
+)
+@patch.object(
+    main,
+    "extract_csv_column_definitions",
+    return_value={"id": "string"},
+)
 @patch.object(main, "create_glue_table")
-def test_process_record_creates_table_from_target_table_folder(
+def test_process_upload_uses_detected_delimiter(
     create_glue_table: MagicMock,
-    _extract_csv_column_definitions: MagicMock,
+    extract_csv_column_definitions: MagicMock,
+    list_table_files: MagicMock,
+    detect_table_delimiter: MagicMock,
 ) -> None:
-    """Create a table named after the target table folder."""
+    """Use one detected delimiter for header parsing and Glue metadata."""
     record = {
         "eventName": "ObjectCreated:Put",
         "s3": {
             "bucket": {"name": "dataplatform-prod-user-uploads"},
             "object": {
-                "key": "parking/ringgo_permits/permits_march.csv",
+                "key": "parking/ringgo_permits/permits_march.tsv",
             },
         },
     }
@@ -107,26 +375,83 @@ def test_process_record_creates_table_from_target_table_folder(
     assert main.process_single_event_record(
         record, "parking_user_uploads_db"
     ) == (True, False)
+    list_table_files.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        "parking/ringgo_permits/permits_march.tsv",
+    )
+    detect_table_delimiter.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        [
+            "s3://dataplatform-prod-user-uploads/"
+            "parking/ringgo_permits/permits_march.tsv"
+        ],
+    )
+    extract_csv_column_definitions.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        "parking/ringgo_permits/permits_march.tsv",
+        "\t",
+    )
     create_glue_table.assert_called_once_with(
         database_name="parking_user_uploads_db",
         table_name="ringgo_permits",
         bucket="dataplatform-prod-user-uploads",
-        s3_key="parking/ringgo_permits/permits_march.csv",
+        s3_key="parking/ringgo_permits/permits_march.tsv",
         columns_types={"id": "string"},
+        delimiter="\t",
     )
 
 
-@patch.object(main.wr.catalog, "create_csv_table")
-def test_create_glue_table_uses_target_table_folder_as_location(
-    create_csv_table: MagicMock,
+@patch.object(main, "create_glue_table")
+@patch.object(main, "extract_csv_column_definitions")
+@patch.object(
+    main,
+    "detect_table_delimiter",
+    side_effect=ValueError("All files must use the same delimiter"),
+)
+@patch.object(
+    main,
+    "list_table_files",
+    return_value=[
+        "s3://dataplatform-prod-user-uploads/parking/notes/january.csv",
+        "s3://dataplatform-prod-user-uploads/parking/notes/february.csv",
+    ],
+)
+def test_process_upload_rejects_mixed_delimiters_without_overwriting_table(
+    _list_table_files: MagicMock,
+    _detect_table_delimiter: MagicMock,
+    extract_csv_column_definitions: MagicMock,
+    create_glue_table: MagicMock,
 ) -> None:
-    """Point the Glue table at its dedicated target table folder."""
+    """Reject mixed delimiters before reading or replacing Glue metadata."""
+    record = {
+        "eventName": "ObjectCreated:Put",
+        "s3": {
+            "bucket": {"name": "dataplatform-prod-user-uploads"},
+            "object": {"key": "parking/notes/february.csv"},
+        },
+    }
+
+    with pytest.raises(ValueError, match="same delimiter"):
+        main.process_single_event_record(record, "parking_user_uploads_db")
+
+    extract_csv_column_definitions.assert_not_called()
+    create_glue_table.assert_not_called()
+
+
+@pytest.mark.parametrize("delimiter", [",", "\t", "|"])
+@patch.object(main.wr.catalog, "create_csv_table")
+def test_create_glue_table_uses_detected_csv_dialect(
+    create_csv_table: MagicMock,
+    delimiter: str,
+) -> None:
+    """Configure OpenCSVSerde with the detected CSV delimiter."""
     main.create_glue_table(
         database_name="parking_user_uploads_db",
         table_name="ringgo_permits",
         bucket="dataplatform-prod-user-uploads",
         s3_key="parking/ringgo_permits/permits_march.csv",
         columns_types={"id": "string"},
+        delimiter=delimiter,
     )
 
     create_csv_table.assert_called_once_with(
@@ -138,30 +463,67 @@ def test_create_glue_table_uses_target_table_folder_as_location(
         ),
         columns_types={"id": "string"},
         mode="overwrite",
+        sep=delimiter,
         skip_header_line_count=1,
+        serde_library="org.apache.hadoop.hive.serde2.OpenCSVSerde",
+        serde_parameters={
+            "separatorChar": delimiter,
+            "quoteChar": '"',
+            "escapeChar": "\\",
+        },
+    )
+
+
+@patch.object(main.wr.s3, "list_objects")
+def test_list_table_files_uses_lowercase_csv_and_tsv_suffixes(
+    list_objects: MagicMock,
+) -> None:
+    """List only lowercase CSV and TSV files that can contribute to a table."""
+    list_objects.return_value = []
+
+    assert main.list_table_files(
+        "dataplatform-prod-user-uploads",
+        "parking/ringgo_permits/january.csv",
+    ) == []
+    list_objects.assert_called_once_with(
+        path=(
+            "s3://dataplatform-prod-user-uploads/"
+            "parking/ringgo_permits/"
+        ),
+        suffix=[".csv", ".tsv"],
     )
 
 
 @patch.object(main, "delete_glue_table")
+@patch.object(main, "create_glue_table")
 @patch.object(
-    main.wr.s3,
-    "list_objects",
+    main,
+    "extract_csv_column_definitions",
+    return_value={"id": "string"},
+)
+@patch.object(main, "detect_table_delimiter", return_value="\t")
+@patch.object(
+    main,
+    "list_table_files",
     return_value=[
         "s3://dataplatform-prod-user-uploads/"
-        "parking/ringgo_permits/february.csv"
+        "parking/ringgo_permits/february.tsv",
     ],
 )
-def test_process_delete_keeps_table_when_csv_files_remain(
-    list_objects: MagicMock,
+def test_process_delete_rebuilds_table_with_remaining_file_dialect(
+    list_table_files: MagicMock,
+    detect_table_delimiter: MagicMock,
+    extract_csv_column_definitions: MagicMock,
+    create_glue_table: MagicMock,
     delete_glue_table: MagicMock,
 ) -> None:
-    """Keep the table while another CSV remains in its table folder."""
+    """Rebuild the table using a remaining supported file's delimiter."""
     record = {
         "eventName": "ObjectRemoved:Delete",
         "s3": {
             "bucket": {"name": "dataplatform-prod-user-uploads"},
             "object": {
-                "key": "parking/ringgo_permits/january.csv",
+                "key": "parking/ringgo_permits/january.tsv",
             },
         },
     }
@@ -169,29 +531,40 @@ def test_process_delete_keeps_table_when_csv_files_remain(
     assert main.process_single_event_record(
         record, "parking_user_uploads_db"
     ) == (True, False)
-    list_objects.assert_called_once_with(
-        path=(
-            "s3://dataplatform-prod-user-uploads/"
-            "parking/ringgo_permits/"
-        ),
-        suffix=".csv",
+    list_table_files.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        "parking/ringgo_permits/january.tsv",
+    )
+    detect_table_delimiter.assert_called_once()
+    extract_csv_column_definitions.assert_called_once_with(
+        "dataplatform-prod-user-uploads",
+        "parking/ringgo_permits/february.tsv",
+        "\t",
+    )
+    create_glue_table.assert_called_once_with(
+        database_name="parking_user_uploads_db",
+        table_name="ringgo_permits",
+        bucket="dataplatform-prod-user-uploads",
+        s3_key="parking/ringgo_permits/february.tsv",
+        columns_types={"id": "string"},
+        delimiter="\t",
     )
     delete_glue_table.assert_not_called()
 
 
 @patch.object(main, "delete_glue_table")
-@patch.object(main.wr.s3, "list_objects", return_value=[])
-def test_process_delete_removes_table_after_last_csv(
-    _list_objects: MagicMock,
+@patch.object(main, "list_table_files", return_value=[])
+def test_process_delete_removes_table_after_last_supported_file(
+    _list_table_files: MagicMock,
     delete_glue_table: MagicMock,
 ) -> None:
-    """Delete the table when no CSV files remain in its table folder."""
+    """Delete the table when no CSV or TSV files remain in its table folder."""
     record = {
         "eventName": "ObjectRemoved:Delete",
         "s3": {
             "bucket": {"name": "dataplatform-prod-user-uploads"},
             "object": {
-                "key": "parking/ringgo_permits/january.csv",
+                "key": "parking/ringgo_permits/january.tsv",
             },
         },
     }


### PR DESCRIPTION
## Summary

- Add automatic comma, Tab, and pipe delimiter detection for lowercase `.csv` uploads.
- Add direct support for lowercase .tsv uploads, using tabs as the delimiter. Tom needs this because he uses TSV files for spreadsheets; when exporting to CSV, text fields are not automatically enclosed in quotation marks.