### PR TITLE
pin numpy 2.3.5

### DIFF
--- a/lambdas/lambda_layers/requirements4.txt
+++ b/lambdas/lambda_layers/requirements4.txt
@@ -1,1 +1,2 @@
-numpy==2.5.0
+# numpy 2.5.x and greater require python 3.12
+numpy==2.3.5


### PR DESCRIPTION
Reverts a version bump that requires Python 3.12 or later.