### PR TITLE
DL-274 Add global configuration for the max number of active tasks and runs per DAG.

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -250,6 +250,8 @@ resource "aws_mwaa_environment" "mwaa" {
 
   airflow_configuration_options = {
     "core.default_timezone"               = "Europe/London"
+    "core.max_active_tasks_per_dag"       = "8"
+    "core.max_active_runs_per_dag"        = "1"
     "webserver.warn_deployment_exposure"  = "False"
     "webserver.auto_refresh"              = "True"
     "scheduler.min_file_process_interval" = "180"


### PR DESCRIPTION
- Add global configuration for the maximum number of active tasks and runs per DAG, as suggested by Cintia. This makes sense even though most active task limits are already specified at the individual DAG level.
- I've set MWAA defaults to **8** active tasks and **1** active run per DAG for stg and prod.