### PR TITLE
Increase Redshift cluster to four rg.large nodes

### DIFF
--- a/terraform/modules/redshift/10-redshift.tf
+++ b/terraform/modules/redshift/10-redshift.tf
@@ -97,7 +97,7 @@ resource "aws_redshift_cluster" "redshift_cluster" {
   master_password              = random_password.redshift_cluster_master_password.result
   node_type                    = "rg.large"
   cluster_type                 = "multi-node"
-  number_of_nodes              = 3
+  number_of_nodes              = 4
   cluster_parameter_group_name = aws_redshift_parameter_group.require_ssl.name
   iam_roles                    = local.iam_role_arns
   cluster_subnet_group_name    = aws_redshift_subnet_group.redshift.name


### PR DESCRIPTION
## Summary

- Increase the Redshift provisioned cluster from three to four `rg.large` nodes.

## Context

Daro has experienced issues loading some larger tables into Qlik. Following AWS's earlier recommendation, the cluster was changed from three `dc2.large` nodes to three `rg.large` nodes. An `rg.large` node provides 2 vCPUs and 16 GiB of memory, compared with 2 vCPUs and 15 GiB for `dc2.large`, so three nodes were expected to provide sufficient ingestion capacity. (see node [mapping guide](https://aws.amazon.com/blogs/big-data/upgrade-amazon-redshift-dc2-clusters-to-the-new-amazon-redshift-rg/#:~:text=DC2%20to%20RG%20node%20mapping%20guidance))

In practice, the current three-node cluster does not appear to provide enough headroom for these larger loads. Adding a fourth node is intended as a temporary capacity increase while Daro validates the setup and tests whether data can be ingested directly from S3 without going through Redshift.