### PR TITLE
DL-268 Upgrade Redshift node type from dc2.large to rg.large

### DIFF
--- a/terraform/modules/redshift/10-redshift.tf
+++ b/terraform/modules/redshift/10-redshift.tf
@@ -95,7 +95,7 @@ resource "aws_redshift_cluster" "redshift_cluster" {
   database_name                = "data_platform"
   master_username              = "data_engineers"
   master_password              = random_password.redshift_cluster_master_password.result
-  node_type                    = "dc2.large"
+  node_type                    = "rg.large"
   cluster_type                 = "multi-node"
   number_of_nodes              = 3
   cluster_parameter_group_name = aws_redshift_parameter_group.require_ssl.name


### PR DESCRIPTION
Upgrades the production Amazon Redshift cluster from 3 × dc2.large nodes to 3 × rg.large nodes.

I’ve got the green light from Daro too, and he’s been notified that there will be approximately 10 minutes of downtime during the upgrade.

A manual snapshot (dataplatform-prod-pre-rg-20260826-151549) has been created and verified before this PR.

Note: AWS Provider v5.0 does not provide an option to select elastic or classic resize. Changing the node type through Terraform calls the Amazon Redshift ModifyCluster API, with the resize process managed by AWS.