### PR TITLE
add pyproject.toml to lambdas

### DIFF
--- a/lambdas/pyproject.toml
+++ b/lambdas/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "data-platform-lambdas"
+version = "0.0.0"
+requires-python = ">=3.11,<3.12"


### PR DESCRIPTION
Adds a `pyproject.toml` to the lambdas directory to try and get dependabot to respect the target python version and not recommend incompatible package bumps. 