### PR TITLE
DL-261 Increase one base MWAA worker for production environment

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -242,7 +242,7 @@ resource "aws_mwaa_environment" "mwaa" {
   # https://docs.aws.amazon.com/mwaa/latest/userguide/t-create-update-environment.html#t-network-failure
   webserver_access_mode           = "PUBLIC_ONLY"                             # Default is PRIVATE_ONLY
   max_workers                     = local.is_production_environment ? 20 : 10 # The default for mw1.medium is 10 for mw1.samll is 5
-  min_workers                     = 1                                         # Default 1
+  min_workers                     = local.is_production_environment ? 2 : 1   # Default 1
   schedulers                      = 2                                         # Must be between 2 and 5
   kms_key                         = aws_kms_key.mwaa_key.arn
   tags                            = module.tags.values


### PR DESCRIPTION
Based on the discussion with AWS Customer Support ([URL](https://365719730767-kk5oc2zj.support.console.aws.amazon.com/support/home#/case/?displayId=178533183500538&language=en)), the BaseWorker memory utilisation remained at 99.78–99.84% from 07:03 to 07:10 UTC on 28 July, while CPU utilisation spiked to 89–98% during the same period. Normally, this corresponds exactly with the task failure. The Scheduler remained healthy, with memory utilisation between 43% and 46%.

The recurring SSL connection failures, including “`unrecognised SSL error code: 6” and “SSL SYSCALL error: EOF detected`”, were caused by the BaseWorker becoming resource-saturated within a short period of time. This did not give MWAA enough time to scale up additional workers.

Following AWS Customer Support’s recommendation, 

- I am increasing the minimum worker count for the production MWAA environment from 1 to 2, while keeping staging at 1. This will provide additional capacity during the morning DAG burst without waiting for autoscaling, reducing resource pressure on a single BaseWorker. This change will result in a small additional cost of approximately $90 per month, as shown in the screenshot (or via [URL](https://aws.amazon.com/managed-workflows-for-apache-airflow/pricing/)).

<img width="2269" height="410" alt="image" src="https://github.com/user-attachments/assets/8f30547f-56c0-46c5-af69-891c761bd9cd" />

- The support reply also recommends splitting the trigger-and-wait pattern for parent DAG. This change will be implemented in the Airflow DAG side.
