### PR TITLE
add permission set attachment dependency

### DIFF
--- a/terraform/modules/department/60-aws-sso.tf
+++ b/terraform/modules/department/60-aws-sso.tf
@@ -20,8 +20,10 @@ resource "aws_ssoadmin_permission_set_inline_policy" "department" {
 
   provider = aws.aws_hackit_account
 
+  # Policy removals reprovision assigned accounts, so policies must be destroyed before the assignment.
   depends_on = [
-    aws_ssoadmin_customer_managed_policy_attachment.departmental_glue_access
+    aws_ssoadmin_account_assignment.permission_set_attachment,
+    aws_ssoadmin_customer_managed_policy_attachment.departmental_glue_access,
   ]
 
   inline_policy      = var.environment == "stg" ? data.aws_iam_policy_document.sso_staging_user_policy.json : data.aws_iam_policy_document.sso_production_user_policy.json
@@ -33,6 +35,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_cloudwa
   count = local.deploy_sso ? 1 : 0
 
   provider = aws.aws_hackit_account
+
+  depends_on = [aws_ssoadmin_account_assignment.permission_set_attachment]
 
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
@@ -48,6 +52,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_glue_co
 
   provider = aws.aws_hackit_account
 
+  depends_on = [aws_ssoadmin_account_assignment.permission_set_attachment]
+
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
 
@@ -61,6 +67,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "departmental_glue_ac
   count = local.deploy_sso ? 1 : 0
 
   provider = aws.aws_hackit_account
+
+  depends_on = [aws_ssoadmin_account_assignment.permission_set_attachment]
 
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
@@ -77,6 +85,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "cloudtrail_access" {
 
   provider = aws.aws_hackit_account
 
+  depends_on = [aws_ssoadmin_account_assignment.permission_set_attachment]
+
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn
 
@@ -91,6 +101,8 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "datahub_ingestion_ac
   count = local.deploy_sso && local.department_identifier == "data-and-insight" && var.datahub_ingestion_bucket != null ? 1 : 0
 
   provider = aws.aws_hackit_account
+
+  depends_on = [aws_ssoadmin_account_assignment.permission_set_attachment]
 
   instance_arn       = var.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.department[0].arn


### PR DESCRIPTION
Address a potential sequencing issue where removing a policy causes the permission set to be reprovisioned while Terraform is concurrently removing the account assignment by making this dependency explicit. 