### PR TITLE
DL-274 Add Mosaic ECS task role and MWAA PassRole permissions

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -112,6 +112,32 @@ resource "aws_iam_role_policy" "mwaa_role_policy" {
   })
 }
 
+# Mosaic resources are created in the ETL stack; the execution role is created by dap-ecs.
+resource "aws_iam_role_policy" "mwaa_mosaic_ingestion" {
+  name = "mwaa_mosaic_ingestion"
+  role = aws_iam_role.mwaa_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "PassMosaicEcsRoles"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          "arn:aws:iam::${var.aws_deploy_account_id}:role/${local.identifier_prefix}-mosaic-ecs-task-role",
+          "arn:aws:iam::${var.aws_deploy_account_id}:role/mosaic-ecs-execution-role",
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
 # To allow the MWAA execution role to assume the housing reporting role and export
 # MTFH tables to S3
 resource "aws_iam_role_policy" "mwaa_assume_role_policy" {

--- a/terraform/etl/64-mosaic.tf
+++ b/terraform/etl/64-mosaic.tf
@@ -1,0 +1,101 @@
+# IAM task role and permissions for Mosaic ECS ingestion to read credentials and shared scripts, and upload raw data.
+data "aws_s3_bucket" "mosaic_etl_scripts" {
+  bucket = "${local.identifier_prefix}-mwaa-etl-scripts-bucket"
+}
+
+data "aws_kms_key" "mosaic_etl_scripts" {
+  key_id = "alias/mwaa-key"
+}
+
+data "aws_iam_policy_document" "mosaic_ecs_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.data_platform.account_id]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:ecs:${var.aws_deploy_region}:${data.aws_caller_identity.data_platform.account_id}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "mosaic_ecs_task" {
+  name               = "${local.identifier_prefix}-mosaic-ecs-task-role"
+  description        = "Task role for shared Mosaic SQL Server ingestion."
+  assume_role_policy = data.aws_iam_policy_document.mosaic_ecs_assume_role.json
+  tags               = module.tags.values
+}
+
+data "aws_iam_policy_document" "mosaic_ingestion" {
+  statement {
+    sid = "WriteMosaicRawData"
+    actions = [
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+    ]
+    resources = ["${module.raw_zone_data_source.bucket_arn}/projects/mosaic/*"]
+  }
+
+  statement {
+    sid       = "ListSharedIngestionScripts"
+    actions   = ["s3:ListBucket"]
+    resources = [data.aws_s3_bucket.mosaic_etl_scripts.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["shared", "shared/*"]
+    }
+  }
+
+  statement {
+    sid       = "ReadSharedIngestionScripts"
+    actions   = ["s3:GetObject"]
+    resources = ["${data.aws_s3_bucket.mosaic_etl_scripts.arn}/shared/*"]
+  }
+
+  statement {
+    sid       = "ReadMosaicCredentials"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.mosaic.arn]
+  }
+
+  statement {
+    sid       = "EncryptMosaicRawData"
+    actions   = ["kms:Decrypt", "kms:GenerateDataKey"]
+    resources = [module.raw_zone_data_source.kms_key_arn]
+  }
+
+  statement {
+    sid     = "DecryptScriptsAndCredentials"
+    actions = ["kms:Decrypt"]
+    resources = [
+      data.aws_kms_key.mosaic_etl_scripts.arn,
+      data.aws_kms_key.secrets_manager_key.arn,
+    ]
+  }
+
+}
+
+resource "aws_iam_policy" "mosaic_ingestion" {
+  name        = "${local.identifier_prefix}-mosaic-ingestion"
+  description = "Read Mosaic credentials and shared scripts, and upload raw data."
+  policy      = data.aws_iam_policy_document.mosaic_ingestion.json
+  tags        = module.tags.values
+}
+
+resource "aws_iam_role_policy_attachment" "mosaic_ingestion" {
+  role       = aws_iam_role.mosaic_ecs_task.name
+  policy_arn = aws_iam_policy.mosaic_ingestion.arn
+}


### PR DESCRIPTION
Add a dedicated ECS task role to read the Mosaic secret and shared scripts, upload raw data, and use the required KMS keys. Allow MWAA to pass the Mosaic task and execution roles to ECS.

Stacked on #2824, which creates the Mosaic secret and catalog databases. 