### PR TITLE
fix spreadsheet import failures

### DIFF
--- a/scripts/jobs/spreadsheet_import.py
+++ b/scripts/jobs/spreadsheet_import.py
@@ -54,11 +54,8 @@ if __name__ == "__main__":
 
     args = getResolvedOptions(sys.argv, ['JOB_NAME'])
 
-    # Configure Spark to prioritize user-supplied JARs over Glue default classpath
     from pyspark.conf import SparkConf
     conf = SparkConf()
-    conf.set("spark.driver.extraClassPath", "/tmp/*")
-    conf.set("spark.executor.extraClassPath", "/tmp/*")
     conf.set("spark.sql.legacy.timeParserPolicy", "CORRECTED")
 
     sc = SparkContext(conf=conf)

--- a/scripts/jobs/spreadsheet_import.py
+++ b/scripts/jobs/spreadsheet_import.py
@@ -1,12 +1,10 @@
 import sys
 import os
-from awsglue.transforms import *
 from awsglue.utils import getResolvedOptions
 from pyspark.context import SparkContext
 from awsglue.context import GlueContext
 from awsglue.job import Job
 from awsglue.dynamicframe import DynamicFrame
-from pyspark.sql import SQLContext
 
 from scripts.helpers.helpers import get_glue_env_var, add_import_time_columns, clean_column_names, PARTITION_KEYS
 

--- a/scripts/jobs/spreadsheet_import.py
+++ b/scripts/jobs/spreadsheet_import.py
@@ -16,6 +16,7 @@ def create_dataframe_from_xlsx(sql_context, worksheet_name, header_row_number, f
         .option("header", "true") \
         .option("inferSchema", "true") \
         .option("dataAddress", f'\'{worksheet_name}\'!A{int(header_row_number)}') \
+        .option("maxByteArraySize", 500000000) \
         .load(file_path)
     dataframe = clean_and_enhance_dataframe(dataframe)
     return dataframe
@@ -53,16 +54,24 @@ if __name__ == "__main__":
     s3_bucket_target = get_glue_env_var('s3_bucket_target', '')
     s3_bucket_source = get_glue_env_var('s3_bucket_source', '')
 
-    ## @params: [JOB_NAME]
     args = getResolvedOptions(sys.argv, ['JOB_NAME'])
-    sc = SparkContext()
+
+    # Configure Spark to prioritize user-supplied JARs over Glue default classpath
+    from pyspark.conf import SparkConf
+    conf = SparkConf()
+    conf.set("spark.driver.extraClassPath", "/tmp/*")
+    conf.set("spark.executor.extraClassPath", "/tmp/*")
+    conf.set("spark.sql.legacy.timeParserPolicy", "CORRECTED")
+
+    sc = SparkContext(conf=conf)
     glueContext = GlueContext(sc)
     spark = glueContext.spark_session
     job = Job(glueContext)
     job.init(args['JOB_NAME'], args)
 
     file_type = infer_file_type(s3_bucket_source)
-    df = load_file(file_type, SQLContext(sc), get_glue_env_var('worksheet_name', ''), get_glue_env_var('header_row_number', 0), s3_bucket_source)
+    # Use glueContext.spark_session instead of SQLContext(sc) for PySpark 3.x+ compatibility
+    df = load_file(file_type, spark, get_glue_env_var('worksheet_name', ''), get_glue_env_var('header_row_number', 0), s3_bucket_source)
 
     frame = DynamicFrame.fromDF(df, glueContext, "DataFrame")
 

--- a/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
+++ b/terraform/modules/import-data-from-spreadsheet-job/10-aws-glue-job.tf
@@ -15,6 +15,7 @@ module "spreadsheet_import" {
     "--header_row_number"   = var.header_row_number
     "--worksheet_name"      = var.worksheet_name
     "--job_bookmark_option" = local.job_bookmark_option
+    "--user-jars-first"     = "true"
   }
   script_s3_object_key       = var.spreadsheet_import_script_key
   spark_ui_output_storage_id = var.spark_ui_output_storage_id


### PR DESCRIPTION
Fix spreadsheet import failures caused by incompatible Apache POI and XMLBeans JARs in AWS  Glue.

  - Prioritise user supplied JARs with `--user-jars-first`.
  - Update Spark configuration for Glue 4 compatibility.
  - Increase the Excel byte-array limit for large workbooks.