### PR TITLE
update-mwaa-maintenance-window

### DIFF
--- a/terraform/core/47-mwaa.tf
+++ b/terraform/core/47-mwaa.tf
@@ -272,7 +272,7 @@ resource "aws_mwaa_environment" "mwaa" {
   schedulers                      = 2                                         # Must be between 2 and 5
   kms_key                         = aws_kms_key.mwaa_key.arn
   tags                            = module.tags.values
-  weekly_maintenance_window_start = "SUN:03:30"
+  weekly_maintenance_window_start = "SUN:18:30"
 
   airflow_configuration_options = {
     "core.default_timezone"               = "Europe/London"


### PR DESCRIPTION
Move prod and staging MWAA maintenance to Sundays at 18:30 UTC (19:30 BST) to avoid affecting early-morning DAGs.