### PR TITLE
Add sso permission set var

### DIFF
--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -72,6 +72,7 @@ module "department_parking" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-parking@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -151,6 +152,7 @@ module "department_data_and_insight" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-datainsight@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -320,6 +322,7 @@ module "department_sandbox" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-sandbox@hackney.gov.uk"
+  create_sso_permission_set       = true
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   user_uploads_bucket             = module.user_uploads
@@ -354,6 +357,7 @@ module "department_benefits_and_housing_needs" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-benefits-housing-needs@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -394,6 +398,7 @@ module "department_revenues" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-revenues@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -438,6 +443,7 @@ module "department_environmental_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-environmental-services@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -475,6 +481,7 @@ module "department_housing" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-housing@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -536,6 +543,7 @@ module "department_children_and_education" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-children-and-family-services@hackney.gov.uk"
+  create_sso_permission_set       = true
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   user_uploads_bucket             = module.user_uploads
@@ -677,6 +685,7 @@ module "department_adult_social_care" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-asc@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -713,6 +722,7 @@ module "department_children_family_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-cfs@hackney.gov.uk"
+  create_sso_permission_set       = true
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn

--- a/terraform/core/05-departments.tf
+++ b/terraform/core/05-departments.tf
@@ -244,6 +244,7 @@ module "department_planning" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-planning@hackney.gov.uk"
+  create_sso_permission_set       = false
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
@@ -569,6 +570,7 @@ module "department_customer_services" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-customer-services@hackney.gov.uk"
+  create_sso_permission_set       = false
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   user_uploads_bucket             = module.user_uploads
@@ -603,6 +605,7 @@ module "department_hr_and_od" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-hr-and-od@hackney.gov.uk"
+  create_sso_permission_set       = false
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn
   user_uploads_bucket             = module.user_uploads
@@ -637,6 +640,7 @@ module "department_streetscene" {
   identity_store_id               = local.identity_store_id
   google_group_admin_display_name = local.google_group_admin_display_name
   google_group_display_name       = "saml-aws-data-platform-collaborator-streetscene@hackney.gov.uk"
+  create_sso_permission_set       = false
   departmental_airflow_role       = local.departmental_airflow_role
   mwaa_etl_scripts_bucket_arn     = aws_s3_bucket.mwaa_etl_scripts_bucket.arn
   mwaa_key_arn                    = aws_kms_key.mwaa_key.arn

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -14,7 +14,7 @@ variable "google_group_display_name" {
 variable "create_sso_permission_set" {
   description = "Whether to create the department's legacy SSO permission set and account assignment"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "google_group_admin_display_name" {

--- a/terraform/modules/department/02-inputs-optional.tf
+++ b/terraform/modules/department/02-inputs-optional.tf
@@ -11,6 +11,12 @@ variable "google_group_display_name" {
   default     = null
 }
 
+variable "create_sso_permission_set" {
+  description = "Whether to create the department's legacy SSO permission set and account assignment"
+  type        = bool
+  default     = true
+}
+
 variable "google_group_admin_display_name" {
   description = <<EOF
     The google group display name for the admin group.

--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -1,5 +1,5 @@
 locals {
-  deploy_sso = var.google_group_display_name != null && var.is_live_environment
+  deploy_sso = var.create_sso_permission_set && var.google_group_display_name != null && var.is_live_environment
 }
 
 resource "aws_ssoadmin_permission_set" "department" {


### PR DESCRIPTION
Creates a new variable `create_sso_permission_set` in the department module to allow for permission sets to be removed without removing other resources or the associated Google Group. 

This new variable defaults to `false` so future instances of the department module will not create an SSO group by default. 

Removes SSO permission sets for 4 departments:
- Planning
- Customer Services
- HR and OD
- Streetscene

These groups are either not in use (identified by last use report from CE) or only contain members of D&I who can be granted access using the Lake Formation permission sets that supersede these groups. 

Planning includes one user who is not a member of D&I. I've spoken to them and they are not actively using the permissions set and they should be moved to a group in `dap-access-management` if they need access in the future. 