### PR TITLE
bump spark-excel to 3.3.4_0.20.4

### DIFF
--- a/external-lib/pom.xml
+++ b/external-lib/pom.xml
@@ -22,8 +22,8 @@
     </dependency>
     <dependency>
       <groupId>com.crealytics</groupId>
-      <artifactId>spark-excel_2.11</artifactId>
-      <version>0.13.7</version>
+      <artifactId>spark-excel_2.12</artifactId>
+      <version>3.3.4_0.20.4</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Addresses an issue where Glue spreadsheet import jobs would fail.

Glue 4.0 uses Spark 3.3 and Scala 2.12. 
Scala 2.11 libraries are not compatible with Scala 2.12, producing the observed error in Glue spreadsheet import job:

> java.lang.NoSuchMethodError:
> scala.Predef$.refArrayOps(...)

This PR bumps the spark-excel version to `3.3.4_0.20.4`, the most recent published version for spark 3.3.x / scala 2.12. 

https://mvnrepository.com/artifact/com.crealytics/spark-excel
