### PR TITLE
Reduce Redshift cluster to three nodes

### DIFF
--- a/terraform/modules/redshift/10-redshift.tf
+++ b/terraform/modules/redshift/10-redshift.tf
@@ -97,7 +97,7 @@ resource "aws_redshift_cluster" "redshift_cluster" {
   master_password              = random_password.redshift_cluster_master_password.result
   node_type                    = "rg.large"
   cluster_type                 = "multi-node"
-  number_of_nodes              = 4
+  number_of_nodes              = 3
   cluster_parameter_group_name = aws_redshift_parameter_group.require_ssl.name
   iam_roles                    = local.iam_role_arns
   cluster_subnet_group_name    = aws_redshift_subnet_group.redshift.name


### PR DESCRIPTION
## Summary

Reduce the Redshift cluster from four `rg.large` nodes to three.

## Why

The fourth node was added as a temporary mitigation for the Qlik out-of-memory failure. Production query logs showed that the failure was caused by an execution-plan change after the DC2-to-RG migration: the original `MAX(import_date)` subquery began scanning the full external-table history, estimated at approximately 35.8 billion rows. The first recorded failure processed around 16.3 billion rows and generated 196 GB of intermediate data before running out of memory.

## Failing query

```sql
SELECT *
FROM "housing_raw_zone"."sow2b_dbo_ssminitransaction"
WHERE import_date = (
    SELECT MAX(import_date)
    FROM "housing_raw_zone"."sow2b_dbo_ssminitransaction"
);
```

This query relies on the Redshift optimizer to avoid scanning every historical partition. The execution plan used after the DC2-to-RG migration instead performed a full historical scan and exhausted the available query memory.

## Recommended query

```sql
SELECT *
FROM "housing_raw_zone"."sow2b_dbo_ssminitransaction"
WHERE import_date = (
    SELECT MAX(json_extract_array_element_text(values, 3))
    FROM svv_external_partitions
    WHERE schemaname = 'housing_raw_zone'
      AND tablename = 'sow2b_dbo_ssminitransaction'
);
```

This obtains the latest date from Redshift partition metadata rather than scanning the external-table data. Production testing confirmed that it selected only one of the 1,071 registered partitions.

## Why the fourth node is no longer needed

Increasing the cluster from three to four `rg.large` nodes did not resolve the unbounded scan. The additional node therefore does not address the root cause and is no longer required. Returning to three `rg.large` nodes restores the AWS-recommended baseline for the previous three-node `dc2.large` cluster and avoids unnecessary ongoing cost.